### PR TITLE
Improved sequence completion detection

### DIFF
--- a/examples/sampler_test/src/system.rs
+++ b/examples/sampler_test/src/system.rs
@@ -102,7 +102,7 @@ impl AudioSystem {
             volume: old_volume,
             repeat_mode: old_repeat_mode,
             ..
-        }) = &mut sampler.params.sequence
+        }) = sampler.params.sequence.as_mut()
         else {
             todo!();
         };


### PR DESCRIPTION
This PR extends `Notify` to allow it to explicitly provide unique IDs for each mutation. For the sampler node, this means that each sequence will automatically have an ID it can use to communicate completion.

Using this approach, there is no possibility of missing sequence completion. The only downside is that game-side logic will need to clear the finished atomic in cases where completion detection needs to happen with the same sequence multiple times. However, this is pretty easy to manage.