### PR TITLE
Expose `wasm-bindgen` `cpal` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,8 @@ spatial_basic_node = ["firewheel-nodes/spatial_basic"]
 stream_nodes = ["firewheel-nodes/stream"]
 # Enables `Component` derive macros for node parameters
 bevy = ["firewheel-nodes/bevy", "firewheel-core/bevy"]
+# Enables the wasm-bindgen feature for the CPAL backend
+wasm-bindgen = ["firewheel-cpal/wasm-bindgen"]
 
 [dependencies]
 firewheel-core = { path = "crates/firewheel-core", version = "0.3.0" }

--- a/crates/firewheel-cpal/Cargo.toml
+++ b/crates/firewheel-cpal/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 
 [features]
 resample_inputs = ["fixed-resample/fft-resampler"]
+wasm-bindgen = ["cpal/wasm-bindgen"]
 
 [dependencies]
 firewheel-core = { path = "../firewheel-core", version = "0.3.0" }
@@ -27,4 +28,4 @@ thiserror.workspace = true
 fast-interleave.workspace = true
 fixed-resample = { version = "0.7.1", default-features = false, features = [
   "channel",
-]}
+] }


### PR DESCRIPTION
This PR exposes `cpal`'s `wasm-bindgen` feature, which is required for proper Wasm browser support.