### PR TITLE
`ScratchBuffer` type alias

### DIFF
--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -74,7 +74,7 @@ pub trait AudioNodeProcessor: 'static + Send {
         outputs: &mut [&mut [f32]],
         events: NodeEventList,
         proc_info: &ProcInfo,
-        scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus;
 
     /// Called when the audio stream has been stopped.
@@ -91,6 +91,13 @@ pub trait AudioNodeProcessor: 'static + Send {
 }
 
 pub const NUM_SCRATCH_BUFFERS: usize = 8;
+
+/// A list of extra scratch buffers that can be
+/// used for processing. This removes the need for nodes to allocate
+/// their own scratch buffers. Each buffer has a length of
+/// [`StreamInfo::max_block_frames`]. These buffers are shared across
+/// all nodes, so assume that they contain junk data.
+pub type ScratchBuffers<'a, 'b> = &'a mut [&'b mut [f32]; NUM_SCRATCH_BUFFERS];
 
 /// Additional information for processing audio
 pub struct ProcInfo<'a> {
@@ -234,7 +241,7 @@ impl AudioNodeProcessor for DummyProcessor {
         _outputs: &mut [&mut [f32]],
         _events: NodeEventList,
         _proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         ProcessStatus::Bypass
     }

--- a/crates/firewheel-cpal/src/input.rs
+++ b/crates/firewheel-cpal/src/input.rs
@@ -12,7 +12,7 @@ use firewheel_core::{
     event::{NodeEventList, NodeEventType},
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     sync_wrapper::SyncWrapper,
     SilenceMask, StreamInfo,
@@ -486,7 +486,7 @@ impl AudioNodeProcessor for Processor {
         outputs: &mut [&mut [f32]],
         mut events: NodeEventList,
         proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         events.for_each(|event| {
             if let NodeEventType::Custom(event) = event {

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -5,7 +5,7 @@ use firewheel_core::{
     event::NodeEventList,
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
 };
 
@@ -92,7 +92,7 @@ impl AudioNodeProcessor for Processor {
         outputs: &mut [&mut [f32]],
         events: NodeEventList,
         _proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         let Some(out) = outputs.first_mut() else {
             return ProcessStatus::ClearAllOutputs;

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -21,7 +21,7 @@ use firewheel_core::{
     event::{NodeEventList, NodeEventType, SequenceCommand},
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     sample_resource::SampleResource,
     SilenceMask, StreamInfo,
@@ -770,7 +770,7 @@ impl AudioNodeProcessor for SamplerProcessor {
         outputs: &mut [&mut [f32]],
         mut events: NodeEventList,
         proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         events.for_each(|event| match event {
             NodeEventType::SequenceCommand(command) => {

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -11,7 +11,7 @@ use firewheel_core::{
     event::{NodeEventList, Vec3},
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     param::smoother::{SmoothedParam, SmootherConfig},
     SilenceMask,
@@ -279,7 +279,7 @@ impl AudioNodeProcessor for Processor {
         outputs: &mut [&mut [f32]],
         events: NodeEventList,
         proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         if self.params.patch_list(events) {
             let computed_values = self.params.compute_values();

--- a/crates/firewheel-nodes/src/stereo_to_mono.rs
+++ b/crates/firewheel-nodes/src/stereo_to_mono.rs
@@ -3,7 +3,7 @@ use firewheel_core::{
     event::NodeEventList,
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
 };
 
@@ -39,7 +39,7 @@ impl AudioNodeProcessor for StereoToMonoProcessor {
         outputs: &mut [&mut [f32]],
         _events: NodeEventList,
         proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         if proc_info.in_silence_mask.all_channels_silent(2)
             || inputs.len() < 2

--- a/crates/firewheel-nodes/src/stream/reader.rs
+++ b/crates/firewheel-nodes/src/stream/reader.rs
@@ -12,7 +12,7 @@ use firewheel_core::{
     event::{NodeEventList, NodeEventType},
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     sync_wrapper::SyncWrapper,
     StreamInfo,
@@ -406,7 +406,7 @@ impl AudioNodeProcessor for Processor {
         _outputs: &mut [&mut [f32]],
         mut events: NodeEventList,
         proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         events.for_each(|event| {
             if let NodeEventType::Custom(event) = event {

--- a/crates/firewheel-nodes/src/stream/writer.rs
+++ b/crates/firewheel-nodes/src/stream/writer.rs
@@ -13,7 +13,7 @@ use firewheel_core::{
     event::{NodeEventList, NodeEventType},
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     sync_wrapper::SyncWrapper,
     SilenceMask, StreamInfo,
@@ -388,7 +388,7 @@ impl AudioNodeProcessor for Processor {
         outputs: &mut [&mut [f32]],
         mut events: NodeEventList,
         proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         events.for_each(|event| {
             if let NodeEventType::Custom(event) = event {

--- a/crates/firewheel-nodes/src/volume.rs
+++ b/crates/firewheel-nodes/src/volume.rs
@@ -5,7 +5,7 @@ use firewheel_core::{
     event::NodeEventList,
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     param::smoother::{SmoothedParam, SmootherConfig},
     SilenceMask,
@@ -129,7 +129,7 @@ impl AudioNodeProcessor for VolumeProcessor {
         outputs: &mut [&mut [f32]],
         events: NodeEventList,
         proc_info: &ProcInfo,
-        scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         if self.params.patch_list(events) {
             self.gain.set_value(self.params.normalized_volume);

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -5,7 +5,7 @@ use firewheel_core::{
     event::NodeEventList,
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     param::smoother::{SmoothedParam, SmootherConfig},
     SilenceMask,
@@ -147,7 +147,7 @@ impl AudioNodeProcessor for Processor {
         outputs: &mut [&mut [f32]],
         events: NodeEventList,
         proc_info: &ProcInfo,
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         if self.params.patch_list(events) {
             let (gain_l, gain_r) = self.params.compute_gains();

--- a/examples/custom_nodes/src/nodes/filter.rs
+++ b/examples/custom_nodes/src/nodes/filter.rs
@@ -16,7 +16,7 @@ use firewheel::{
     event::NodeEventList,
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     param::smoother::{SmoothedParam, SmoothedParamBuffer},
     SilenceMask, StreamInfo,
@@ -135,7 +135,7 @@ impl AudioNodeProcessor for Processor {
         // Additional information about the process.
         proc_info: &ProcInfo,
         // Optional scratch buffers that can be used for processing.
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         // Process the events.
         let enabled = self.params.enabled;

--- a/examples/custom_nodes/src/nodes/noise_gen.rs
+++ b/examples/custom_nodes/src/nodes/noise_gen.rs
@@ -7,7 +7,7 @@ use firewheel::{
     event::NodeEventList,
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     SilenceMask, StreamInfo,
 };
@@ -111,7 +111,7 @@ impl AudioNodeProcessor for Processor {
         // Additional information about the process.
         _proc_info: &ProcInfo,
         // Optional scratch buffers that can be used for processing.
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         // Process the events.
         if self.params.patch_list(events) {

--- a/examples/custom_nodes/src/nodes/rms.rs
+++ b/examples/custom_nodes/src/nodes/rms.rs
@@ -11,7 +11,7 @@ use firewheel::{
     event::NodeEventList,
     node::{
         AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        ScratchBuffers,
     },
     StreamInfo,
 };
@@ -157,7 +157,7 @@ impl AudioNodeProcessor for Processor {
         // Additional information about the process.
         proc_info: &ProcInfo,
         // Optional scratch buffers that can be used for processing.
-        _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
+        _scratch_buffers: ScratchBuffers,
     ) -> ProcessStatus {
         if !self.shared_state.enabled.load(Ordering::Relaxed) {
             self.shared_state.rms_value.store(0.0, Ordering::Relaxed);


### PR DESCRIPTION
This PR introduces a type alias for scratch buffers.

Because scratch buffers are only used occasionally, it seems reasonable to reduce the symbol load they impose on the `AudioNodeProcessor` trait. This also makes changing the underlying type a bit easier in the future, even if it's technically breaking.