### PR TITLE
Add ability to get a reference to the active backend

### DIFF
--- a/crates/firewheel-graph/src/context.rs
+++ b/crates/firewheel-graph/src/context.rs
@@ -151,6 +151,22 @@ impl<B: AudioBackend> FirewheelCtx<B> {
         }
     }
 
+    /// Get a reference to the currently active instance of the backend. Returns `None` if the backend has not
+    /// yet been initialized with `start_stream`.
+    pub fn active_backend(&self) -> Option<&B> {
+        self.active_state
+            .as_ref()
+            .map(|state| &state.backend_handle)
+    }
+
+    /// Get a mutable reference to the currently active instance of the backend. Returns `None` if the backend has not
+    /// yet been initialized with `start_stream`.
+    pub fn active_backend_mut(&mut self) -> Option<&mut B> {
+        self.active_state
+            .as_mut()
+            .map(|state| &mut state.backend_handle)
+    }
+
     /// Get a list of the available audio input devices.
     pub fn available_input_devices(&self) -> Vec<DeviceInfo> {
         B::available_input_devices()


### PR DESCRIPTION
This allows a user to write a basic `AudioBackend` which just owns its buffers and `FirewheelProcessor`, and then get a reference to that backend to manually drive the processor. This is useful for offline rendering using Firewheel.

I am currently using `Arc<AtomicOption<..>>` to get the processor directly, which works just fine, but I didn't see a strong reason that the backend shouldn't be directly accessible. A developer could misuse the interface (e.g. by setting the backend config to something incompatible) but it doesn't affect safety and it seems like the flexibility could be desirable so long as the caveats are clear.