### PR TITLE
New Constructor API

### DIFF
--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -62,7 +62,7 @@ pub trait AudioNodeConstructor {
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 pub struct EmptyConfig;
 
-/// A type-erased [`AudioNodeConstructor`].
+/// A dyn-compatible [`AudioNodeConstructor`].
 pub trait AudioNode {
     fn info(&self) -> AudioNodeInfo;
     fn processor(&self, stream_info: &StreamInfo) -> Box<dyn AudioNodeProcessor>;

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -38,6 +38,11 @@ pub struct AudioNodeInfo {
 }
 
 pub trait AudioNodeConstructor {
+    /// A type representing this constructor's configuration.
+    ///
+    /// This is intended as a one-time configuration to be used
+    /// when constructing an audio processor. When no configuration
+    /// is required, [`EmptyConfig`] should be used.
     type Configuration: Default;
 
     /// Get information about this node.

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -274,7 +274,7 @@ pub struct DummyConfig {
 impl AudioNodeConstructor for DummyConfig {
     type Configuration = ();
 
-    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "dummy",
             channel_config: self.channel_config,
@@ -284,7 +284,7 @@ impl AudioNodeConstructor for DummyConfig {
 
     fn processor(
         &self,
-        _: &Self::Configuration,
+        _config: &Self::Configuration,
         _stream_info: &StreamInfo,
     ) -> impl AudioNodeProcessor {
         DummyProcessor

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -53,6 +53,15 @@ pub trait AudioNodeConstructor {
     ) -> impl AudioNodeProcessor;
 }
 
+/// An empty constructor configuration.
+///
+/// This should be preferred over `()` because it implements
+/// [`Component`][bevy_ecs::prelude::Component], making the
+/// [`AudioNodeConstructor`] implementor trivially Bevy-compatible.
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+pub struct EmptyConfig;
+
 /// A type-erased [`AudioNodeConstructor`].
 pub trait AudioNode {
     fn info(&self) -> AudioNodeInfo;
@@ -250,8 +259,10 @@ pub struct DummyConfig {
     pub channel_config: ChannelConfig,
 }
 
-impl AudioNode for DummyConfig {
-    fn info(&self) -> AudioNodeInfo {
+impl AudioNodeConstructor for DummyConfig {
+    type Configuration = ();
+
+    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "dummy",
             channel_config: self.channel_config,
@@ -259,8 +270,12 @@ impl AudioNode for DummyConfig {
         }
     }
 
-    fn processor(&self, _stream_info: &StreamInfo) -> Box<dyn AudioNodeProcessor> {
-        Box::new(DummyProcessor)
+    fn processor(
+        &self,
+        _: &Self::Configuration,
+        _stream_info: &StreamInfo,
+    ) -> impl AudioNodeProcessor {
+        DummyProcessor
     }
 }
 

--- a/crates/firewheel-cpal/Cargo.toml
+++ b/crates/firewheel-cpal/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 [features]
 input = ["dep:fixed-resample"]
 resample_inputs = ["input", "fixed-resample?/fft-resampler"]
+bevy = ["dep:bevy_ecs"]
 
 [dependencies]
 firewheel-core = { path = "../firewheel-core", version = "0.2.4-beta.0" }
@@ -25,4 +26,8 @@ cpal = "0.15.3"
 log.workspace = true
 ringbuf.workspace = true
 thiserror.workspace = true
-fixed-resample = { version = "0.4.2", default-features = false, features = ["channel"], optional = true }
+fixed-resample = { version = "0.4.2", default-features = false, features = [
+  "channel",
+], optional = true }
+bevy_ecs = { version = "0.15", optional = true }
+

--- a/crates/firewheel-cpal/Cargo.toml
+++ b/crates/firewheel-cpal/Cargo.toml
@@ -17,7 +17,6 @@ all-features = true
 [features]
 input = ["dep:fixed-resample"]
 resample_inputs = ["input", "fixed-resample?/fft-resampler"]
-bevy = ["dep:bevy_ecs"]
 
 [dependencies]
 firewheel-core = { path = "../firewheel-core", version = "0.2.4-beta.0" }
@@ -29,5 +28,3 @@ thiserror.workspace = true
 fixed-resample = { version = "0.4.2", default-features = false, features = [
   "channel",
 ], optional = true }
-bevy_ecs = { version = "0.15", optional = true }
-

--- a/crates/firewheel-cpal/src/input.rs
+++ b/crates/firewheel-cpal/src/input.rs
@@ -2,7 +2,7 @@ use std::{
     num::{NonZeroU32, NonZeroUsize},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex,
     },
 };
 
@@ -30,7 +30,6 @@ use crate::{BUILD_STREAM_TIMEOUT, DEFAULT_MAX_BLOCK_FRAMES};
 use super::StreamStartError;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 pub struct CpalInputNodeConfig {
     /// The configuration of the input to output channel.
     pub channel_config: ResamplingChannelConfig,
@@ -112,6 +111,7 @@ impl Default for CpalInputConfig {
     }
 }
 
+#[derive(Clone)]
 pub struct CpalInputNodeHandle {
     config: CpalInputNodeConfig,
     channels: NonZeroChannelCount,
@@ -126,14 +126,6 @@ impl CpalInputNodeHandle {
             channels,
             active_state: None,
             shared_state: Arc::new(SharedState::new()),
-        }
-    }
-
-    pub fn constructor(&self) -> Constructor {
-        Constructor {
-            shared_state: Arc::clone(&self.shared_state),
-            config: self.config,
-            channels: self.channels,
         }
     }
 
@@ -385,8 +377,8 @@ impl CpalInputNodeHandle {
         stream_handle.play()?;
 
         self.active_state = Some(ActiveHandleState {
-            _stream_handle: stream_handle,
-            from_err_rx,
+            _stream_handle: Arc::new(stream_handle),
+            from_err_rx: Arc::new(Mutex::new(from_err_rx)),
         });
         self.shared_state
             .stream_active
@@ -421,12 +413,13 @@ impl CpalInputNodeHandle {
     // Poll the status of the active input stream. If an error is returned, then
     // it means that the input stream has been stopped.
     pub fn poll_status(&mut self) -> Result<(), cpal::StreamError> {
-        if let Some(state) = &mut self.active_state {
-            if let Some(e) = state.from_err_rx.try_pop() {
-                self.active_state = None;
-
-                return Err(e);
-            }
+        if let Some(error) = self
+            .active_state
+            .as_ref()
+            .and_then(|state| state.from_err_rx.lock().unwrap().try_pop())
+        {
+            self.active_state = None;
+            return Err(error);
         }
 
         Ok(())
@@ -439,14 +432,7 @@ impl Drop for CpalInputNodeHandle {
     }
 }
 
-#[derive(Clone)]
-pub struct Constructor {
-    shared_state: Arc<SharedState>,
-    config: CpalInputNodeConfig,
-    channels: NonZeroChannelCount,
-}
-
-impl AudioNodeConstructor for Constructor {
+impl AudioNodeConstructor for CpalInputNodeHandle {
     type Configuration = EmptyConfig;
 
     fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
@@ -474,9 +460,10 @@ impl AudioNodeConstructor for Constructor {
     }
 }
 
+#[derive(Clone)]
 struct ActiveHandleState {
-    _stream_handle: cpal::Stream,
-    from_err_rx: ringbuf::HeapCons<cpal::StreamError>,
+    _stream_handle: Arc<cpal::Stream>,
+    from_err_rx: Arc<Mutex<ringbuf::HeapCons<cpal::StreamError>>>,
 }
 
 struct Processor {

--- a/crates/firewheel-graph/src/context.rs
+++ b/crates/firewheel-graph/src/context.rs
@@ -469,8 +469,11 @@ impl<B: AudioBackend> FirewheelCtx<B> {
     }
 
     /// Add a node to the audio graph.
-    pub fn add_node(&mut self, constructor: impl AudioNodeConstructor + 'static) -> NodeID {
-        self.graph.add_node(constructor)
+    pub fn add_node<T>(&mut self, constructor: T, config: Option<T::Configuration>) -> NodeID
+    where
+        T: AudioNodeConstructor + 'static,
+    {
+        self.graph.add_node(constructor, config)
     }
 
     /// Remove the given node from the audio graph.

--- a/crates/firewheel-graph/src/graph.rs
+++ b/crates/firewheel-graph/src/graph.rs
@@ -65,7 +65,7 @@ impl AudioGraph {
                 channel_config: graph_in_config.channel_config,
                 uses_events: false,
             },
-            Box::new(graph_in_config),
+            Box::new(Constructor::new(graph_in_config, None)),
         )));
         nodes[graph_in_id.0].id = graph_in_id;
 
@@ -75,7 +75,7 @@ impl AudioGraph {
                 channel_config: graph_out_config.channel_config,
                 uses_events: false,
             },
-            Box::new(graph_out_config),
+            Box::new(Constructor::new(graph_out_config, None)),
         )));
         nodes[graph_out_id.0].id = graph_out_id;
 

--- a/crates/firewheel-graph/src/graph/compiler.rs
+++ b/crates/firewheel-graph/src/graph/compiler.rs
@@ -1,4 +1,4 @@
-use firewheel_core::node::{AudioNodeConstructor, AudioNodeInfo, NodeID};
+use firewheel_core::node::{AudioNode, AudioNodeInfo, NodeID};
 use smallvec::SmallVec;
 use std::{collections::VecDeque, rc::Rc};
 use thunderdome::Arena;
@@ -13,7 +13,7 @@ use schedule::{InBufferAssignment, OutBufferAssignment, ScheduledNode};
 pub struct NodeEntry {
     pub id: NodeID,
     pub info: AudioNodeInfo,
-    pub constructor: Box<dyn AudioNodeConstructor>,
+    pub constructor: Box<dyn AudioNode>,
     pub activated: bool,
     /// The edges connected to this node's input ports.
     incoming: SmallVec<[Edge; 4]>,
@@ -22,7 +22,7 @@ pub struct NodeEntry {
 }
 
 impl NodeEntry {
-    pub fn new(info: AudioNodeInfo, constructor: Box<dyn AudioNodeConstructor>) -> Self {
+    pub fn new(info: AudioNodeInfo, constructor: Box<dyn AudioNode>) -> Self {
         Self {
             id: NodeID::DANGLING,
             info,

--- a/crates/firewheel-graph/src/graph/compiler/schedule.rs
+++ b/crates/firewheel-graph/src/graph/compiler/schedule.rs
@@ -820,9 +820,12 @@ mod tests {
     }
 
     fn add_dummy_node(graph: &mut AudioGraph, channel_config: impl Into<ChannelConfig>) -> NodeID {
-        graph.add_node(DummyConfig {
-            channel_config: channel_config.into(),
-        })
+        graph.add_node(
+            DummyConfig {
+                channel_config: channel_config.into(),
+            },
+            None,
+        )
     }
 
     fn verify_node(

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -4,8 +4,8 @@ use firewheel_core::{
     dsp::decibel::normalized_volume_to_raw_gain,
     event::NodeEventList,
     node::{
-        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, EmptyConfig, ProcInfo,
+        ProcessStatus, NUM_SCRATCH_BUFFERS,
     },
 };
 
@@ -29,13 +29,6 @@ pub struct BeepTestParams {
     pub enabled: bool,
 }
 
-impl BeepTestParams {
-    /// Create a beep test node constructor using these parameters.
-    pub fn constructor(&self) -> Constructor {
-        Constructor { params: *self }
-    }
-}
-
 impl Default for BeepTestParams {
     fn default() -> Self {
         Self {
@@ -46,12 +39,10 @@ impl Default for BeepTestParams {
     }
 }
 
-pub struct Constructor {
-    pub params: BeepTestParams,
-}
+impl AudioNodeConstructor for BeepTestParams {
+    type Configuration = EmptyConfig;
 
-impl AudioNodeConstructor for Constructor {
-    fn info(&self) -> AudioNodeInfo {
+    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "beep_test",
             channel_config: ChannelConfig {
@@ -63,17 +54,17 @@ impl AudioNodeConstructor for Constructor {
     }
 
     fn processor(
-        &mut self,
+        &self,
+        _: &Self::Configuration,
         stream_info: &firewheel_core::StreamInfo,
-    ) -> Box<dyn AudioNodeProcessor> {
-        Box::new(Processor {
+    ) -> impl AudioNodeProcessor {
+        Processor {
             phasor: 0.0,
-            phasor_inc: self.params.freq_hz.clamp(20.0, 20_000.0)
-                * stream_info.sample_rate_recip as f32,
-            gain: normalized_volume_to_raw_gain(self.params.normalized_volume),
+            phasor_inc: self.freq_hz.clamp(20.0, 20_000.0) * stream_info.sample_rate_recip as f32,
+            gain: normalized_volume_to_raw_gain(self.normalized_volume),
             sample_rate_recip: (stream_info.sample_rate.get() as f32).recip(),
-            params: self.params,
-        })
+            params: *self,
+        }
     }
 }
 

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -42,7 +42,7 @@ impl Default for BeepTestParams {
 impl AudioNodeConstructor for BeepTestParams {
     type Configuration = EmptyConfig;
 
-    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "beep_test",
             channel_config: ChannelConfig {
@@ -55,7 +55,7 @@ impl AudioNodeConstructor for BeepTestParams {
 
     fn processor(
         &self,
-        _: &Self::Configuration,
+        _config: &Self::Configuration,
         stream_info: &firewheel_core::StreamInfo,
     ) -> impl AudioNodeProcessor {
         Processor {

--- a/crates/firewheel-nodes/src/peak_meter.rs
+++ b/crates/firewheel-nodes/src/peak_meter.rs
@@ -175,12 +175,6 @@ impl<const NUM_CHANNELS: usize> PeakMeterHandle<NUM_CHANNELS> {
         }
     }
 
-    pub fn constructor(&self) -> Constructor<NUM_CHANNELS> {
-        Constructor {
-            shared_state: ArcGc::clone(&self.shared_state),
-        }
-    }
-
     /// Get the latest peak values for each channel in decibels.
     ///
     /// If the node is currently disabled, then this will return a value
@@ -205,13 +199,10 @@ impl<const NUM_CHANNELS: usize> PeakMeterHandle<NUM_CHANNELS> {
     }
 }
 
-#[derive(Clone)]
-pub struct Constructor<const NUM_CHANNELS: usize> {
-    shared_state: ArcGc<SharedState<NUM_CHANNELS>>,
-}
+impl<const NUM_CHANNELS: usize> AudioNodeConstructor for PeakMeterHandle<NUM_CHANNELS> {
+    type Configuration = ();
 
-impl<const NUM_CHANNELS: usize> AudioNodeConstructor for Constructor<NUM_CHANNELS> {
-    fn info(&self) -> AudioNodeInfo {
+    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "peak_meter",
             channel_config: ChannelConfig {
@@ -222,11 +213,15 @@ impl<const NUM_CHANNELS: usize> AudioNodeConstructor for Constructor<NUM_CHANNEL
         }
     }
 
-    fn processor(&mut self, _stream_info: &StreamInfo) -> Box<dyn AudioNodeProcessor> {
-        Box::new(Processor {
+    fn processor(
+        &self,
+        _: &Self::Configuration,
+        _stream_info: &StreamInfo,
+    ) -> impl AudioNodeProcessor {
+        Processor {
             shared_state: ArcGc::clone(&self.shared_state),
             enabled: self.shared_state.enabled.load(Ordering::Relaxed),
-        })
+        }
     }
 }
 

--- a/crates/firewheel-nodes/src/peak_meter.rs
+++ b/crates/firewheel-nodes/src/peak_meter.rs
@@ -7,8 +7,8 @@ use firewheel_core::{
     dsp::decibel::{gain_to_db_clamped_neg_100_db, DbMeterNormalizer},
     event::NodeEventList,
     node::{
-        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, EmptyConfig, ProcInfo,
+        ProcessStatus, NUM_SCRATCH_BUFFERS,
     },
     StreamInfo,
 };
@@ -200,7 +200,7 @@ impl<const NUM_CHANNELS: usize> PeakMeterHandle<NUM_CHANNELS> {
 }
 
 impl<const NUM_CHANNELS: usize> AudioNodeConstructor for PeakMeterHandle<NUM_CHANNELS> {
-    type Configuration = ();
+    type Configuration = EmptyConfig;
 
     fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {

--- a/crates/firewheel-nodes/src/peak_meter.rs
+++ b/crates/firewheel-nodes/src/peak_meter.rs
@@ -202,7 +202,7 @@ impl<const NUM_CHANNELS: usize> PeakMeterHandle<NUM_CHANNELS> {
 impl<const NUM_CHANNELS: usize> AudioNodeConstructor for PeakMeterHandle<NUM_CHANNELS> {
     type Configuration = EmptyConfig;
 
-    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "peak_meter",
             channel_config: ChannelConfig {
@@ -215,7 +215,7 @@ impl<const NUM_CHANNELS: usize> AudioNodeConstructor for PeakMeterHandle<NUM_CHA
 
     fn processor(
         &self,
-        _: &Self::Configuration,
+        _config: &Self::Configuration,
         _stream_info: &StreamInfo,
     ) -> impl AudioNodeProcessor {
         Processor {

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -190,7 +190,7 @@ pub struct ComputedValues {
 impl AudioNodeConstructor for SpatialBasicParams {
     type Configuration = SpatialBasicConfig;
 
-    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "spatial_basic",
             channel_config: ChannelConfig {

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -22,6 +22,7 @@ const DAMPING_CUTOFF_HZ_MAX: f32 = 21_500.0;
 const CALC_FILTER_COEFF_INTERVAL: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 pub struct SpatialBasicConfig {
     /// The time in seconds of the internal smoothing filter.
     ///
@@ -142,14 +143,6 @@ impl Default for SpatialBasicParams {
 }
 
 impl SpatialBasicParams {
-    /// Create a volume pan node constructor using these parameters.
-    pub fn constructor(&self, config: SpatialBasicConfig) -> Constructor {
-        Constructor {
-            params: *self,
-            config,
-        }
-    }
-
     pub fn compute_values(&self) -> ComputedValues {
         let x2_z2 = (self.offset[0] * self.offset[0]) + (self.offset[2] * self.offset[2]);
         let xyz_distance = (x2_z2 + (self.offset[1] * self.offset[1])).sqrt();
@@ -194,14 +187,10 @@ pub struct ComputedValues {
     pub damping_cutoff_hz: Option<f32>,
 }
 
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
-pub struct Constructor {
-    pub params: SpatialBasicParams,
-    pub config: SpatialBasicConfig,
-}
+impl AudioNodeConstructor for SpatialBasicParams {
+    type Configuration = SpatialBasicConfig;
 
-impl AudioNodeConstructor for Constructor {
-    fn info(&self) -> AudioNodeInfo {
+    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "spatial_basic",
             channel_config: ChannelConfig {
@@ -213,18 +202,19 @@ impl AudioNodeConstructor for Constructor {
     }
 
     fn processor(
-        &mut self,
+        &self,
+        config: &Self::Configuration,
         stream_info: &firewheel_core::StreamInfo,
-    ) -> Box<dyn AudioNodeProcessor> {
-        let computed_values = self.params.compute_values();
+    ) -> impl AudioNodeProcessor {
+        let computed_values = self.compute_values();
 
         dbg!(stream_info.sample_rate);
 
-        Box::new(Processor {
+        Processor {
             gain_l: SmoothedParam::new(
                 computed_values.gain_l,
                 SmootherConfig {
-                    smooth_secs: self.config.smooth_secs,
+                    smooth_secs: config.smooth_secs,
                     ..Default::default()
                 },
                 stream_info.sample_rate,
@@ -232,7 +222,7 @@ impl AudioNodeConstructor for Constructor {
             gain_r: SmoothedParam::new(
                 computed_values.gain_r,
                 SmootherConfig {
-                    smooth_secs: self.config.smooth_secs,
+                    smooth_secs: config.smooth_secs,
                     ..Default::default()
                 },
                 stream_info.sample_rate,
@@ -242,7 +232,7 @@ impl AudioNodeConstructor for Constructor {
                     .damping_cutoff_hz
                     .unwrap_or(DAMPING_CUTOFF_HZ_MAX),
                 SmootherConfig {
-                    smooth_secs: self.config.smooth_secs,
+                    smooth_secs: config.smooth_secs,
                     ..Default::default()
                 },
                 stream_info.sample_rate,
@@ -250,10 +240,10 @@ impl AudioNodeConstructor for Constructor {
             damping_disabled: computed_values.damping_cutoff_hz.is_none(),
             filter_l: OnePoleLPBiquad::default(),
             filter_r: OnePoleLPBiquad::default(),
-            params: self.params,
+            params: *self,
             prev_block_was_silent: true,
             sample_rate_recip: stream_info.sample_rate_recip as f32,
-        })
+        }
     }
 }
 

--- a/crates/firewheel-nodes/src/stereo_to_mono.rs
+++ b/crates/firewheel-nodes/src/stereo_to_mono.rs
@@ -11,7 +11,9 @@ use firewheel_core::{
 pub struct StereoToMonoNode;
 
 impl AudioNodeConstructor for StereoToMonoNode {
-    fn info(&self) -> AudioNodeInfo {
+    type Configuration = ();
+
+    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "stereo_to_mono",
             channel_config: ChannelConfig {
@@ -23,10 +25,11 @@ impl AudioNodeConstructor for StereoToMonoNode {
     }
 
     fn processor(
-        &mut self,
+        &self,
+        _: &Self::Configuration,
         _stream_info: &firewheel_core::StreamInfo,
-    ) -> Box<dyn AudioNodeProcessor> {
-        Box::new(StereoToMonoProcessor {})
+    ) -> impl AudioNodeProcessor {
+        StereoToMonoProcessor
     }
 }
 

--- a/crates/firewheel-nodes/src/stereo_to_mono.rs
+++ b/crates/firewheel-nodes/src/stereo_to_mono.rs
@@ -14,7 +14,7 @@ pub struct StereoToMonoNode;
 impl AudioNodeConstructor for StereoToMonoNode {
     type Configuration = EmptyConfig;
 
-    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "stereo_to_mono",
             channel_config: ChannelConfig {
@@ -27,7 +27,7 @@ impl AudioNodeConstructor for StereoToMonoNode {
 
     fn processor(
         &self,
-        _: &Self::Configuration,
+        _config: &Self::Configuration,
         _stream_info: &firewheel_core::StreamInfo,
     ) -> impl AudioNodeProcessor {
         StereoToMonoProcessor

--- a/crates/firewheel-nodes/src/stereo_to_mono.rs
+++ b/crates/firewheel-nodes/src/stereo_to_mono.rs
@@ -2,16 +2,17 @@ use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     event::NodeEventList,
     node::{
-        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, EmptyConfig, ProcInfo,
+        ProcessStatus, NUM_SCRATCH_BUFFERS,
     },
 };
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 pub struct StereoToMonoNode;
 
 impl AudioNodeConstructor for StereoToMonoNode {
-    type Configuration = ();
+    type Configuration = EmptyConfig;
 
     fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {

--- a/crates/firewheel-nodes/src/stream/reader.rs
+++ b/crates/firewheel-nodes/src/stream/reader.rs
@@ -3,7 +3,7 @@ use std::{
     ops::Range,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex,
     },
 };
 
@@ -20,7 +20,6 @@ use firewheel_core::{
 use fixed_resample::{ReadStatus, ResamplingChannelConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 pub struct StreamReaderConfig {
     /// The configuration of the input to output channel.
     pub channel_config: ResamplingChannelConfig,
@@ -38,6 +37,8 @@ impl Default for StreamReaderConfig {
     }
 }
 
+#[derive(Clone)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 pub struct StreamReaderHandle {
     /// The configuration of the stream.
     ///
@@ -59,13 +60,6 @@ impl StreamReaderHandle {
         }
     }
 
-    pub fn constructor(&self) -> Constructor {
-        Constructor {
-            shared_state: Arc::clone(&self.shared_state),
-            channels: self.channels,
-        }
-    }
-
     /// Returns `true` if there is there is currently an active stream on this node.
     pub fn is_active(&self) -> bool {
         self.active_state.is_some() && self.shared_state.stream_active.load(Ordering::Relaxed)
@@ -78,7 +72,7 @@ impl StreamReaderHandle {
     /// increasing [`StreamReaderConfig::channel_config.latency_seconds`].
     ///
     /// (Calling this will also reset the flag indicating whether an
-    /// underflow occurred.)
+    /// underflow occurred.)out
     pub fn underflow_occurred(&self) -> bool {
         self.shared_state
             .underflow_occurred
@@ -128,7 +122,10 @@ impl StreamReaderHandle {
             self.config.channel_config,
         );
 
-        self.active_state = Some(ActiveState { cons, sample_rate });
+        self.active_state = Some(ActiveState {
+            cons: Arc::new(Mutex::new(cons)),
+            sample_rate,
+        });
         self.shared_state
             .stream_active
             .store(true, Ordering::Relaxed);
@@ -145,7 +142,7 @@ impl StreamReaderHandle {
         if self.is_ready() {
             self.active_state
                 .as_ref()
-                .map(|s| s.cons.available_frames())
+                .map(|s| s.cons.lock().unwrap().available_frames())
                 .unwrap_or(0)
         } else {
             0
@@ -160,7 +157,7 @@ impl StreamReaderHandle {
         if self.is_ready() {
             self.active_state
                 .as_ref()
-                .map(|s| s.cons.available_seconds())
+                .map(|s| s.cons.lock().unwrap().available_seconds())
                 .unwrap_or(0.0)
         } else {
             0.0
@@ -178,7 +175,7 @@ impl StreamReaderHandle {
     pub fn occupied_seconds(&self) -> Option<f64> {
         self.active_state
             .as_ref()
-            .map(|s| s.cons.occupied_seconds())
+            .map(|s| s.cons.lock().unwrap().occupied_seconds())
     }
 
     /// Returns the number of input frames (samples in a single channel) from the producer
@@ -188,7 +185,7 @@ impl StreamReaderHandle {
     pub fn occupied_input_frames(&self) -> Option<usize> {
         self.active_state
             .as_ref()
-            .map(|s| s.cons.occupied_input_frames())
+            .map(|s| s.cons.lock().unwrap().occupied_input_frames())
     }
 
     /// The value of [`ResamplingChannelConfig::latency_seconds`] that was passed when
@@ -203,7 +200,7 @@ impl StreamReaderHandle {
     pub fn capacity_seconds(&self) -> Option<f64> {
         self.active_state
             .as_ref()
-            .map(|s| s.cons.capacity_seconds())
+            .map(|s| s.cons.lock().unwrap().capacity_seconds())
     }
 
     /// The capacity of the channel in input frames (samples in a single channel) from
@@ -213,7 +210,7 @@ impl StreamReaderHandle {
     pub fn capacity_input_frames(&self) -> Option<usize> {
         self.active_state
             .as_ref()
-            .map(|s| s.cons.capacity_input_frames())
+            .map(|s| s.cons.lock().unwrap().capacity_input_frames())
     }
 
     /// The number of channels in this node.
@@ -245,6 +242,8 @@ impl StreamReaderHandle {
                 .as_mut()
                 .unwrap()
                 .cons
+                .lock()
+                .unwrap()
                 .read_interleaved(output),
         )
     }
@@ -270,7 +269,15 @@ impl StreamReaderHandle {
             return None;
         }
 
-        Some(self.active_state.as_mut().unwrap().cons.read(output, range))
+        Some(
+            self.active_state
+                .as_mut()
+                .unwrap()
+                .cons
+                .lock()
+                .unwrap()
+                .read(output, range),
+        )
     }
 
     /// Discard all data currently in the channel.
@@ -283,7 +290,7 @@ impl StreamReaderHandle {
     /// Returns the number of input frames that were discarded.
     pub fn discard_all(&mut self) -> usize {
         if let Some(state) = &mut self.active_state {
-            state.cons.discard_input_frames(usize::MAX)
+            state.cons.lock().unwrap().discard_input_frames(usize::MAX)
         } else {
             0
         }
@@ -301,7 +308,7 @@ impl StreamReaderHandle {
     /// then this will do nothing.
     pub fn discard_jitter(&mut self, threshold_seconds: f64) -> usize {
         if let Some(state) = &mut self.active_state {
-            state.cons.discard_jitter(threshold_seconds)
+            state.cons.lock().unwrap().discard_jitter(threshold_seconds)
         } else {
             0
         }
@@ -340,16 +347,10 @@ impl Drop for StreamReaderHandle {
     }
 }
 
-#[derive(Clone)]
-pub struct Constructor {
-    shared_state: Arc<SharedState>,
-    channels: NonZeroChannelCount,
-}
-
-impl AudioNodeConstructor for Constructor {
+impl AudioNodeConstructor for StreamReaderHandle {
     type Configuration = EmptyConfig;
 
-    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "stream_output",
             channel_config: ChannelConfig {
@@ -362,7 +363,7 @@ impl AudioNodeConstructor for Constructor {
 
     fn processor(
         &self,
-        _: &Self::Configuration,
+        _config: &Self::Configuration,
         _stream_info: &StreamInfo,
     ) -> impl AudioNodeProcessor {
         Processor {
@@ -372,8 +373,9 @@ impl AudioNodeConstructor for Constructor {
     }
 }
 
+#[derive(Clone)]
 struct ActiveState {
-    cons: fixed_resample::ResamplingCons<f32>,
+    cons: Arc<Mutex<fixed_resample::ResamplingCons<f32>>>,
     sample_rate: NonZeroU32,
 }
 

--- a/crates/firewheel-nodes/src/stream/writer.rs
+++ b/crates/firewheel-nodes/src/stream/writer.rs
@@ -12,8 +12,8 @@ use firewheel_core::{
     dsp::declick::{Declicker, FadeType},
     event::{NodeEventList, NodeEventType},
     node::{
-        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, EmptyConfig, ProcInfo,
+        ProcessStatus, NUM_SCRATCH_BUFFERS,
     },
     sync_wrapper::SyncWrapper,
     SilenceMask, StreamInfo,
@@ -318,7 +318,9 @@ pub struct Constructor {
 }
 
 impl AudioNodeConstructor for Constructor {
-    fn info(&self) -> AudioNodeInfo {
+    type Configuration = EmptyConfig;
+
+    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "stream_input",
             channel_config: ChannelConfig {
@@ -329,14 +331,18 @@ impl AudioNodeConstructor for Constructor {
         }
     }
 
-    fn processor(&mut self, _stream_info: &StreamInfo) -> Box<dyn AudioNodeProcessor> {
-        Box::new(Processor {
+    fn processor(
+        &self,
+        _: &Self::Configuration,
+        _stream_info: &StreamInfo,
+    ) -> impl AudioNodeProcessor {
+        Processor {
             cons: None,
             shared_state: Arc::clone(&self.shared_state),
             discard_jitter_threshold_seconds: self.config.discard_jitter_threshold_seconds,
             check_for_silence: self.config.check_for_silence,
             pause_declicker: Declicker::SettledAt0,
-        })
+        }
     }
 }
 

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -87,7 +87,7 @@ impl Default for VolumePanParams {
 impl AudioNodeConstructor for VolumePanParams {
     type Configuration = VolumeNodeConfig;
 
-    fn info(&self, _: &Self::Configuration) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             debug_name: "volume_pan",
             channel_config: ChannelConfig {

--- a/examples/beep_test/src/main.rs
+++ b/examples/beep_test/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
         enabled: true,
     };
 
-    let beep_test_id = cx.add_node(beep_test_params.constructor());
+    let beep_test_id = cx.add_node(beep_test_params, None);
     let graph_out_id = cx.graph_out_node();
 
     cx.connect(beep_test_id, graph_out_id, &[(0, 0), (0, 1)], false)

--- a/examples/cpal_input/src/main.rs
+++ b/examples/cpal_input/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let mut input_node_handle =
         CpalInputNodeHandle::new(Default::default(), NonZeroChannelCount::MONO);
-    let input_node_id = cx.add_node(input_node_handle.constructor());
+    let input_node_id = cx.add_node(input_node_handle.constructor(), None);
 
     cx.connect(input_node_id, graph_out_node, &[(0, 0), (0, 1)], false)
         .unwrap();

--- a/examples/cpal_input/src/main.rs
+++ b/examples/cpal_input/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let mut input_node_handle =
         CpalInputNodeHandle::new(Default::default(), NonZeroChannelCount::MONO);
-    let input_node_id = cx.add_node(input_node_handle.constructor(), None);
+    let input_node_id = cx.add_node(input_node_handle.clone(), None);
 
     cx.connect(input_node_id, graph_out_node, &[(0, 0), (0, 1)], false)
         .unwrap();

--- a/examples/custom_nodes/src/nodes/filter.rs
+++ b/examples/custom_nodes/src/nodes/filter.rs
@@ -15,8 +15,8 @@ use firewheel::{
     },
     event::NodeEventList,
     node::{
-        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, ProcInfo, ProcessStatus,
-        NUM_SCRATCH_BUFFERS,
+        AudioNodeConstructor, AudioNodeInfo, AudioNodeProcessor, EmptyConfig, ProcInfo,
+        ProcessStatus, NUM_SCRATCH_BUFFERS,
     },
     param::smoother::{SmoothedParam, SmoothedParamBuffer},
     SilenceMask, StreamInfo,
@@ -43,29 +43,15 @@ impl Default for FilterParams {
     }
 }
 
-impl FilterParams {
-    // Add a method to create a new node constructor using these parameters.
-    //
-    // You may also pass any additional configuration for the node here.
-    pub fn constructor(&self) -> Constructor {
-        Constructor { params: *self }
-    }
-}
+// Implement the AudioNodeConstructor type for your node.
+impl AudioNodeConstructor for FilterParams {
+    // Since this node doesnt't need any configuration, we'll just
+    // default to `EmptyConfig`.
+    type Configuration = EmptyConfig;
 
-// This struct holds information to construct the node in the audio graph.
-//
-// Here we only store the current parameters, but you may add any
-// additional information as needed.
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
-pub struct Constructor {
-    pub params: FilterParams,
-}
-
-// Derive the AudioNodeConstructor type for your constructor.
-impl AudioNodeConstructor for Constructor {
     // Return information about your node. This method is only ever called
     // once.
-    fn info(&self) -> AudioNodeInfo {
+    fn info(&self, _config: &Self::Configuration) -> AudioNodeInfo {
         AudioNodeInfo {
             // A static name used for debugging purposes.
             debug_name: "example_filter",
@@ -86,22 +72,26 @@ impl AudioNodeConstructor for Constructor {
     //
     // This method is called before the node processor is sent to the realtime
     // thread, so it is safe to do non-realtime things here like allocating.
-    fn processor(&mut self, stream_info: &StreamInfo) -> Box<dyn AudioNodeProcessor> {
+    fn processor(
+        &self,
+        _config: &Self::Configuration,
+        stream_info: &StreamInfo,
+    ) -> impl AudioNodeProcessor {
         // The reciprocal of the sample rate.
         let sample_rate_recip = stream_info.sample_rate_recip as f32;
 
-        let cutoff_hz = self.params.cutoff_hz.clamp(20.0, 20_000.0);
-        let gain = normalized_volume_to_raw_gain(self.params.normalized_volume);
+        let cutoff_hz = self.cutoff_hz.clamp(20.0, 20_000.0);
+        let gain = normalized_volume_to_raw_gain(self.normalized_volume);
 
-        Box::new(Processor {
+        Processor {
             filter_l: OnePoleLPBiquad::new(cutoff_hz, sample_rate_recip),
             filter_r: OnePoleLPBiquad::new(cutoff_hz, sample_rate_recip),
             cutoff_hz: SmoothedParam::new(cutoff_hz, Default::default(), stream_info.sample_rate),
             gain: SmoothedParamBuffer::new(gain, Default::default(), stream_info),
-            enable_declicker: Declicker::from_enabled(self.params.enabled),
-            params: self.params,
+            enable_declicker: Declicker::from_enabled(self.enabled),
+            params: *self,
             sample_rate_recip,
-        })
+        }
     }
 }
 
@@ -138,6 +128,9 @@ impl AudioNodeProcessor for Processor {
         _scratch_buffers: &mut [&mut [f32]; NUM_SCRATCH_BUFFERS],
     ) -> ProcessStatus {
         // Process the events.
+        //
+        // If a parameter was actually updated,
+        // `patch_list` will return true.
         let enabled = self.params.enabled;
         if self.params.patch_list(events) {
             self.cutoff_hz

--- a/examples/custom_nodes/src/system.rs
+++ b/examples/custom_nodes/src/system.rs
@@ -1,21 +1,17 @@
 use firewheel::{diff::Memo, error::UpdateError, node::NodeID, FirewheelContext};
 
-use crate::nodes::{
-    filter::FilterParams,
-    noise_gen::NoiseGenParams,
-    rms::{RmsHandle, RmsParams},
-};
+use crate::nodes::{filter::FilterParams, noise_gen::NoiseGenParams, rms::RmsParams};
 
 pub struct AudioSystem {
     pub cx: FirewheelContext,
 
     pub noise_gen_params: Memo<NoiseGenParams>,
     pub filter_params: Memo<FilterParams>,
-    pub rms_params: RmsParams,
-    pub rms_handle: RmsHandle,
+    pub rms_params: Memo<RmsParams>,
 
     pub noise_gen_node: NodeID,
     pub filter_node: NodeID,
+    pub rms_node: NodeID,
 }
 
 impl AudioSystem {
@@ -26,11 +22,10 @@ impl AudioSystem {
         let noise_gen_params = NoiseGenParams::default();
         let filter_params = FilterParams::default();
         let rms_params = RmsParams::default();
-        let rms_handle = RmsHandle::new(rms_params);
 
-        let noise_gen_node = cx.add_node(noise_gen_params.constructor(None));
-        let filter_node = cx.add_node(filter_params.constructor());
-        let rms_node = cx.add_node(rms_handle.constructor(Default::default()));
+        let noise_gen_node = cx.add_node(noise_gen_params, None);
+        let filter_node = cx.add_node(filter_params, None);
+        let rms_node = cx.add_node(rms_params.clone(), None);
 
         let graph_out = cx.graph_out_node();
 
@@ -44,10 +39,10 @@ impl AudioSystem {
             cx,
             noise_gen_params: Memo::new(noise_gen_params),
             filter_params: Memo::new(filter_params),
-            rms_params,
-            rms_handle,
+            rms_params: Memo::new(rms_params),
             noise_gen_node,
             filter_node,
+            rms_node,
         }
     }
 

--- a/examples/custom_nodes/src/ui.rs
+++ b/examples/custom_nodes/src/ui.rs
@@ -90,11 +90,11 @@ impl App for DemoApp {
                 .changed()
             {
                 self.audio_system
-                    .rms_handle
-                    .sync_params(self.audio_system.rms_params);
+                    .rms_params
+                    .update_memo(&mut self.audio_system.cx.event_queue(self.audio_system.rms_node));
             }
 
-            let rms_value = self.audio_system.rms_handle.rms_value();
+            let rms_value = self.audio_system.rms_params.rms_value();
 
             // The rms value is quite low, so scale it up to register on the meter better.
             ui.add(ProgressBar::new(rms_value * 2.0).fill(Color32::DARK_GREEN));

--- a/examples/play_sample/src/main.rs
+++ b/examples/play_sample/src/main.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use clap::Parser;
 use firewheel::{
     error::UpdateError,
-    nodes::sampler::{PlaybackState, RepeatMode, SamplerHandle, SamplerParams},
+    nodes::sampler::{PlaybackState, RepeatMode, SamplerParams},
     FirewheelContext,
 };
 use symphonium::SymphoniumLoader;
@@ -30,11 +30,9 @@ fn main() {
 
     // --- Create a sampler state, and add it as a node in the audio graph. --------------
 
-    let sampler_handle = SamplerHandle::default();
     let mut sampler_params = SamplerParams::default();
 
-    let sampler_id =
-        cx.add_node(sampler_handle.constructor(sampler_params.clone(), Default::default()));
+    let sampler_id = cx.add_node(sampler_params.clone(), None);
     let graph_out_id = cx.graph_out_node();
 
     cx.connect(sampler_id, graph_out_id, &[(0, 0), (1, 1)], false)
@@ -51,8 +49,7 @@ fn main() {
     sampler_params.set_sample(sample, 1.0, RepeatMode::PlayOnce);
     cx.queue_event_for(
         sampler_id,
-        sampler_handle.sync_params_event(
-            sampler_params.clone(),
+        sampler_params.sync_params_event(
             true, // start immediately
         ),
     );
@@ -68,7 +65,7 @@ fn main() {
     // --- Simulated update loop ---------------------------------------------------------
 
     loop {
-        if sampler_handle.playback_state() == PlaybackState::Stopped {
+        if sampler_params.playback_state() == PlaybackState::Stopped {
             // Sample has finished playing.
             break;
         }

--- a/examples/sampler_pool/src/system.rs
+++ b/examples/sampler_pool/src/system.rs
@@ -4,7 +4,7 @@ use firewheel::{
     error::UpdateError,
     nodes::{
         sampler::{RepeatMode, SamplerParams},
-        volume::VolumeParams,
+        volume::{VolumeNodeConfig, VolumeParams},
         StereoToMonoNode,
     },
     sampler_pool::{FxChain, SamplerPool, VolumePanChain},
@@ -120,11 +120,16 @@ impl FxChain for MyCustomChain {
         assert_eq!(sampler_num_channels, NonZeroChannelCount::STEREO);
         assert_eq!(dst_num_channels, NonZeroChannelCount::STEREO);
 
-        let stereo_to_mono_node_id = cx.add_node(StereoToMonoNode);
+        let stereo_to_mono_node_id = cx.add_node(StereoToMonoNode, None);
 
         let volume_params = VolumeParams::default();
-        let volume_node_id =
-            cx.add_node(volume_params.constructor(NonZeroChannelCount::MONO, Default::default()));
+        let volume_node_id = cx.add_node(
+            volume_params,
+            Some(VolumeNodeConfig {
+                channels: NonZeroChannelCount::MONO,
+                ..Default::default()
+            }),
+        );
 
         // Connect the sampler node to the stereo_to_mono node.
         cx.connect(

--- a/examples/spatial_basic/src/system.rs
+++ b/examples/spatial_basic/src/system.rs
@@ -3,7 +3,7 @@ use firewheel::{
     error::UpdateError,
     node::NodeID,
     nodes::{
-        sampler::{RepeatMode, SamplerHandle, SamplerParams},
+        sampler::{RepeatMode, SamplerParams},
         spatial_basic::SpatialBasicParams,
     },
     FirewheelContext,
@@ -14,7 +14,6 @@ pub struct AudioSystem {
     pub cx: FirewheelContext,
 
     pub _sampler_params: SamplerParams,
-    pub _sampler_handle: SamplerHandle,
     pub _sampler_node: NodeID,
 
     pub spatial_basic_params: Memo<SpatialBasicParams>,
@@ -43,27 +42,21 @@ impl AudioSystem {
         let mut sampler_params = SamplerParams::default();
         sampler_params.set_sample(sample, 1.0, RepeatMode::RepeatEndlessly);
 
-        let sampler_handle = SamplerHandle::new();
-        let sampler_node =
-            cx.add_node(sampler_handle.constructor(sampler_params.clone(), Default::default()));
+        let sampler_node = cx.add_node(sampler_params.clone(), None);
 
         let spatial_basic_params = SpatialBasicParams::default();
-        let spatial_basic_node = cx.add_node(spatial_basic_params.constructor(Default::default()));
+        let spatial_basic_node = cx.add_node(spatial_basic_params, None);
 
         cx.connect(sampler_node, spatial_basic_node, &[(0, 0), (1, 1)], false)
             .unwrap();
         cx.connect(spatial_basic_node, graph_out, &[(0, 0), (1, 1)], false)
             .unwrap();
 
-        cx.queue_event_for(
-            sampler_node,
-            sampler_handle.start_or_restart_event(&sampler_params, None),
-        );
+        cx.queue_event_for(sampler_node, sampler_params.start_or_restart_event(None));
 
         Self {
             cx,
             _sampler_params: sampler_params,
-            _sampler_handle: sampler_handle,
             _sampler_node: sampler_node,
             spatial_basic_params: Memo::new(spatial_basic_params),
             spatial_basic_node,

--- a/examples/stream_nodes/src/main.rs
+++ b/examples/stream_nodes/src/main.rs
@@ -67,8 +67,8 @@ fn main() {
         NUM_CHANNELS,
     );
 
-    let stream_writer_id = cx.add_node(stream_writer_handle.constructor(), None);
-    let stream_reader_id = cx.add_node(stream_reader_handle.constructor(), None);
+    let stream_writer_id = cx.add_node(stream_writer_handle.clone(), None);
+    let stream_reader_id = cx.add_node(stream_reader_handle.clone(), None);
 
     cx.connect(stream_writer_id, graph_out_node, &[(0, 0), (1, 1)], false)
         .unwrap();

--- a/examples/stream_nodes/src/main.rs
+++ b/examples/stream_nodes/src/main.rs
@@ -67,8 +67,8 @@ fn main() {
         NUM_CHANNELS,
     );
 
-    let stream_writer_id = cx.add_node(stream_writer_handle.constructor());
-    let stream_reader_id = cx.add_node(stream_reader_handle.constructor());
+    let stream_writer_id = cx.add_node(stream_writer_handle.constructor(), None);
+    let stream_reader_id = cx.add_node(stream_reader_handle.constructor(), None);
 
     cx.connect(stream_writer_id, graph_out_node, &[(0, 0), (1, 1)], false)
         .unwrap();

--- a/examples/visual_node_graph/src/system.rs
+++ b/examples/visual_node_graph/src/system.rs
@@ -4,7 +4,9 @@ use firewheel::{
     event::{NodeEvent, NodeEventType},
     node::NodeID,
     nodes::{
-        beep_test::BeepTestParams, volume::VolumeParams, volume_pan::VolumePanParams,
+        beep_test::BeepTestParams,
+        volume::{VolumeNodeConfig, VolumeParams},
+        volume_pan::VolumePanParams,
         StereoToMonoNode,
     },
     ContextQueue, CpalBackend, FirewheelContext,
@@ -41,18 +43,23 @@ impl AudioSystem {
 
     pub fn add_node(&mut self, node_type: NodeType) -> GuiAudioNode {
         let id = match node_type {
-            NodeType::BeepTest => self.cx.add_node(BeepTestParams::default().constructor()),
-            NodeType::StereoToMono => self.cx.add_node(StereoToMonoNode),
+            NodeType::BeepTest => self.cx.add_node(BeepTestParams::default(), None),
+            NodeType::StereoToMono => self.cx.add_node(StereoToMonoNode, None),
             NodeType::VolumeMono => self.cx.add_node(
-                VolumeParams::default().constructor(NonZeroChannelCount::MONO, Default::default()),
+                VolumeParams::default(),
+                Some(VolumeNodeConfig {
+                    channels: NonZeroChannelCount::MONO,
+                    ..Default::default()
+                }),
             ),
             NodeType::VolumeStereo => self.cx.add_node(
-                VolumeParams::default()
-                    .constructor(NonZeroChannelCount::STEREO, Default::default()),
+                VolumeParams::default(),
+                Some(VolumeNodeConfig {
+                    channels: NonZeroChannelCount::STEREO,
+                    ..Default::default()
+                }),
             ),
-            NodeType::VolumePan => self
-                .cx
-                .add_node(VolumePanParams::default().constructor(Default::default())),
+            NodeType::VolumePan => self.cx.add_node(VolumePanParams::default(), None),
         };
 
         match node_type {


### PR DESCRIPTION
This PR introduces a new constructor API:

```rs
pub trait AudioNodeConstructor {
    type Configuration: Default;

    fn info(&self, configuration: &Self::Configuration) -> AudioNodeInfo;

    fn processor(
        &self,
        configuration: &Self::Configuration,
        stream_info: &StreamInfo,
    ) -> impl AudioNodeProcessor;
}
```

This aims to reduce boilerplate involved in node authoring and integration with `bevy_ecs`. With a node's configuration exposed as an associated type, we can remove the need to create intermediate `Constructor` types, and we can use this associated type to make concise ECS APIs.

As a part of these changes, I've tried to consolidate some types to simplify their APIs. Most notably, I consolidated the `SamplerParams` and `SamplerHandle` types. The `RmsParams` in the `custom_nodes` example illustrates why this is useful in a more self-contained way than the sampler.

Not all nodes are completely ported to this paradigm. In particular, the input and output stream nodes as well as the CPAL input node present some issues and may need more consideration before merging.
