### PR TITLE
Type-erased state getters

### DIFF
--- a/crates/firewheel-graph/src/context.rs
+++ b/crates/firewheel-graph/src/context.rs
@@ -1,4 +1,5 @@
 use atomic_float::AtomicF64;
+use core::any::Any;
 use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     clock::{ClockSamples, ClockSeconds, MusicalTime, MusicalTransport},
@@ -513,9 +514,18 @@ impl<B: AudioBackend> FirewheelCtx<B> {
         self.graph.node_state(id)
     }
 
+    /// Get a type-erased, immutable reference to the custom state of a node.
+    pub fn node_state_dyn(&self, id: NodeID) -> Option<&dyn Any> {
+        self.graph.node_state_dyn(id)
+    }
+
     /// Get a mutable reference to the custom state of a node.
     pub fn node_state_mut<T: 'static>(&mut self, id: NodeID) -> Option<&mut T> {
         self.graph.node_state_mut(id)
+    }
+
+    pub fn node_state_dyn_mut(&mut self, id: NodeID) -> Option<&mut dyn Any> {
+        self.graph.node_state_dyn_mut(id)
     }
 
     /// Get a list of all the existing nodes in the graph.

--- a/crates/firewheel-graph/src/graph.rs
+++ b/crates/firewheel-graph/src/graph.rs
@@ -1,5 +1,6 @@
 mod compiler;
 
+use core::any::Any;
 use std::fmt::Debug;
 use std::hash::Hash;
 
@@ -197,24 +198,26 @@ impl AudioGraph {
 
     /// Get an immutable reference to the custom state of a node.
     pub fn node_state<T: 'static>(&self, id: NodeID) -> Option<&T> {
-        self.nodes.get(id.0).and_then(|node_entry| {
-            node_entry
-                .info
-                .custom_state
-                .as_ref()
-                .and_then(|s| s.downcast_ref::<T>())
-        })
+        self.node_state_dyn(id).and_then(|s| s.downcast_ref())
+    }
+
+    /// Get a type-erased, immutable reference to the custom state of a node.
+    pub fn node_state_dyn(&self, id: NodeID) -> Option<&dyn Any> {
+        self.nodes
+            .get(id.0)
+            .and_then(|node_entry| node_entry.info.custom_state.as_ref().map(|s| s.as_ref()))
     }
 
     /// Get a mutable reference to the custom state of a node.
     pub fn node_state_mut<T: 'static>(&mut self, id: NodeID) -> Option<&mut T> {
-        self.nodes.get_mut(id.0).and_then(|node_entry| {
-            node_entry
-                .info
-                .custom_state
-                .as_mut()
-                .and_then(|s| s.downcast_mut::<T>())
-        })
+        self.node_state_dyn_mut(id).and_then(|s| s.downcast_mut())
+    }
+
+    /// Get a type-erased, mutable reference to the custom state of a node.
+    pub fn node_state_dyn_mut(&mut self, id: NodeID) -> Option<&mut dyn Any> {
+        self.nodes
+            .get_mut(id.0)
+            .and_then(|node_entry| node_entry.info.custom_state.as_mut().map(|s| s.as_mut()))
     }
 
     /// Get a list of all the existing nodes in the graph.


### PR DESCRIPTION
This PR adds type-erased state getters to `FirewheelCtx` and `AudioGraph`. This is required to allow `bevy_seedling` to abstract over any `FirewheelCtx<B>` without needing viral generics in both user-facing and internal code. (There's probably a better solution possible since `bevy_seedling` has to duplicate quite a few methods, but it works for now.)