### PR TITLE
Generic `ArcGc` collector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run tests
         run: |
-          cargo test -j 1 --locked --workspace --all-features --all-targets
+          cargo test --locked --workspace --all-features --all-targets
 
   # Check formatting.
   format:

--- a/crates/firewheel-core/src/collector.rs
+++ b/crates/firewheel-core/src/collector.rs
@@ -1,3 +1,5 @@
+//! Garbage collected smart pointer.
+
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
@@ -5,38 +7,73 @@ use std::sync::{
 
 /// A wrapper around `Arc` that automatically collects resources
 /// from the audio thread and drops them on the main thread.
+///
+/// The performance characteristics and stack size of [`ArcGc`] are
+/// similar to [`Arc`], except that the default [`GlobalCollector`]
+/// acquires a mutex lock once during construction.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ArcGc<T: ?Sized>(Arc<T>);
+pub struct ArcGc<T: ?Sized + Send + Sync + 'static, C: Collector = GlobalCollector> {
+    data: Arc<T>,
+    collector: C,
+}
 
 impl<T: Send + Sync + 'static> ArcGc<T> {
+    /// Construct a new [`ArcGc`].
     pub fn new(value: T) -> Self {
-        let value = Self(Arc::new(value));
+        let data = Arc::new(value);
 
-        REGISTRY
-            .lock()
-            .unwrap()
-            .push(Box::new(Arc::clone(&value.0)));
+        let collector = GlobalCollector::default();
+        collector.register(Arc::clone(&data));
 
-        value
+        Self { data, collector }
     }
 }
 
 impl<T: ?Sized + Send + Sync + 'static> ArcGc<T> {
+    /// Construct a new [`ArcGc`] with _unsized_ data, such as `[T]`.
+    ///
+    /// ```
+    /// # use firewheel_core::collector::ArcGc;
+    /// # use std::sync::Arc;
+    /// let value = ArcGc::new_unsized(|| Arc::<[i32]>::from([1, 2, 3]));
+    /// ```
     pub fn new_unsized(f: impl FnOnce() -> Arc<T>) -> Self {
-        let value = Self(f());
+        let data = f();
 
-        REGISTRY
-            .lock()
-            .unwrap()
-            .push(Box::new(Arc::clone(&value.0)));
+        let collector = GlobalCollector::default();
+        collector.register(Arc::clone(&data));
 
-        value
+        Self { data, collector }
     }
+}
 
+impl<T: Send + Sync + 'static, C: Collector> ArcGc<T, C> {
+    /// Construct a new [`ArcGc`] with a custom collector.
+    pub fn new_in(value: T, collector: C) -> Self {
+        let data = Arc::new(value);
+
+        collector.register(Arc::clone(&data));
+
+        Self { data, collector }
+    }
+}
+
+impl<T: ?Sized + Send + Sync + 'static, C: Collector> ArcGc<T, C> {
+    /// Construct a new [`ArcGc`] with _unsized_ data and a custom collector.
+    pub fn new_unsized_in(f: impl FnOnce() -> Arc<T>, collector: C) -> Self {
+        let data = f();
+
+        collector.register(Arc::clone(&data));
+
+        Self { data, collector }
+    }
+}
+
+impl<T: ?Sized + Send + Sync + 'static, C: Collector> ArcGc<T, C> {
     /// A wrapper around [std::sync::Arc::ptr_eq].
     #[inline(always)]
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
-        Arc::ptr_eq(&this.0, &other.0)
+        Arc::ptr_eq(&this.data, &other.data)
     }
 }
 
@@ -46,25 +83,95 @@ impl<T: ?Sized + Send + Sync + 'static> Into<ArcGc<T>> for Arc<T> {
     }
 }
 
-impl<T: ?Sized> core::ops::Deref for ArcGc<T> {
+impl<T: ?Sized + Send + Sync + 'static, C: Collector> core::ops::Deref for ArcGc<T, C> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.data
     }
 }
 
-impl<T: ?Sized> Drop for ArcGc<T> {
+impl<T: ?Sized + Send + Sync + 'static, C: Collector> Drop for ArcGc<T, C> {
     fn drop(&mut self) {
-        if Arc::strong_count(&self.0) == 2 {
-            // Relaxed ordering should be sufficient since the collector can always
-            // drop it on the next collect cycle.
-            ANY_PTR_DROPPED.store(true, Ordering::Relaxed);
+        self.collector.remove(&self.data);
+    }
+}
+
+impl<T: ?Sized + Send + Sync + 'static, C: Collector + Clone> Clone for ArcGc<T, C> {
+    fn clone(&self) -> Self {
+        Self {
+            data: Arc::clone(&self.data),
+            collector: self.collector.clone(),
         }
     }
 }
 
-trait StrongCount: Send + Sync {
+/// The default garbage collector for [`ArcGc`].
+///
+/// This uses global statics, so registration and collection
+/// runs may block. If you need particular characteristics, consider
+/// providing a custom collector.
+///
+/// To collect all default-constructed [`ArcGc`] instances, simply
+/// construct an instance of [`GlobalCollector`] and call
+/// [`Collector::collect`].
+///
+/// ```
+/// use firewheel_core::collector::{GlobalCollector, Collector};
+///
+/// GlobalCollector.collect();
+/// ```
+#[derive(Default, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct GlobalCollector;
+
+static REGISTRY: Mutex<Vec<Box<dyn StrongCount + 'static>>> = Mutex::new(Vec::new());
+static ANY_PTR_DROPPED: AtomicBool = AtomicBool::new(false);
+
+impl Collector for GlobalCollector {
+    fn register<T>(&self, data: Arc<T>)
+    where
+        T: ?Sized + Send + Sync + 'static,
+        Arc<T>: StrongCount,
+    {
+        register(&REGISTRY, data)
+    }
+
+    fn remove<T>(&self, data: &Arc<T>)
+    where
+        T: ?Sized + Send + Sync + 'static,
+        Arc<T>: StrongCount,
+    {
+        remove(data, &ANY_PTR_DROPPED)
+    }
+
+    fn collect(&self) {
+        collect(&REGISTRY, &ANY_PTR_DROPPED)
+    }
+}
+
+/// Garbage collection utilities.
+pub trait Collector {
+    /// Register this data with the garbage collector.
+    fn register<T>(&self, data: Arc<T>)
+    where
+        T: ?Sized + Send + Sync + 'static,
+        Arc<T>: StrongCount;
+
+    /// Called in [`ArcGc`]'s `Drop` implementation.
+    ///
+    /// This can be used to indicate that garbage colllected
+    /// items should be checked for pruning.
+    fn remove<T>(&self, data: &Arc<T>)
+    where
+        T: ?Sized + Send + Sync + 'static,
+        Arc<T>: StrongCount;
+
+    /// Collect and drop all unused [`ArcGc`] resources.
+    fn collect(&self);
+}
+
+/// A trait for type-erasing `Arc<T>` types.
+pub trait StrongCount: Send + Sync {
     fn count(&self) -> usize;
 }
 
@@ -74,25 +181,35 @@ impl<T: Send + Sync + ?Sized> StrongCount for Arc<T> {
     }
 }
 
-static REGISTRY: Mutex<Vec<Box<dyn StrongCount + 'static>>> = Mutex::new(Vec::new());
-static ANY_PTR_DROPPED: AtomicBool = AtomicBool::new(false);
-
 /// Collect and drop all unused [`ArcGc`] resources.
-pub fn collect() {
-    // Relaxed ordering should be sufficient since the collector can always
-    // drop resources on the next collect cycle.
-    if ANY_PTR_DROPPED.load(Ordering::Relaxed) {
-        ANY_PTR_DROPPED.store(false, Ordering::Relaxed);
+fn register<T: ?Sized + 'static>(
+    registry: &Mutex<Vec<Box<dyn StrongCount + 'static>>>,
+    data: Arc<T>,
+) where
+    Arc<T>: StrongCount,
+{
+    registry.lock().unwrap().push(Box::new(data));
+}
 
-        let mut registry = REGISTRY.lock().unwrap();
-
-        registry.retain(|ptr| ptr.count() > 1);
+/// Indicate that data has been dropped.
+fn remove<T: ?Sized>(data: &Arc<T>, any_dropped: &AtomicBool) {
+    if Arc::strong_count(data) == 2 {
+        // Relaxed ordering should be sufficient since the collector can always
+        // drop it on the next collect cycle.
+        any_dropped.store(true, Ordering::Relaxed);
     }
 }
 
-impl<T: ?Sized> Clone for ArcGc<T> {
-    fn clone(&self) -> Self {
-        Self(Arc::clone(&self.0))
+/// Collect and drop all unused [`ArcGc`] resources.
+fn collect(registry: &Mutex<Vec<Box<dyn StrongCount + 'static>>>, any_dropped: &AtomicBool) {
+    // Relaxed ordering should be sufficient since the collector can always
+    // drop resources on the next collect cycle.
+    if any_dropped.load(Ordering::Relaxed) {
+        any_dropped.store(false, Ordering::Relaxed);
+
+        let mut registry = registry.lock().unwrap();
+
+        registry.retain(|ptr| ptr.count() > 1);
     }
 }
 
@@ -100,69 +217,98 @@ impl<T: ?Sized> Clone for ArcGc<T> {
 mod test {
     use super::*;
 
-    fn registry_size() -> usize {
-        REGISTRY.lock().unwrap().len()
+    #[derive(Default, Clone)]
+    struct LocalCollector {
+        registry: Arc<Mutex<Vec<Box<dyn StrongCount + 'static>>>>,
+        any_dropped: Arc<AtomicBool>,
     }
 
+    impl Collector for LocalCollector {
+        fn register<T>(&self, data: Arc<T>)
+        where
+            T: ?Sized + Send + Sync + 'static,
+            Arc<T>: StrongCount,
+        {
+            register(&self.registry, data)
+        }
+
+        fn remove<T>(&self, data: &Arc<T>)
+        where
+            T: ?Sized + Send + Sync + 'static,
+            Arc<T>: StrongCount,
+        {
+            remove(data, &self.any_dropped)
+        }
+
+        fn collect(&self) {
+            collect(&self.registry, &self.any_dropped)
+        }
+    }
+
+    impl LocalCollector {
+        fn size(&self) -> usize {
+            self.registry.lock().unwrap().len()
+        }
+
+        fn any_dropped(&self) -> bool {
+            self.any_dropped.load(Ordering::Relaxed)
+        }
+    }
+
+    #[test]
     fn test_drop_works() {
-        assert_eq!(registry_size(), 0);
+        let collector = LocalCollector::default();
 
-        let value = ArcGc::new(1);
+        assert_eq!(collector.size(), 0);
 
-        assert_eq!(registry_size(), 1);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), false);
+        let value = ArcGc::new_in(1, collector.clone());
 
-        collect();
+        assert_eq!(collector.size(), 1);
+        assert_eq!(collector.any_dropped(), false);
 
-        assert_eq!(registry_size(), 1);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), false);
+        collector.collect();
+
+        assert_eq!(collector.size(), 1);
+        assert_eq!(collector.any_dropped(), false);
 
         drop(value);
 
         // Even though we've dropped the "last reference,"
         // the inner drop won't be called until we do garbage
         // collection.
-        assert_eq!(registry_size(), 1);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), true);
+        assert_eq!(collector.size(), 1);
+        assert_eq!(collector.any_dropped(), true);
 
-        collect();
+        collector.collect();
 
-        assert_eq!(registry_size(), 0);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), false);
+        assert_eq!(collector.size(), 0);
+        assert_eq!(collector.any_dropped(), false);
     }
 
+    #[test]
     fn test_unsized_works() {
-        assert_eq!(registry_size(), 0);
+        let collector = LocalCollector::default();
 
-        let value = ArcGc::new_unsized(|| Arc::<[i32]>::from([1, 2, 3]));
+        assert_eq!(collector.size(), 0);
 
-        assert_eq!(registry_size(), 1);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), false);
+        let value = ArcGc::new_unsized_in(|| Arc::<[i32]>::from([1, 2, 3]), collector.clone());
 
-        collect();
+        assert_eq!(collector.size(), 1);
+        assert_eq!(collector.any_dropped(), false);
 
-        assert_eq!(registry_size(), 1);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), false);
+        collector.collect();
+
+        assert_eq!(collector.size(), 1);
+        assert_eq!(collector.any_dropped(), false);
 
         drop(value);
 
-        assert_eq!(registry_size(), 1);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), true);
+        assert_eq!(collector.size(), 1);
+        assert_eq!(collector.any_dropped(), true);
 
-        collect();
+        collector.collect();
 
-        assert_eq!(registry_size(), 0);
-        assert_eq!(ANY_PTR_DROPPED.load(Ordering::Relaxed), false);
-    }
-
-    // These have to be grouped into one test because
-    // they all access a global context.
-    //
-    // This still isn't very robust -- no other tests
-    // in this crate can use `ArcGc` types.
-    #[test]
-    fn test_shared() {
-        test_drop_works();
-        test_unsized_works();
+        assert_eq!(collector.size(), 0);
+        assert_eq!(collector.any_dropped(), false);
     }
 }

--- a/crates/firewheel-core/src/collector.rs
+++ b/crates/firewheel-core/src/collector.rs
@@ -1,4 +1,4 @@
-//! Garbage collected smart pointer.
+//! Garbage-collected smart pointer.
 
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -159,7 +159,7 @@ pub trait Collector {
 
     /// Called in [`ArcGc`]'s `Drop` implementation.
     ///
-    /// This can be used to indicate that garbage colllected
+    /// This can be used to indicate that garbage-collected
     /// items should be checked for pruning.
     fn remove<T>(&self, data: &Arc<T>)
     where

--- a/crates/firewheel-graph/src/context.rs
+++ b/crates/firewheel-graph/src/context.rs
@@ -2,6 +2,7 @@ use atomic_float::AtomicF64;
 use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     clock::{ClockSamples, ClockSeconds, MusicalTime, MusicalTransport},
+    collector::Collector,
     dsp::declick::DeclickValues,
     event::{NodeEvent, NodeEventType},
     node::{AudioNode, DynAudioNode, NodeID},
@@ -378,7 +379,7 @@ impl<B: AudioBackend> FirewheelCtx<B> {
     ///
     /// This must be called reguarly (i.e. once every frame).
     pub fn update(&mut self) -> Result<(), UpdateError<B::StreamError>> {
-        firewheel_core::collector::collect();
+        firewheel_core::collector::GlobalCollector.collect();
 
         for msg in self.from_processor_rx.pop_iter() {
             match msg {
@@ -650,7 +651,7 @@ impl<B: AudioBackend> Drop for FirewheelCtx<B> {
             }
         }
 
-        firewheel_core::collector::collect();
+        firewheel_core::collector::GlobalCollector.collect();
     }
 }
 


### PR DESCRIPTION
This PR makes `ArcGc` generic over its collector. The API mirrors the standard library's unstable `Allocator` API.

This should introduce zero overhead compared to the previous implementation given the default collector. It also requires no code changes except in how we call the default collection.

The way the test collector is written should guarantee that it behaves the same as the global one except that it's isolated from other tests. The test now passes reliably.