### PR TITLE
Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "firewheel"
 version = "0.1.0"
 description = "Flexible, high-performance, and libre audio engine for games (WIP)"
-homepage = "https://github.com/BillyDM/firewheel"
+repository = "https://github.com/BillyDM/firewheel"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.