### PR TITLE
chore: Update Cargo.toml add repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "firewheel"
 version = "0.4.3"
 description = "Flexible, high-performance, and libre audio engine for games (WIP)"
-repository = "https://github.com/BillyDM/firewheel"
+repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -21,6 +21,7 @@ authors = ["Billy Messenger <60663878+BillyDM@users.noreply.github.com>"]
 keywords = ["game", "audio", "graph"]
 categories = ["game-development", "multimedia::audio"]
 exclude = ["assets/"]
+repository = "https://github.com/BillyDM/firewheel"
 
 [workspace]
 members = [

--- a/crates/firewheel-core/Cargo.toml
+++ b/crates/firewheel-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "firewheel-core"
 version = "0.4.2"
 description = "Shared types for Firewheel crates"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-core"
+repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/firewheel-cpal/Cargo.toml
+++ b/crates/firewheel-cpal/Cargo.toml
@@ -3,6 +3,7 @@ name = "firewheel-cpal"
 version = "0.4.3"
 description = "cpal backend for Firewheel"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-cpal"
+repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/firewheel-graph/Cargo.toml
+++ b/crates/firewheel-graph/Cargo.toml
@@ -3,6 +3,7 @@ name = "firewheel-graph"
 version = "0.4.2"
 description = "Core audio graph algorithm and executor for Firewheel"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-graph"
+repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/firewheel-macros/Cargo.toml
+++ b/crates/firewheel-macros/Cargo.toml
@@ -3,6 +3,7 @@ name = "firewheel-macros"
 version = "0.1.1"
 description = "Macros for Firewheel crates"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-macros"
+repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/firewheel-nodes/Cargo.toml
+++ b/crates/firewheel-nodes/Cargo.toml
@@ -3,6 +3,7 @@ name = "firewheel-nodes"
 version = "0.4.2"
 description = "Official factory nodes for the Firewheel audio engine"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-nodes"
+repository.workspace = true
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
To make it easier for potential contributors and automated tools to find the repository. More explanation: https://github.com/szabgab/rust-digger/issues/89
The page listing your crates can be found here:  https://rust-digger.code-maven.com/users/billydm