### PR TITLE
Added `SyncWrapper`, added CI, and fixed errors

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,75 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: --deny warnings
+  RUSTDOCFLAGS: --deny warnings
+
+jobs:
+  # Run tests.
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+
+      - name: Populate target directory from cache
+        uses: Leafwing-Studios/cargo-cache@v2
+        with:
+          sweep-cache: true
+
+      - name: Run tests
+        run: |
+          cargo test --locked --workspace --all-features --all-targets
+
+  # Check formatting.
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+  # Check documentation.
+  doc:
+    name: Docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: sudo apt-get update; sudo apt-get install -y --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+
+      - name: Populate target directory from cache
+        uses: Leafwing-Studios/cargo-cache@v2
+        with:
+          sweep-cache: true
+
+      - name: Check documentation
+        run: cargo doc --locked --workspace --all-features --no-deps

--- a/benches/core.rs
+++ b/benches/core.rs
@@ -75,7 +75,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         source.randomize(&mut rng);
     }
 
-    let mut target = ShallowParams::default();
+    let target = ShallowParams::default();
     let mut messages = Vec::with_capacity(128 * 3);
 
     c.bench_function("diffing shallow", |b| {
@@ -104,7 +104,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("patching shallow", |b| {
         b.iter(|| {
             for message in &messages {
-                target.patch_params(&message);
+                target.patch_event(&message);
                 black_box(&target);
             }
         })
@@ -125,7 +125,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("patching three", |b| {
         b.iter(|| {
             for message in &messages {
-                target.patch_params(&message);
+                target.patch_event(&message);
                 black_box(&target);
             }
         })
@@ -148,7 +148,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             }
 
             for message in messages.drain(..) {
-                target.patch_params(&message);
+                target.patch_event(&message);
                 black_box(&target);
             }
         })
@@ -170,7 +170,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             }
 
             for message in messages.drain(..) {
-                target.patch_params(&message);
+                target.patch_event(&message);
                 black_box(&target);
             }
         })
@@ -192,7 +192,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             }
 
             for message in messages.drain(..) {
-                target.patch_params(&message);
+                target.patch_event(&message);
                 black_box(&target);
             }
         })

--- a/crates/firewheel-core/src/clock.rs
+++ b/crates/firewheel-core/src/clock.rs
@@ -11,8 +11,8 @@ pub enum EventDelay {
     /// Note, this clock is not perfectly accurate, but it does correctly
     /// account for any output underflows that may occur.
     ///
-    /// The value is an absolute time, *NOT* a delta time. Use
-    /// [`FirewheelCtx::clock_now`] to get the current time of the clock.
+    /// The value is an absolute time, *NOT* a delta time. Use the context's
+    /// `clock_now` method to get the current time of the clock.
     DelayUntilSeconds(ClockSeconds),
 
     /// The event should happen when the clock reaches the given time in
@@ -22,8 +22,8 @@ pub enum EventDelay {
     /// account for any output underflows that may occur. This clock is
     /// ideal for syncing events to a custom musical transport.
     ///
-    /// The value is an absolute time, *NOT* a delta time. Use
-    /// [`FirewheelCtx::clock_samples`] to get the current time of the clock.
+    /// The value is an absolute time, *NOT* a delta time. Use the context's
+    /// `clock_samples` to get the current time of the clock.
     DelayUntilSamples(ClockSamples),
 
     /// The event should happen when the musical clock reaches the given

--- a/crates/firewheel-core/src/diff/memo.rs
+++ b/crates/firewheel-core/src/diff/memo.rs
@@ -1,0 +1,48 @@
+use super::{Diff, EventQueue, PathBuilder};
+
+/// A "memoized" parameters wrapper.
+///
+/// This type simplifies diffing management for
+/// standalone parameters.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Memo<T> {
+    value: T,
+    baseline: T,
+}
+
+impl<T: Diff + Clone> Memo<T> {
+    /// Construct a new [`Memo`].
+    ///
+    /// This clones the provided value to maintain
+    /// a baseline for diffing.
+    pub fn new(value: T) -> Self {
+        Self {
+            baseline: value.clone(),
+            value,
+        }
+    }
+
+    /// Generate events if the inner value has changed.
+    ///
+    /// This will also clone the inner value and assign it to the baseline.
+    /// This may be inneficient if cloning is slow.
+    pub fn update_memo<E: EventQueue>(&mut self, event_queue: &mut E) {
+        self.value
+            .diff(&self.baseline, PathBuilder::default(), event_queue);
+        self.baseline = self.value.clone();
+    }
+}
+
+impl<T> core::ops::Deref for Memo<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> core::ops::DerefMut for Memo<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}

--- a/crates/firewheel-core/src/diff/mod.rs
+++ b/crates/firewheel-core/src/diff/mod.rs
@@ -7,6 +7,9 @@ use smallvec::SmallVec;
 
 mod collections;
 mod leaf;
+mod memo;
+
+pub use memo::Memo;
 
 pub use firewheel_macros::{Diff, Patch};
 

--- a/crates/firewheel-core/src/event.rs
+++ b/crates/firewheel-core/src/event.rs
@@ -4,7 +4,7 @@ pub use glam::{Vec2, Vec3};
 
 use crate::{clock::EventDelay, diff::ParamPath, node::NodeID};
 
-/// An event sent to an [`AudioNodeProcessor`].
+/// An event sent to an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
 pub struct NodeEvent {
     /// The ID of the node that should receive the event.
     pub node_id: NodeID,
@@ -12,7 +12,7 @@ pub struct NodeEvent {
     pub event: NodeEventType,
 }
 
-/// An event type associated with an [`AudioNodeProcessor`].
+/// An event type associated with an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
 pub enum NodeEventType {
     Param {
         /// Data for a specific parameter.
@@ -113,7 +113,7 @@ pub enum SequenceCommand {
     Stop,
 }
 
-/// A list of events for an [`AudioNodeProcessor`].
+/// A list of events for an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
 pub struct NodeEventList<'a> {
     event_buffer: &'a mut [NodeEvent],
     indices: &'a [u32],

--- a/crates/firewheel-core/src/lib.rs
+++ b/crates/firewheel-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod node;
 pub mod param;
 pub mod sample_resource;
 mod silence_mask;
+pub mod sync_wrapper;
 
 use std::num::NonZeroU32;
 

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -66,7 +66,7 @@ pub trait AudioNodeProcessor: 'static + Send {
     /// * `scratch_buffers` - A list of extra scratch buffers that can be
     /// used for processing. This removes the need for nodes to allocate
     /// their own scratch buffers. Each buffer has a length of
-    /// [`StreamInfo::max_block_samples`]. These buffers are shared across
+    /// [`StreamInfo::max_block_frames`]. These buffers are shared across
     /// all nodes, so assume that they contain junk data.
     fn process(
         &mut self,
@@ -124,7 +124,7 @@ pub struct ProcInfo<'a> {
     /// have been processed since the start of the audio stream.
     ///
     /// This value can be used for more accurate timing than
-    /// [`ProcInfo::clock_secs`], but note it does *NOT* account for any
+    /// [`ProcInfo::clock_seconds`], but note it does *NOT* account for any
     /// output underflows that may occur.
     pub clock_samples: ClockSamples,
 

--- a/crates/firewheel-core/src/param/smoother.rs
+++ b/crates/firewheel-core/src/param/smoother.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use crate::{dsp::smoothing_filter, StreamInfo};
 
-/// The configuration for a [`ParamSmoother`]
+/// The configuration for a [`SmoothedParam`]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SmootherConfig {
     /// The amount of smoothing in seconds

--- a/crates/firewheel-core/src/sample_resource.rs
+++ b/crates/firewheel-core/src/sample_resource.rs
@@ -448,6 +448,8 @@ pub fn load_audio_file<P: AsRef<std::path::Path>>(
 /// * `hint` -  An optional hint to help the format registry guess what format reader is appropriate.
 /// * `sample_rate` - The sample rate of the audio stream.
 /// * `resample_quality` - The quality of the resampler to use.
+///
+/// [`MediaSource`]: symphonium::symphonia::core::io::MediaSource
 #[cfg(feature = "symphonium")]
 pub fn load_audio_file_from_source(
     loader: &mut symphonium::SymphoniumLoader,

--- a/crates/firewheel-core/src/sync_wrapper.rs
+++ b/crates/firewheel-core/src/sync_wrapper.rs
@@ -1,0 +1,48 @@
+/// A wrapper around a non-`Sync` type to make it `Sync`.
+///
+/// The mechanism is very simple. [`SyncWrapper`] prevents
+/// shared borrowing of the inner type. The only way to get
+/// to the inner data is through `take` or `get_mut`. Both methods
+/// can only be called with a mutable reference to [`SyncWrapper`],
+/// so it's not possible that the inner value can be observed
+/// simultaneously in multiple threads.
+#[derive(Debug)]
+pub struct SyncWrapper<T>(Option<T>);
+
+impl<T> SyncWrapper<T> {
+    /// Construct a new [`SyncWrapper`].
+    pub fn new(value: T) -> Self {
+        Self(Some(value))
+    }
+
+    /// Move out the inner value.
+    ///
+    /// If this has already been called on this thread or elsewhere,
+    /// this will return `None`.
+    pub fn take(&mut self) -> Option<T> {
+        self.0.take()
+    }
+
+    /// Obtain a mutable reference to the inner value.
+    ///
+    /// If `take` has been called previously, this returns `None`.
+    pub fn get_mut(&mut self) -> Option<&mut T> {
+        self.0.as_mut()
+    }
+}
+
+/// # Safety
+///
+/// [`SyncWrapper`] prevents
+/// shared borrowing of the inner type. The only way to get
+/// to the inner data is through `take` or `get_mut`. Both methods
+/// can only be called with a mutable reference to [`SyncWrapper`],
+/// so it's not possible that the inner value can be observed
+/// simultaneously in multiple threads.
+///
+/// Therefore, this implementation is safe.
+///
+/// For further reference, see the [standard library's
+/// implementation of `Sync` on `std::sync::Mutex`](https://doc.rust-lang.org/src/std/sync/poison/mutex.rs.html#189),
+/// as well as the [`get_mut` method](https://doc.rust-lang.org/src/std/sync/poison/mutex.rs.html#557-581).
+unsafe impl<T: Send> Sync for SyncWrapper<T> {}

--- a/crates/firewheel-graph/src/error.rs
+++ b/crates/firewheel-graph/src/error.rs
@@ -54,7 +54,7 @@ pub enum CompileGraphError {
 }
 
 /// An error occurred while attempting to activate an audio stream in
-/// a [`FirewheelCtx`].
+/// a [`FirewheelCtx`][crate::context::FirewheelCtx].
 #[derive(Debug, thiserror::Error)]
 pub enum StartStreamError<E: Error> {
     /// An audio stream is already running in this context.
@@ -77,7 +77,7 @@ pub enum StartStreamError<E: Error> {
     BackendError(E),
 }
 
-/// An error occured while updating a [`FirewheelCtx`].
+/// An error occured while updating a [`FirewheelCtx`][crate::context::FirewheelCtx].
 #[derive(Debug, thiserror::Error)]
 pub enum UpdateError<E: Error> {
     /// The context to processor message channel is full.

--- a/crates/firewheel-graph/src/graph/compiler.rs
+++ b/crates/firewheel-graph/src/graph/compiler.rs
@@ -34,7 +34,7 @@ impl NodeEntry {
     }
 }
 
-/// The index of an input/output port on a particular [Node].
+/// The index of an input/output port on a particular node.
 pub type PortIdx = u32;
 
 /// A globally unique identifier for an [Edge].
@@ -203,7 +203,7 @@ impl<'a> GraphIR<'a> {
     }
 
     /// Sort the nodes topologically using Kahn's algorithm.
-    /// https://www.geeksforgeeks.org/topological-sorting-indegree-based-solution/
+    /// <https://www.geeksforgeeks.org/topological-sorting-indegree-based-solution/>
     fn sort_topologically(mut self, build_schedule: bool) -> Result<Self, CompileGraphError> {
         let mut in_degree = vec![0i32; self.nodes.capacity()];
         let mut queue = VecDeque::with_capacity(self.nodes.len());

--- a/crates/firewheel-graph/src/graph/compiler/schedule.rs
+++ b/crates/firewheel-graph/src/graph/compiler/schedule.rs
@@ -9,7 +9,7 @@ use firewheel_core::{
 
 use super::{InsertedSum, NodeID};
 
-/// A [ScheduledNode] is a [Node] that has been assigned buffers
+/// A [ScheduledNode] is a node that has been assigned buffers
 /// and a place in the schedule.
 #[derive(Clone)]
 pub(super) struct ScheduledNode {

--- a/crates/firewheel-graph/src/lib.rs
+++ b/crates/firewheel-graph/src/lib.rs
@@ -4,4 +4,4 @@ pub mod error;
 pub mod graph;
 pub mod processor;
 
-pub use context::{FirewheelConfig, FirewheelCtx};
+pub use context::{ContextQueue, FirewheelConfig, FirewheelCtx};

--- a/crates/firewheel-graph/src/processor.rs
+++ b/crates/firewheel-graph/src/processor.rs
@@ -176,9 +176,6 @@ impl FirewheelProcessorInner {
     // TODO: Add a `process_deinterleaved` method.
 
     /// Process the given buffers of audio data.
-    ///
-    /// If this returns [`ProcessStatus::DropProcessor`], then this
-    /// [`FirewheelProcessorInner`] must be dropped.
     pub fn process_interleaved(
         &mut self,
         input: &[f32],

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -72,7 +72,6 @@ impl AudioNodeConstructor for Constructor {
                 * stream_info.sample_rate_recip as f32,
             gain: normalized_volume_to_raw_gain(self.params.normalized_volume),
             sample_rate_recip: (stream_info.sample_rate.get() as f32).recip(),
-            enabled: self.params.enabled,
             params: self.params,
         })
     }
@@ -83,7 +82,6 @@ struct Processor {
     phasor_inc: f32,
     gain: f32,
     sample_rate_recip: f32,
-    enabled: bool,
     params: BeepTestParams,
 }
 
@@ -103,10 +101,9 @@ impl AudioNodeProcessor for Processor {
         if self.params.patch_list(events) {
             self.phasor_inc = self.params.freq_hz.clamp(20.0, 20_000.0) * self.sample_rate_recip;
             self.gain = normalized_volume_to_raw_gain(self.params.normalized_volume);
-            self.enabled = self.params.enabled;
         }
 
-        if !self.enabled {
+        if !self.params.enabled {
             return ProcessStatus::ClearAllOutputs;
         }
 

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -103,6 +103,7 @@ impl AudioNodeProcessor for Processor {
         if self.params.patch_list(events) {
             self.phasor_inc = self.params.freq_hz.clamp(20.0, 20_000.0) * self.sample_rate_recip;
             self.gain = normalized_volume_to_raw_gain(self.params.normalized_volume);
+            self.enabled = self.params.enabled;
         }
 
         if !self.enabled {

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -292,7 +292,7 @@ impl SamplerHandle {
 
     /// Manually mark the playback state of this node. This can be used to account
     /// for the delay between when creating a [`SamplerEvent`] and when the processor
-    /// receives the event when using [`SamplerNode::worker_score`].
+    /// receives the event when using [`SamplerHandle::worker_score`].
     ///
     /// Note, if you use the methods on this struct to construct the events, then
     /// this is automatically done for you.

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -277,18 +277,11 @@ impl AudioNodeProcessor for Processor {
         &mut self,
         inputs: &[&[f32]],
         outputs: &mut [&mut [f32]],
-        mut events: NodeEventList,
+        events: NodeEventList,
         proc_info: &ProcInfo,
         _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
     ) -> ProcessStatus {
-        let mut params_changed = false;
-
-        events.for_each(|event| {
-            self.params.patch_params(event);
-            params_changed = true;
-        });
-
-        if params_changed {
+        if self.params.patch_list(events) {
             let computed_values = self.params.compute_values();
 
             self.gain_l.set_value(computed_values.gain_l);
@@ -402,7 +395,7 @@ impl AudioNodeProcessor for Processor {
             }
         }
 
-        return ProcessStatus::outputs_modified(SilenceMask::NONE_SILENT);
+        ProcessStatus::outputs_modified(SilenceMask::NONE_SILENT)
     }
 
     fn new_stream(&mut self, stream_info: &firewheel_core::StreamInfo) {

--- a/examples/custom_nodes/src/system.rs
+++ b/examples/custom_nodes/src/system.rs
@@ -1,4 +1,4 @@
-use firewheel::{error::UpdateError, node::NodeID, FirewheelContext};
+use firewheel::{diff::Memo, error::UpdateError, node::NodeID, FirewheelContext};
 
 use crate::nodes::{
     filter::FilterParams,
@@ -9,8 +9,8 @@ use crate::nodes::{
 pub struct AudioSystem {
     pub cx: FirewheelContext,
 
-    pub noise_gen_params: NoiseGenParams,
-    pub filter_params: FilterParams,
+    pub noise_gen_params: Memo<NoiseGenParams>,
+    pub filter_params: Memo<FilterParams>,
     pub rms_params: RmsParams,
     pub rms_handle: RmsHandle,
 
@@ -42,8 +42,8 @@ impl AudioSystem {
 
         Self {
             cx,
-            noise_gen_params,
-            filter_params,
+            noise_gen_params: Memo::new(noise_gen_params),
+            filter_params: Memo::new(filter_params),
             rms_params,
             rms_handle,
             noise_gen_node,

--- a/examples/custom_nodes/src/ui.rs
+++ b/examples/custom_nodes/src/ui.rs
@@ -36,77 +36,51 @@ impl App for DemoApp {
         egui::CentralPanel::default().show(cx, |ui| {
             ui.label("Noise gen");
 
-            if ui
-                .add(
-                    egui::Slider::new(
-                        &mut self.audio_system.noise_gen_params.normalized_volume,
-                        0.0..=1.0,
-                    )
-                    .text("volume"),
+            ui.add(
+                egui::Slider::new(
+                    &mut self.audio_system.noise_gen_params.normalized_volume,
+                    0.0..=1.0,
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.noise_gen_node,
-                    self.audio_system.noise_gen_params.sync_volume_event(),
-                );
-            }
+                .text("volume"),
+            );
 
-            if ui
-                .checkbox(&mut self.audio_system.noise_gen_params.enabled, "enabled")
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.noise_gen_node,
-                    self.audio_system.noise_gen_params.sync_enabled_event(),
-                );
-            }
+            ui.checkbox(&mut self.audio_system.noise_gen_params.enabled, "enabled");
+
+            self.audio_system.noise_gen_params.update_memo(
+                &mut self
+                    .audio_system
+                    .cx
+                    .event_queue(self.audio_system.noise_gen_node),
+            );
 
             ui.separator();
             ui.label("Filter");
 
-            if ui
-                .add(
-                    egui::Slider::new(
-                        &mut self.audio_system.filter_params.normalized_volume,
-                        0.0..=1.0,
-                    )
-                    .text("volume"),
+            ui.add(
+                egui::Slider::new(
+                    &mut self.audio_system.filter_params.normalized_volume,
+                    0.0..=1.0,
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.filter_node,
-                    self.audio_system.filter_params.sync_volume_event(),
-                );
-            }
+                .text("volume"),
+            );
 
-            if ui
-                .add(
-                    egui::Slider::new(
-                        &mut self.audio_system.filter_params.cutoff_hz,
-                        20.0..=20_000.0,
-                    )
-                    .text("cutoff")
-                    .logarithmic(true),
+            ui.add(
+                egui::Slider::new(
+                    &mut self.audio_system.filter_params.cutoff_hz,
+                    20.0..=20_000.0,
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.filter_node,
-                    self.audio_system.filter_params.sync_cutoff_event(),
-                );
-            }
+                .text("cutoff")
+                .logarithmic(true),
+            );
 
-            if ui
-                .checkbox(&mut self.audio_system.filter_params.enabled, "enabled")
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.filter_node,
-                    self.audio_system.filter_params.sync_enabled_event(),
-                );
-            }
+            ui.checkbox(&mut self.audio_system.filter_params.enabled, "enabled");
+
+            self.audio_system.filter_params.update_memo(
+                &mut self
+                    .audio_system
+                    .cx
+                    .event_queue(self.audio_system.filter_node),
+            );
 
             ui.separator();
             ui.label("RMS meter");

--- a/examples/sampler_pool/src/system.rs
+++ b/examples/sampler_pool/src/system.rs
@@ -1,5 +1,6 @@
 use firewheel::{
     channel_config::NonZeroChannelCount,
+    diff::Memo,
     error::UpdateError,
     nodes::{
         sampler::{RepeatMode, SamplerParams},
@@ -96,7 +97,7 @@ impl AudioSystem {
 #[derive(Default)]
 pub struct MyCustomChain {
     pub _stereo_to_mono: StereoToMonoNode,
-    pub volume: VolumeParams,
+    pub volume: Memo<VolumeParams>,
 }
 
 impl FxChain for MyCustomChain {

--- a/examples/sampler_pool/src/ui.rs
+++ b/examples/sampler_pool/src/ui.rs
@@ -74,12 +74,13 @@ impl App for DemoApp {
                         // you would want to reset the parameters to the desired state when playing
                         // a new sample.
                         fx_chain_state.fx_chain.volume.normalized_volume = 1.0;
-                        cx.queue_event_for(
-                            // The nodes IDs appear in the same order as what was returned in
-                            // [`MyCustomChain::construct_and_connect`].
-                            fx_chain_state.node_ids[1],
-                            fx_chain_state.fx_chain.volume.sync_volume_event(),
-                        );
+
+                        // The nodes IDs appear in the same order as what was returned in
+                        // [`MyCustomChain::construct_and_connect`].
+                        fx_chain_state
+                            .fx_chain
+                            .volume
+                            .update_memo(&mut cx.event_queue(fx_chain_state.node_ids[1]));
                     },
                 );
             }

--- a/examples/spatial_basic/src/system.rs
+++ b/examples/spatial_basic/src/system.rs
@@ -1,4 +1,5 @@
 use firewheel::{
+    diff::Memo,
     error::UpdateError,
     node::NodeID,
     nodes::{
@@ -16,7 +17,7 @@ pub struct AudioSystem {
     pub _sampler_handle: SamplerHandle,
     pub _sampler_node: NodeID,
 
-    pub spatial_basic_params: SpatialBasicParams,
+    pub spatial_basic_params: Memo<SpatialBasicParams>,
     pub spatial_basic_node: NodeID,
 }
 
@@ -64,7 +65,7 @@ impl AudioSystem {
             _sampler_params: sampler_params,
             _sampler_handle: sampler_handle,
             _sampler_node: sampler_node,
-            spatial_basic_params,
+            spatial_basic_params: Memo::new(spatial_basic_params),
             spatial_basic_node,
         }
     }

--- a/examples/spatial_basic/src/ui.rs
+++ b/examples/spatial_basic/src/ui.rs
@@ -38,7 +38,9 @@ impl App for DemoApp {
         });
 
         egui::CentralPanel::default().show(cx, |ui| {
-            if ui
+            let mut updated = false;
+
+            updated |= ui
                 .add(
                     egui::Slider::new(
                         &mut self.audio_system.spatial_basic_params.normalized_volume,
@@ -47,64 +49,42 @@ impl App for DemoApp {
                     .step_by(0.0)
                     .text("volume"),
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.spatial_basic_node,
-                    self.audio_system.spatial_basic_params.sync_volume_event(),
-                );
-            }
+                .changed();
 
-            if ui
+            updated |= ui
                 .add(
                     egui::Slider::new(
-                        &mut self.audio_system.spatial_basic_params.offset[0],
+                        &mut self.audio_system.spatial_basic_params.offset.x,
                         RANGE.clone(),
                     )
                     .step_by(0.0)
                     .text("x"),
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.spatial_basic_node,
-                    self.audio_system.spatial_basic_params.sync_offset_event(),
-                );
-            }
-            if ui
+                .changed();
+
+            updated |= ui
                 .add(
                     egui::Slider::new(
-                        &mut self.audio_system.spatial_basic_params.offset[1],
+                        &mut self.audio_system.spatial_basic_params.offset.y,
                         RANGE.clone(),
                     )
                     .step_by(0.0)
                     .text("y"),
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.spatial_basic_node,
-                    self.audio_system.spatial_basic_params.sync_offset_event(),
-                );
-            }
-            if ui
+                .changed();
+
+            updated |= ui
                 .add(
                     egui::Slider::new(
-                        &mut self.audio_system.spatial_basic_params.offset[2],
+                        &mut self.audio_system.spatial_basic_params.offset.z,
                         RANGE.clone(),
                     )
                     .step_by(0.0)
                     .text("z"),
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.spatial_basic_node,
-                    self.audio_system.spatial_basic_params.sync_offset_event(),
-                );
-            }
+                .changed();
 
-            if ui
+            updated |= ui
                 .add(
                     egui::Slider::new(
                         &mut self.audio_system.spatial_basic_params.damping_factor,
@@ -114,17 +94,9 @@ impl App for DemoApp {
                     .text("damping factor")
                     .logarithmic(true),
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.spatial_basic_node,
-                    self.audio_system
-                        .spatial_basic_params
-                        .sync_damping_factor_event(),
-                );
-            }
+                .changed();
 
-            if ui
+            updated |= ui
                 .add(
                     egui::Slider::new(
                         &mut self.audio_system.spatial_basic_params.panning_threshold,
@@ -133,31 +105,25 @@ impl App for DemoApp {
                     .step_by(0.0)
                     .text("panning threshold"),
                 )
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.spatial_basic_node,
-                    self.audio_system
-                        .spatial_basic_params
-                        .sync_panning_threshold_event(),
-                );
-            }
+                .changed();
 
-            let (x, yz) = self
-                .audio_system
-                .spatial_basic_params
-                .offset
-                .split_first_mut()
-                .unwrap();
-            let z = &mut yz[1];
-            if ui
+            let offset = &mut self.audio_system.spatial_basic_params.offset;
+            let x = &mut offset.x;
+            let z = &mut offset.z;
+
+            updated |= ui
                 .add(XYPad::new(x, z, RANGE.clone(), RANGE.clone(), 200.0))
-                .changed()
-            {
-                self.audio_system.cx.queue_event_for(
-                    self.audio_system.spatial_basic_node,
-                    self.audio_system.spatial_basic_params.sync_offset_event(),
-                );
+                .changed();
+
+            if updated {
+                let mut queue = self
+                    .audio_system
+                    .cx
+                    .event_queue(self.audio_system.spatial_basic_node);
+
+                self.audio_system
+                    .spatial_basic_params
+                    .update_memo(&mut queue);
             }
         });
 

--- a/examples/visual_node_graph/src/system.rs
+++ b/examples/visual_node_graph/src/system.rs
@@ -7,7 +7,7 @@ use firewheel::{
         beep_test::BeepTestParams, volume::VolumeParams, volume_pan::VolumePanParams,
         StereoToMonoNode,
     },
-    FirewheelContext,
+    ContextQueue, CpalBackend, FirewheelContext,
 };
 
 use crate::ui::GuiAudioNode;
@@ -58,20 +58,20 @@ impl AudioSystem {
         match node_type {
             NodeType::BeepTest => GuiAudioNode::BeepTest {
                 id,
-                params: BeepTestParams::default(),
+                params: Default::default(),
             },
             NodeType::StereoToMono => GuiAudioNode::StereoToMono { id },
             NodeType::VolumeMono => GuiAudioNode::VolumeMono {
                 id,
-                params: VolumeParams::default(),
+                params: Default::default(),
             },
             NodeType::VolumeStereo => GuiAudioNode::VolumeStereo {
                 id,
-                params: VolumeParams::default(),
+                params: Default::default(),
             },
             NodeType::VolumePan => GuiAudioNode::VolumePan {
                 id,
-                params: VolumePanParams::default(),
+                params: Default::default(),
             },
         }
     }
@@ -131,7 +131,12 @@ impl AudioSystem {
         }
     }
 
+    #[expect(dead_code)]
     pub fn queue_event(&mut self, node_id: NodeID, event: NodeEventType) {
         self.cx.queue_event(NodeEvent { node_id, event });
+    }
+
+    pub fn event_queue(&mut self, node_id: NodeID) -> ContextQueue<CpalBackend> {
+        self.cx.event_queue(node_id)
     }
 }


### PR DESCRIPTION
This PR resolves all errors introduced in #25, updates all the examples to compile with the latest changes, and introduces CI actions for pull requests.

The CI checks revealed a number of issues with docs links, so I resolved them as well as I could. There's [one remaining doc link](<https://github.com/BillyDM/Firewheel/blob/552ae13bed25649877e4c9690fd153d38526b680/crates/firewheel-nodes/src/stream/reader.rs#L273>) error that wasn't immediately obvious to me.

To address the `!Send` types, I added a `SyncWrapper` type. Currently, it supports two usages: a container that allows the user to move out the inner type, or one that simply gives out a mutable reference. I assumed the former would be more common, but currently we only use it as the latter. We may split these two usages out into two types in the future.

To support free-standing parameter diffing, I also added a `Memo` type:

```rs
/// A "memoized" parameters wrapper.
///
/// This type simplifies diffing management for
/// standalone parameters.
#[derive(Debug, Clone, Copy, Default)]
pub struct Memo<T> {
    value: T,
    baseline: T,
}
```

The usage is very simple as demonstrated in the examples. If there is a more appropriate name or you'd prefer a different approach for free-standing parameters, please discuss!

