### PR TITLE
Finish applying `for_each_patch`

### DIFF
--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -89,15 +89,14 @@ impl AudioNodeProcessor for Processor {
             return ProcessStatus::ClearAllOutputs;
         };
 
-        events.for_each(|event| match BeepTestNode::patch_event(event) {
-            Some(BeepTestNodePatch::FreqHz(f)) => {
+        events.for_each_patch::<BeepTestNode>(|patch| match patch {
+            BeepTestNodePatch::FreqHz(f) => {
                 self.phasor_inc = f.clamp(20.0, 20_000.0) * self.sample_rate_recip;
             }
-            Some(BeepTestNodePatch::Volume(v)) => {
+            BeepTestNodePatch::Volume(v) => {
                 self.gain = v.amp_clamped(DEFAULT_AMP_EPSILON);
             }
-            Some(BeepTestNodePatch::Enabled(e)) => self.enabled = e,
-            _ => {}
+            BeepTestNodePatch::Enabled(e) => self.enabled = e,
         });
 
         if !self.enabled {

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -272,11 +272,7 @@ impl AudioNodeProcessor for Processor {
         mut events: NodeEventList,
     ) -> ProcessStatus {
         let mut updated = false;
-        events.for_each(|e| {
-            let Some(mut patch) = SpatialBasicNode::patch_event(e) else {
-                return;
-            };
-
+        events.for_each_patch::<SpatialBasicNode>(|mut patch| {
             match &mut patch {
                 SpatialBasicNodePatch::Offset(offset) => {
                     if !offset.is_finite() {

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -128,11 +128,7 @@ impl AudioNodeProcessor for Processor {
         mut events: NodeEventList,
     ) -> ProcessStatus {
         let mut updated = false;
-        events.for_each(|e| {
-            let Some(mut patch) = VolumePanNode::patch_event(e) else {
-                return;
-            };
-
+        events.for_each_patch::<VolumePanNode>(|mut patch| {
             // here we selectively clamp the panning, leaving
             // other patches untouched
             if let VolumePanNodePatch::Pan(p) = &mut patch {

--- a/examples/custom_nodes/src/nodes/filter.rs
+++ b/examples/custom_nodes/src/nodes/filter.rs
@@ -136,20 +136,17 @@ impl AudioNodeProcessor for Processor {
         //
         // We don't need to keep around a `FilterNode` instance,
         // so we can just match on each event directly.
-        events.for_each(|e| {
-            match FilterNode::patch_event(e) {
-                Some(FilterNodePatch::CutoffHz(cutoff)) => {
-                    self.cutoff_hz.set_value(cutoff.clamp(20.0, 20_000.0));
-                }
-                Some(FilterNodePatch::Volume(volume)) => {
-                    self.gain.set_value(volume.amp_clamped(DEFAULT_AMP_EPSILON));
-                }
-                Some(FilterNodePatch::Enabled(enabled)) => {
-                    // Tell the declicker to crossfade.
-                    self.enable_declicker
-                        .fade_to_enabled(enabled, proc_info.declick_values);
-                }
-                _ => {}
+        events.for_each_patch::<FilterNode>(|patch| match patch {
+            FilterNodePatch::CutoffHz(cutoff) => {
+                self.cutoff_hz.set_value(cutoff.clamp(20.0, 20_000.0));
+            }
+            FilterNodePatch::Volume(volume) => {
+                self.gain.set_value(volume.amp_clamped(DEFAULT_AMP_EPSILON));
+            }
+            FilterNodePatch::Enabled(enabled) => {
+                // Tell the declicker to crossfade.
+                self.enable_declicker
+                    .fade_to_enabled(enabled, proc_info.declick_values);
             }
         });
 

--- a/examples/custom_nodes/src/nodes/noise_gen.rs
+++ b/examples/custom_nodes/src/nodes/noise_gen.rs
@@ -120,11 +120,7 @@ impl AudioNodeProcessor for Processor {
         mut events: NodeEventList,
     ) -> ProcessStatus {
         // Process the events.
-        events.for_each(|e| {
-            let Some(patch) = NoiseGenNode::patch_event(e) else {
-                return;
-            };
-
+        events.for_each_patch::<NoiseGenNode>(|patch| {
             // Since we want to clamp the volume event, we can
             // grab it here and perform the processing only when required.
             if let NoiseGenNodePatch::Volume(vol) = &patch {


### PR DESCRIPTION
This PR just does some cleanup on the remaining `for_each` calls that can be trivially refactored to `for_each_patch`. It's low-priority, but makes the code base and examples a bit more consistent.