### PR TITLE
`enum` derive macros

### DIFF
--- a/crates/firewheel-core/src/diff/collections.rs
+++ b/crates/firewheel-core/src/diff/collections.rs
@@ -62,6 +62,20 @@ macro_rules! tuple_diff {
                 )*
             }
         }
+
+        #[allow(non_snake_case, unused_variables)]
+        impl<$($gen: Patch),*> Patch for ($($gen,)*) {
+            fn patch(&mut self, data: &ParamData, path: &[u32]) -> Result<(), PatchError> {
+                let ($($gen,)*) = self;
+
+                match path {
+                    $(
+                        [$index, tail @ ..] => $gen.patch(data, tail),
+                    )*
+                    _ => Err(PatchError::InvalidPath),
+                }
+            }
+        }
     };
 }
 

--- a/crates/firewheel-core/src/diff/mod.rs
+++ b/crates/firewheel-core/src/diff/mod.rs
@@ -156,3 +156,43 @@ pub enum PatchError {
     /// The data supplied for the path did not match the expected type.
     InvalidData,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    extern crate self as firewheel_core;
+
+    #[derive(Debug, Clone, Diff, Patch, PartialEq)]
+    enum DiffingExample {
+        Unit,
+        Tuple(f32, f32),
+        Struct { a: f32, b: f32 },
+    }
+
+    #[test]
+    fn test_enum_diff() {
+        let mut baseline = DiffingExample::Tuple(1.0, 0.0);
+        let value = DiffingExample::Tuple(1.0, 1.0);
+
+        let mut messages = Vec::new();
+        value.diff(&baseline, PathBuilder::default(), &mut messages);
+
+        assert_eq!(messages.len(), 1);
+        assert!(baseline.patch_event(&messages[0]));
+        assert_eq!(baseline, value);
+    }
+
+    #[test]
+    fn test_enum_switch_variant() {
+        let mut baseline = DiffingExample::Unit;
+        let value = DiffingExample::Struct { a: 1.0, b: 1.0 };
+
+        let mut messages = Vec::new();
+        value.diff(&baseline, PathBuilder::default(), &mut messages);
+
+        assert_eq!(messages.len(), 1);
+        assert!(baseline.patch_event(&messages[0]));
+        assert_eq!(baseline, value);
+    }
+}

--- a/crates/firewheel-core/src/dsp/pan_law.rs
+++ b/crates/firewheel-core/src/dsp/pan_law.rs
@@ -1,13 +1,10 @@
 use std::f32::consts::FRAC_PI_2;
 
-use crate::{
-    diff::{Diff, Patch},
-    event::ParamData,
-};
+use crate::diff::{Diff, Patch};
 
 /// The algorithm to use to map a normalized panning value in the range `[-1.0, 1.0]`
 /// to the corresponding gain values for the left and right channels.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Diff, Patch)]
 #[repr(u32)]
 pub enum PanLaw {
     /// This pan law makes the signal appear to play at a constant volume across
@@ -68,35 +65,6 @@ impl PanLaw {
             2 => Self::SquareRoot,
             3 => Self::Linear,
             _ => Self::EqualPower3dB,
-        }
-    }
-}
-
-impl Diff for PanLaw {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self as u32, path);
-        }
-    }
-}
-
-impl Patch for PanLaw {
-    fn patch(
-        &mut self,
-        data: &crate::event::ParamData,
-        _path: &[u32],
-    ) -> Result<(), crate::diff::PatchError> {
-        match data {
-            ParamData::U32(raw) => {
-                *self = Self::from_u32(*raw);
-                Ok(())
-            }
-            _ => Err(crate::diff::PatchError::InvalidData),
         }
     }
 }

--- a/crates/firewheel-core/src/lib.rs
+++ b/crates/firewheel-core/src/lib.rs
@@ -14,6 +14,8 @@ use std::num::NonZeroU32;
 
 pub use silence_mask::SilenceMask;
 
+extern crate self as firewheel_core;
+
 /// Information about a running audio stream.
 #[derive(Debug, Clone, PartialEq)]
 pub struct StreamInfo {

--- a/crates/firewheel-graph/src/context.rs
+++ b/crates/firewheel-graph/src/context.rs
@@ -661,15 +661,32 @@ pub(crate) struct ClockValues {
 }
 
 impl<B: AudioBackend> FirewheelCtx<B> {
-    /// Construct an event queue for diffing.
+    /// Construct an [`ContextQueue`] for diffing.
     pub fn event_queue(&mut self, id: NodeID) -> ContextQueue<'_, B> {
         ContextQueue { context: self, id }
     }
 }
 
-/// An event queue acquired from [`FirewheelCtx`].
+/// An event queue acquired from [`FirewheelCtx::event_queue`].
 ///
-/// This avoids intermediate event queues.
+/// This can help reduce event queue allocations
+/// when you have direct access to the context.
+///
+/// ```
+/// # use firewheel_core::{diff::{Diff, PathBuilder}, node::NodeID};
+/// # use firewheel_graph::{backend::AudioBackend, FirewheelCtx, ContextQueue};
+/// # fn context_queue<B: AudioBackend, D: Diff>(
+/// #     context: &mut FirewheelCtx<B>,
+/// #     node_id: NodeID,
+/// #     params: &D,
+/// #     baseline: &D,
+/// # ) {
+/// // Get a queue that will send events directly to the provided node.
+/// let mut queue = context.event_queue(node_id);
+/// // Perform diffing using this queue.
+/// params.diff(baseline, PathBuilder::default(), &mut queue);
+/// # }
+/// ```
 pub struct ContextQueue<'a, B: AudioBackend> {
     context: &'a mut FirewheelCtx<B>,
     id: NodeID,

--- a/crates/firewheel-macros/src/diff.rs
+++ b/crates/firewheel-macros/src/diff.rs
@@ -1,0 +1,303 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote, quote_spanned};
+use syn::spanned::Spanned;
+
+use crate::{get_paths, struct_fields};
+
+pub fn derive_diff(input: TokenStream) -> syn::Result<TokenStream2> {
+    let input: syn::DeriveInput = syn::parse(input)?;
+    let identifier = &input.ident;
+    let (firewheel_path, diff_path) = get_paths();
+
+    let DiffOutput { body, bounds } = match &input.data {
+        syn::Data::Struct(data) => DiffOutput::from_struct(data, &diff_path)?,
+        syn::Data::Enum(data) => {
+            DiffOutput::from_enum(identifier, data, &firewheel_path, &diff_path)?
+        }
+        syn::Data::Union(_) => {
+            return Err(syn::Error::new(
+                input.span(),
+                "`Diff` cannot be derived on unions.",
+            ));
+        }
+    };
+
+    let (impl_generics, ty_generics, where_generics) = input.generics.split_for_impl();
+
+    let where_generics = match where_generics {
+        Some(wg) => {
+            quote! {
+                #wg
+                #(#bounds,)*
+            }
+        }
+        None => {
+            if bounds.is_empty() {
+                quote! {}
+            } else {
+                quote! {
+                    where #(#bounds,)*
+                }
+            }
+        }
+    };
+
+    Ok(quote! {
+        impl #impl_generics #diff_path::Diff for #identifier #ty_generics #where_generics {
+            fn diff<__E: #diff_path::EventQueue>(&self, baseline: &Self, path: #diff_path::PathBuilder, event_queue: &mut __E) {
+                #body
+            }
+        }
+    })
+}
+
+struct DiffOutput {
+    body: TokenStream2,
+    bounds: Vec<TokenStream2>,
+}
+
+struct UnnamedField<'a> {
+    /// The type is useful for error spans.
+    ty: &'a syn::Type,
+    /// An identifier for tuple fields.
+    unpack_ident: syn::Ident,
+}
+
+/// A convenience struct for keeping track of a struct variant's
+/// identifier along with an identifier we can use without causing
+/// name clashing.
+struct NamedField<'a> {
+    /// The type is useful for error spans.
+    ty: &'a syn::Type,
+    /// The struct field's actual name.
+    type_ident: &'a syn::Ident,
+    /// An identifier that avoids the possibility of name clashing.
+    unpack_ident: syn::Ident,
+}
+
+impl DiffOutput {
+    pub fn from_struct(data: &syn::DataStruct, diff_path: &TokenStream2) -> syn::Result<Self> {
+        let fields = struct_fields(data);
+
+        let arms = fields.iter().enumerate().map(|(i, (identifier, _))| {
+            let index = i as u32;
+            quote! {
+                self.#identifier.diff(&baseline.#identifier, path.with(#index), event_queue);
+            }
+        });
+
+        Ok(Self {
+            body: quote! { #(#arms)* },
+            bounds: fields
+                .iter()
+                .map(|(_, ty)| {
+                    let span = ty.span();
+                    quote_spanned! {span=> #ty: #diff_path::Diff }
+                })
+                .collect(),
+        })
+    }
+
+    // This is quite a bit more complicated because we need to account for
+    // three kinds of variants _and_ we need to be able to construct variants
+    // with all required data at once in addition to fine-grained diffing.
+    pub fn from_enum(
+        identifier: &syn::Ident,
+        data: &syn::DataEnum,
+        firewheel_path: &syn::Path,
+        diff_path: &TokenStream2,
+    ) -> syn::Result<DiffOutput> {
+        let mut arms = Vec::new();
+        let mut types = Vec::new();
+        for (index, variant) in data.variants.iter().enumerate() {
+            let variant_index = index as u32;
+            let variant_ident = &variant.ident;
+
+            match &variant.fields {
+                syn::Fields::Unit => {
+                    arms.push(quote! {
+                        (#identifier::#variant_ident, #identifier::#variant_ident) => {}
+                    });
+
+                    arms.push(quote! {
+                        (#identifier::#variant_ident, _) => {
+                            event_queue.push_param(
+                                #firewheel_path::event::ParamData::U32(0),
+                                path.with(#variant_index),
+                            );
+                        }
+                    });
+                }
+                syn::Fields::Unnamed(fields) => {
+                    let mut a_idents = Vec::new();
+                    let mut b_idents = Vec::new();
+
+                    for (i, field) in fields.unnamed.iter().enumerate() {
+                        types.push(&field.ty);
+
+                        a_idents.push(UnnamedField {
+                            ty: &field.ty,
+                            unpack_ident: format_ident!("a{i}"),
+                        });
+                        b_idents.push(UnnamedField {
+                            ty: &field.ty,
+                            unpack_ident: format_ident!("b{i}"),
+                        });
+                    }
+
+                    let diff_statements = a_idents.iter().zip(b_idents.iter()).enumerate().map(
+                        |(i, (a, b))| {
+                            let i = i as u32;
+                            let ty = &a.ty;
+                            let a = &a.unpack_ident;
+                            let b = &b.unpack_ident;
+
+                            quote! {
+                                <#ty as #diff_path::Diff>::diff(#a, #b, path.with(#i), event_queue);
+                            }
+                        },
+                    );
+
+                    let a_unpacked: Vec<_> = a_idents
+                        .iter()
+                        .map(|a| {
+                            let unpack = &a.unpack_ident;
+
+                            quote! {
+                                #unpack
+                            }
+                        })
+                        .collect();
+
+                    let b_unpacked = b_idents.iter().map(|b| {
+                        let unpack = &b.unpack_ident;
+
+                        quote! {
+                            #unpack
+                        }
+                    });
+
+                    arms.push(quote! {
+                        (#identifier::#variant_ident(#(#a_unpacked),*), #identifier::#variant_ident(#(#b_unpacked),*)) => {
+                            let path = path.with(#variant_index);
+
+                            #(#diff_statements)*
+                        }
+                    });
+
+                    let set_items = a_idents.iter().map(|a| {
+                        let ty = &a.ty;
+                        let a = &a.unpack_ident;
+
+                        quote! { <#ty as ::core::clone::Clone>::clone(&#a) }
+                    });
+
+                    arms.push(quote! {
+                        (#identifier::#variant_ident(#(#a_unpacked),*), _) => {
+                            event_queue.push_param(
+                                #firewheel_path::event::ParamData::any((#(#set_items,)*)),
+                                path.with(#variant_index),
+                            );
+                        }
+                    })
+                }
+                syn::Fields::Named(fields) => {
+                    let mut a_idents = Vec::new();
+                    let mut b_idents = Vec::new();
+
+                    for (i, field) in fields.named.iter().enumerate() {
+                        types.push(&field.ty);
+
+                        a_idents.push(NamedField {
+                            ty: &field.ty,
+                            type_ident: field.ident.as_ref().expect("field ident should exist"),
+                            unpack_ident: format_ident!("a{i}"),
+                        });
+
+                        b_idents.push(NamedField {
+                            ty: &field.ty,
+                            type_ident: field.ident.as_ref().expect("field ident should exist"),
+                            unpack_ident: format_ident!("b{i}"),
+                        });
+                    }
+
+                    let a_unpacked: Vec<_> = a_idents
+                        .iter()
+                        .map(|a| {
+                            let ident = a.type_ident;
+                            let unpack = &a.unpack_ident;
+
+                            quote! {
+                                #ident: #unpack
+                            }
+                        })
+                        .collect();
+
+                    let b_unpacked = b_idents.iter().map(|b| {
+                        let ident = b.type_ident;
+                        let unpack = &b.unpack_ident;
+
+                        quote! {
+                            #ident: #unpack
+                        }
+                    });
+
+                    let diff_statements = a_idents.iter().zip(b_idents.iter()).enumerate().map(
+                        |(i, (a, b))| {
+                            let i = i as u32;
+                            let ty = a.ty;
+                            let a = &a.unpack_ident;
+                            let b = &b.unpack_ident;
+
+                            quote! {
+                                <#ty as #diff_path::Diff>::diff(#a, #b, path.with(#i), event_queue);
+                            }
+                        },
+                    );
+
+                    arms.push(quote! {
+                        (#identifier::#variant_ident{#(#a_unpacked),*}, #identifier::#variant_ident{#(#b_unpacked),*}) => {
+                            let path = path.with(#variant_index);
+
+                            #(#diff_statements)*
+                        }
+                    });
+
+                    let set_items = a_idents.iter().map(|a| {
+                        let ty = &a.ty;
+                        let a = &a.unpack_ident;
+
+                        quote! { <#ty as ::core::clone::Clone>::clone(&#a) }
+                    });
+
+                    arms.push(quote! {
+                        (#identifier::#variant_ident{#(#a_unpacked),*}, _) => {
+                            event_queue.push_param(
+                                #firewheel_path::event::ParamData::any((#(#set_items,)*)),
+                                path.with(#variant_index),
+                            );
+                        }
+                    })
+                }
+            }
+        }
+
+        let body = quote! {
+            match (self, baseline) {
+                #(#arms)*
+            }
+        };
+
+        Ok(Self {
+            body,
+            bounds: types
+                .iter()
+                .map(|ty| {
+                    let span = ty.span();
+                    quote_spanned! {span=> #ty: #diff_path::Diff + ::core::clone::Clone + ::core::marker::Send + ::core::marker::Sync + 'static }
+                })
+                .collect(),
+        })
+    }
+}

--- a/crates/firewheel-macros/src/lib.rs
+++ b/crates/firewheel-macros/src/lib.rs
@@ -1,102 +1,25 @@
 extern crate proc_macro;
 
-use bevy_macro_utils::fq_std::{FQOption, FQResult};
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
-use syn::spanned::Spanned;
 
+mod diff;
 mod firewheel_manifest;
+mod patch;
 
 #[proc_macro_derive(Diff, attributes(diff))]
 pub fn derive_diff(input: TokenStream) -> TokenStream {
-    derive_diff_inner(input)
+    diff::derive_diff(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
-}
-
-fn derive_diff_inner(input: TokenStream) -> syn::Result<TokenStream2> {
-    let input: syn::DeriveInput = syn::parse(input)?;
-    let identifier = &input.ident;
-
-    let fields = get_fields(&input)?;
-
-    let messages = fields.iter().enumerate().map(|(i, (identifier, _))| {
-        let index = i as u32;
-        quote! {
-            self.#identifier.diff(&baseline.#identifier, path.with(#index), event_queue);
-        }
-    });
-
-    let (_, diff_path) = get_paths();
-
-    let (impl_generics, ty_generics, where_generics) = input.generics.split_for_impl();
-
-    let mut where_generics = where_generics.cloned().unwrap_or_else(|| syn::WhereClause {
-        where_token: Default::default(),
-        predicates: Default::default(),
-    });
-
-    for (_, ty) in &fields {
-        where_generics
-            .predicates
-            .push(syn::parse2(quote! { #ty: #diff_path::Diff }).unwrap());
-    }
-
-    Ok(quote! {
-        impl #impl_generics #diff_path::Diff for #identifier #ty_generics #where_generics {
-            fn diff<__E: #diff_path::EventQueue>(&self, baseline: &Self, path: #diff_path::PathBuilder, event_queue: &mut __E) {
-                #(#messages)*
-            }
-        }
-    })
 }
 
 #[proc_macro_derive(Patch, attributes(diff))]
 pub fn derive_patch(input: TokenStream) -> TokenStream {
-    derive_patch_inner(input)
+    patch::derive_patch(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
-}
-
-fn derive_patch_inner(input: TokenStream) -> syn::Result<TokenStream2> {
-    let input: syn::DeriveInput = syn::parse(input)?;
-    let identifier = &input.ident;
-
-    let fields = get_fields(&input)?;
-
-    let patches = fields.iter().enumerate().map(|(i, (identifier, _))| {
-        let index = i as u32;
-        quote! {
-            #FQOption::Some(#index) => self.#identifier.patch(data, &path[1..])
-        }
-    });
-
-    let (firewheel_path, diff_path) = get_paths();
-
-    let (impl_generics, ty_generics, where_generics) = input.generics.split_for_impl();
-
-    let mut where_generics = where_generics.cloned().unwrap_or_else(|| syn::WhereClause {
-        where_token: Default::default(),
-        predicates: Default::default(),
-    });
-
-    for (_, ty) in &fields {
-        where_generics
-            .predicates
-            .push(syn::parse2(quote! { #ty: #diff_path::Patch }).unwrap());
-    }
-
-    Ok(quote! {
-        impl #impl_generics #diff_path::Patch for #identifier #ty_generics #where_generics {
-            fn patch(&mut self, data: &#firewheel_path::event::ParamData, path: &[u32]) -> #FQResult<(), #diff_path::PatchError> {
-                match path.first() {
-                    #(#patches,)*
-                    _ => #FQResult::Err(#diff_path::PatchError::InvalidPath),
-                }
-            }
-        }
-    })
 }
 
 fn get_paths() -> (syn::Path, TokenStream2) {
@@ -125,14 +48,7 @@ fn should_skip(attrs: &[syn::Attribute]) -> bool {
     skip
 }
 
-fn get_fields(input: &syn::DeriveInput) -> syn::Result<Vec<(TokenStream2, &syn::Type)>> {
-    let syn::Data::Struct(data) = &input.data else {
-        return Err(syn::Error::new(
-            input.span(),
-            "`Diff` and `Patch` can only be derived on structs",
-        ));
-    };
-
+fn struct_fields(data: &syn::DataStruct) -> Vec<(TokenStream2, &syn::Type)> {
     // NOTE: a trivial optimization would be to automatically
     // flatten structs with only a single field so their
     // paths can be one index shorter.
@@ -156,5 +72,5 @@ fn get_fields(input: &syn::DeriveInput) -> syn::Result<Vec<(TokenStream2, &syn::
         syn::Fields::Unit => Vec::new(),
     };
 
-    Ok(fields)
+    fields
 }

--- a/crates/firewheel-macros/src/patch.rs
+++ b/crates/firewheel-macros/src/patch.rs
@@ -13,9 +13,7 @@ pub fn derive_patch(input: TokenStream) -> syn::Result<TokenStream2> {
 
     let PatchOutput { body, bounds } = match &input.data {
         syn::Data::Struct(data) => PatchOutput::from_struct(data, &diff_path)?,
-        syn::Data::Enum(data) => {
-            PatchOutput::from_enum(identifier, data, &firewheel_path, &diff_path)?
-        }
+        syn::Data::Enum(data) => PatchOutput::from_enum(identifier, data, &diff_path)?,
         syn::Data::Union(_) => {
             return Err(syn::Error::new(
                 input.span(),
@@ -117,7 +115,6 @@ impl PatchOutput {
     pub fn from_enum(
         identifier: &syn::Ident,
         data: &syn::DataEnum,
-        firewheel_path: &syn::Path,
         diff_path: &TokenStream2,
     ) -> syn::Result<PatchOutput> {
         let mut arms = Vec::new();

--- a/crates/firewheel-macros/src/patch.rs
+++ b/crates/firewheel-macros/src/patch.rs
@@ -164,7 +164,9 @@ impl PatchOutput {
                     });
                     arms.push(quote! {
                         ([#variant_index], s) => {
-                            let (#(#unpacked,)*): &(#(#unpacked_types,)*) = data.downcast_ref().ok_or(PatchError::InvalidData)?;
+                            let (#(#unpacked,)*): &(#(#unpacked_types,)*) = data
+                                .downcast_ref()
+                                .ok_or(#diff_path::PatchError::InvalidData)?;
 
                             *s = #identifier::#variant_ident(#(#unpacked_cloned),*);
                             Ok(())
@@ -219,7 +221,9 @@ impl PatchOutput {
                     let unpacked_types = idents.iter().map(|i| i.ty);
                     arms.push(quote! {
                         ([#variant_index], s) => {
-                            let (#(#tuple,)*): &(#(#unpacked_types,)*) = data.downcast_ref().ok_or(PatchError::InvalidData)?;
+                            let (#(#tuple,)*): &(#(#unpacked_types,)*) = data
+                                .downcast_ref()
+                                .ok_or(#diff_path::PatchError::InvalidData)?;
 
                             *s = #identifier::#variant_ident{#(#unpacked_cloned),*};
                             Ok(())

--- a/crates/firewheel-macros/src/patch.rs
+++ b/crates/firewheel-macros/src/patch.rs
@@ -1,49 +1,279 @@
 use bevy_macro_utils::fq_std::FQResult;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
+use quote::{format_ident, quote, quote_spanned};
+use syn::spanned::Spanned;
 
 use crate::{get_paths, struct_fields};
 
 pub fn derive_patch(input: TokenStream) -> syn::Result<TokenStream2> {
     let input: syn::DeriveInput = syn::parse(input)?;
     let identifier = &input.ident;
-
-    let fields = match &input.data {
-        syn::Data::Struct(data) => struct_fields(data),
-        _ => todo!(),
-    };
-
-    let patches = fields.iter().enumerate().map(|(i, (identifier, _))| {
-        let index = i as u32;
-        quote! {
-            [#index, tail @ .. ] => self.#identifier.patch(data, tail)
-        }
-    });
-
     let (firewheel_path, diff_path) = get_paths();
+
+    let PatchOutput { body, bounds } = match &input.data {
+        syn::Data::Struct(data) => PatchOutput::from_struct(data, &diff_path)?,
+        syn::Data::Enum(data) => {
+            PatchOutput::from_enum(identifier, data, &firewheel_path, &diff_path)?
+        }
+        syn::Data::Union(_) => {
+            return Err(syn::Error::new(
+                input.span(),
+                "`Patch` cannot be derived on unions.",
+            ));
+        }
+    };
 
     let (impl_generics, ty_generics, where_generics) = input.generics.split_for_impl();
 
-    let mut where_generics = where_generics.cloned().unwrap_or_else(|| syn::WhereClause {
-        where_token: Default::default(),
-        predicates: Default::default(),
-    });
-
-    for (_, ty) in &fields {
-        where_generics
-            .predicates
-            .push(syn::parse2(quote! { #ty: #diff_path::Patch }).unwrap());
-    }
-
-    Ok(quote! {
-        impl #impl_generics #diff_path::Patch for #identifier #ty_generics #where_generics {
-            fn patch(&mut self, data: &#firewheel_path::event::ParamData, path: &[u32]) -> #FQResult<(), #diff_path::PatchError> {
-                match path {
-                    #(#patches,)*
-                    _ => #FQResult::Err(#diff_path::PatchError::InvalidPath),
+    let where_generics = match where_generics {
+        Some(wg) => {
+            quote! {
+                #wg
+                #(#bounds,)*
+            }
+        }
+        None => {
+            if bounds.is_empty() {
+                quote! {}
+            } else {
+                quote! {
+                    where #(#bounds,)*
                 }
             }
         }
+    };
+
+    Ok(quote! {
+        impl #impl_generics #diff_path::Patch for #identifier #ty_generics #where_generics {
+            fn patch(
+                &mut self,
+                data: &#firewheel_path::event::ParamData,
+                path: &[u32]
+            ) -> #FQResult<(), #diff_path::PatchError> {
+                #body
+            }
+        }
     })
+}
+
+struct PatchOutput {
+    body: TokenStream2,
+    bounds: Vec<TokenStream2>,
+}
+
+struct UnnamedField<'a> {
+    /// The type is useful for error spans.
+    ty: &'a syn::Type,
+    /// An identifier for tuple fields.
+    unpack_ident: syn::Ident,
+}
+
+/// A convenience struct for keeping track of a struct variant's
+/// identifier along with an identifier we can use without causing
+/// name clashing.
+struct NamedField<'a> {
+    /// The type is useful for error spans.
+    ty: &'a syn::Type,
+    /// The struct field's actual name.
+    type_ident: &'a syn::Ident,
+    /// An identifier that avoids the possibility of name clashing.
+    unpack_ident: syn::Ident,
+}
+
+impl PatchOutput {
+    pub fn from_struct(data: &syn::DataStruct, diff_path: &TokenStream2) -> syn::Result<Self> {
+        let fields = struct_fields(data);
+
+        let arms = fields.iter().enumerate().map(|(i, (identifier, _))| {
+            let index = i as u32;
+            quote! {
+                [#index, tail @ .. ] => self.#identifier.patch(data, tail)
+            }
+        });
+
+        let body = quote! {
+            match path {
+                #(#arms,)*
+                _ => #FQResult::Err(#diff_path::PatchError::InvalidPath),
+            }
+        };
+
+        Ok(Self {
+            body,
+            bounds: fields
+                .iter()
+                .map(|(_, ty)| {
+                    let span = ty.span();
+                    quote_spanned! {span=> #ty: #diff_path::Patch }
+                })
+                .collect(),
+        })
+    }
+
+    // This is quite a bit more complicated because we need to account for
+    // three kinds of variants _and_ we need to be able to construct variants
+    // with all required data at once in addition to fine-grained diffing.
+    pub fn from_enum(
+        identifier: &syn::Ident,
+        data: &syn::DataEnum,
+        firewheel_path: &syn::Path,
+        diff_path: &TokenStream2,
+    ) -> syn::Result<PatchOutput> {
+        let mut arms = Vec::new();
+        let mut types = Vec::new();
+        for (index, variant) in data.variants.iter().enumerate() {
+            let variant_index = index as u32;
+            let variant_ident = &variant.ident;
+
+            match &variant.fields {
+                syn::Fields::Unit => {
+                    arms.push(quote! {
+                        ([#variant_index], s) => {
+                            *s = #identifier::#variant_ident;
+
+                            Ok(())
+                        }
+                    });
+                }
+                syn::Fields::Unnamed(fields) => {
+                    let mut idents = Vec::new();
+
+                    for (i, field) in fields.unnamed.iter().enumerate() {
+                        types.push(&field.ty);
+
+                        idents.push(UnnamedField {
+                            ty: &field.ty,
+                            unpack_ident: format_ident!("a{i}"),
+                        });
+                    }
+
+                    let unpacked: Vec<_> = idents
+                        .iter()
+                        .map(|a| {
+                            let unpack = &a.unpack_ident;
+
+                            quote! {
+                                #unpack
+                            }
+                        })
+                        .collect();
+
+                    let unpacked_types = idents.iter().map(|i| i.ty);
+                    let unpacked_cloned = idents.iter().map(|i| {
+                        let unpack = &i.unpack_ident;
+                        let ty = i.ty;
+                        quote! { <#ty as ::core::clone::Clone>::clone(#unpack) }
+                    });
+                    arms.push(quote! {
+                        ([#variant_index], s) => {
+                            let (#(#unpacked,)*): &(#(#unpacked_types,)*) = data.downcast_ref().ok_or(PatchError::InvalidData)?;
+
+                            *s = #identifier::#variant_ident(#(#unpacked_cloned),*);
+                            Ok(())
+                        }
+                    });
+
+                    let inner = idents.iter().enumerate().map(|(i, a)| {
+                        let ty = &a.ty;
+                        let a = &a.unpack_ident;
+                        let i = i as u32;
+
+                        quote! {
+                            ([#variant_index, #i, tail @ ..], #identifier::#variant_ident(#(#unpacked),*)) => {
+                                <#ty as #diff_path::Patch>::patch(#a, data, tail)
+                            }
+                        }
+                    });
+
+                    arms.extend(inner);
+                }
+                syn::Fields::Named(fields) => {
+                    let mut idents = Vec::new();
+
+                    for (i, field) in fields.named.iter().enumerate() {
+                        types.push(&field.ty);
+
+                        idents.push(NamedField {
+                            ty: &field.ty,
+                            type_ident: &field.ident.as_ref().expect("should have named ident"),
+                            unpack_ident: format_ident!("a{i}"),
+                        });
+                    }
+
+                    let tuple = idents.iter().map(|a| {
+                        let unpack = &a.unpack_ident;
+
+                        quote! {
+                            #unpack
+                        }
+                    });
+
+                    let unpacked_cloned = idents.iter().map(|a| {
+                        let unpack = &a.unpack_ident;
+                        let ident = &a.type_ident;
+                        let ty = &a.ty;
+
+                        quote! {
+                            #ident: <#ty as ::core::clone::Clone>::clone(#unpack)
+                        }
+                    });
+
+                    let unpacked_types = idents.iter().map(|i| i.ty);
+                    arms.push(quote! {
+                        ([#variant_index], s) => {
+                            let (#(#tuple,)*): &(#(#unpacked_types,)*) = data.downcast_ref().ok_or(PatchError::InvalidData)?;
+
+                            *s = #identifier::#variant_ident{#(#unpacked_cloned),*};
+                            Ok(())
+                        }
+                    });
+
+                    let unpacked: Vec<_> = idents
+                        .iter()
+                        .map(|a| {
+                            let unpack = &a.unpack_ident;
+                            let ident = &a.type_ident;
+
+                            quote! {
+                                #ident: #unpack
+                            }
+                        })
+                        .collect();
+
+                    let inner = idents.iter().enumerate().map(|(i, a)| {
+                        let ty = &a.ty;
+                        let a = &a.unpack_ident;
+                        let i = i as u32;
+
+                        quote! {
+                            ([#variant_index, #i, tail @ ..], #identifier::#variant_ident{#(#unpacked),*}) => {
+                                <#ty as #diff_path::Patch>::patch(#a, data, tail)
+                            }
+                        }
+                    });
+
+                    arms.extend(inner);
+                }
+            }
+        }
+
+        let body = quote! {
+            match (path, self) {
+                #(#arms)*
+                _ => #FQResult::Err(#diff_path::PatchError::InvalidPath),
+            }
+        };
+
+        Ok(Self {
+            body,
+            bounds: types
+                .iter()
+                .map(|ty| {
+                    let span = ty.span();
+                    quote_spanned! {span=> #ty: #diff_path::Patch + ::core::clone::Clone + ::core::marker::Send + ::core::marker::Sync + 'static }
+                })
+                .collect(),
+        })
+    }
 }

--- a/crates/firewheel-macros/src/patch.rs
+++ b/crates/firewheel-macros/src/patch.rs
@@ -1,0 +1,49 @@
+use bevy_macro_utils::fq_std::FQResult;
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+use crate::{get_paths, struct_fields};
+
+pub fn derive_patch(input: TokenStream) -> syn::Result<TokenStream2> {
+    let input: syn::DeriveInput = syn::parse(input)?;
+    let identifier = &input.ident;
+
+    let fields = match &input.data {
+        syn::Data::Struct(data) => struct_fields(data),
+        _ => todo!(),
+    };
+
+    let patches = fields.iter().enumerate().map(|(i, (identifier, _))| {
+        let index = i as u32;
+        quote! {
+            [#index, tail @ .. ] => self.#identifier.patch(data, tail)
+        }
+    });
+
+    let (firewheel_path, diff_path) = get_paths();
+
+    let (impl_generics, ty_generics, where_generics) = input.generics.split_for_impl();
+
+    let mut where_generics = where_generics.cloned().unwrap_or_else(|| syn::WhereClause {
+        where_token: Default::default(),
+        predicates: Default::default(),
+    });
+
+    for (_, ty) in &fields {
+        where_generics
+            .predicates
+            .push(syn::parse2(quote! { #ty: #diff_path::Patch }).unwrap());
+    }
+
+    Ok(quote! {
+        impl #impl_generics #diff_path::Patch for #identifier #ty_generics #where_generics {
+            fn patch(&mut self, data: &#firewheel_path::event::ParamData, path: &[u32]) -> #FQResult<(), #diff_path::PatchError> {
+                match path {
+                    #(#patches,)*
+                    _ => #FQResult::Err(#diff_path::PatchError::InvalidPath),
+                }
+            }
+        }
+    })
+}


### PR DESCRIPTION
This PR introduces `Diff` and `Patch` derive macro functionality for enums, as well as proper documentation for diffing-related code.

I think this is a fairly important addition since enums are very common and extremely useful. This implementation is maximally performant for data-less enums while still perfectly general. This increases the complexity of the derive macros a bit, but it's absolutely worth the cost in my estimation.

Since enums require _all_ data to be present when a variant is changed, this will require use of the `ParamData::Any` variant in certain cases during diffing. Nonetheless, the overall performance should still be high enough that users will almost never need to reach for alternatives.

In order to apply the macros to internal types like `PanLaw` as well as use them in documentation, I had to resort to the `extern crate self as firewheel_core;` trick. This allows the macros to use `firewheel_core` instead of `crate` within `firewheel_core`. It looks a little weird, but as far as I know has no real negative consequences for users or maintainers.