### PR TITLE
add support for playing sample in the past

### DIFF
--- a/crates/firewheel-core/src/clock.rs
+++ b/crates/firewheel-core/src/clock.rs
@@ -1,7 +1,9 @@
 use bevy_platform::time::Instant;
 use core::num::NonZeroU32;
-use core::ops::{Add, AddAssign, Range, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Range, Sub, SubAssign};
 
+use crate::diff::{Diff, Patch};
+use crate::event::ParamData;
 use crate::{diff::Notify, node::ProcInfo};
 
 pub const MAX_PROC_TRANSPORT_KEYFRAMES: usize = 16;
@@ -15,18 +17,18 @@ pub enum EventInstant {
     ///
     /// The value is an absolute time, *NOT* a delta time. Use
     /// `FirewheelCtx::audio_clock` to get the current time of the clock.
-    Seconds(ClockSeconds),
+    Seconds(InstantSeconds),
 
     /// The event should happen when the clock reaches the given time in
     /// samples (of a single channel of audio).
     ///
     /// The value is an absolute time, *NOT* a delta time. Use
     /// `FirewheelCtx::audio_clock` to get the current time of the clock.
-    Samples(ClockSamples),
+    Samples(InstantSamples),
 
     /// The event should happen when the musical clock reaches the given
     /// musical time.
-    Musical(MusicalTime),
+    Musical(InstantMusical),
 }
 
 impl EventInstant {
@@ -35,7 +37,7 @@ impl EventInstant {
     /// If this is of type `Event::Instant::Musical` and if either there
     /// is no transport or the transport is currently paused, then this
     /// will return `None`.
-    pub fn to_samples(&self, proc_info: &ProcInfo) -> Option<ClockSamples> {
+    pub fn to_samples(&self, proc_info: &ProcInfo) -> Option<InstantSamples> {
         match self {
             EventInstant::Seconds(seconds) => Some(seconds.to_samples(proc_info.sample_rate)),
             EventInstant::Samples(samples) => Some(*samples),
@@ -55,8 +57,8 @@ impl EventInstant {
 
     pub fn elapsed_this_block(&self, proc_info: &ProcInfo) -> bool {
         match self {
-            EventInstant::Seconds(seconds) => *seconds < proc_info.audio_clock_seconds.end,
-            EventInstant::Samples(samples) => *samples < proc_info.audio_clock_samples.end,
+            EventInstant::Seconds(seconds) => *seconds < proc_info.clock_seconds.end,
+            EventInstant::Samples(samples) => *samples < proc_info.clock_samples.end,
             EventInstant::Musical(musical) => {
                 if let Some(transport) = &proc_info.transport_info {
                     transport.playing && *musical < transport.clock_musical.end
@@ -70,12 +72,12 @@ impl EventInstant {
     pub fn elapsed_on_frame(&self, proc_info: &ProcInfo, sample_rate: NonZeroU32) -> Option<usize> {
         match self {
             EventInstant::Seconds(seconds) => {
-                if *seconds <= proc_info.audio_clock_seconds.start {
+                if *seconds <= proc_info.clock_seconds.start {
                     Some(0)
-                } else if *seconds >= proc_info.audio_clock_seconds.end {
+                } else if *seconds >= proc_info.clock_seconds.end {
                     None
                 } else {
-                    let frame = ((seconds.0 - proc_info.audio_clock_seconds.start.0)
+                    let frame = ((seconds.0 - proc_info.clock_seconds.start.0)
                         * f64::from(sample_rate.get()))
                     .round() as usize;
 
@@ -87,12 +89,12 @@ impl EventInstant {
                 }
             }
             EventInstant::Samples(samples) => {
-                if *samples <= proc_info.audio_clock_samples.start {
+                if *samples <= proc_info.clock_samples.start {
                     Some(0)
-                } else if *samples >= proc_info.audio_clock_samples.end {
+                } else if *samples >= proc_info.clock_samples.end {
                     None
                 } else {
-                    Some((*samples - proc_info.audio_clock_samples.start).0 as usize)
+                    Some((*samples - proc_info.clock_samples.start).0 as usize)
                 }
             }
             EventInstant::Musical(musical) => {
@@ -110,7 +112,7 @@ impl EventInstant {
                     *musical,
                     transport_info.start_clock_samples.unwrap(),
                     proc_info.sample_rate,
-                ) - proc_info.audio_clock_samples.start)
+                ) - proc_info.clock_samples.start)
                     .0
                     .max(0) as usize;
 
@@ -124,75 +126,274 @@ impl EventInstant {
     }
 }
 
-/// An absolute clock time in units of seconds.
+impl Diff for EventInstant {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            match self {
+                EventInstant::Seconds(s) => event_queue.push_param(*s, path),
+                EventInstant::Samples(s) => event_queue.push_param(*s, path),
+                EventInstant::Musical(m) => event_queue.push_param(*m, path),
+            }
+        }
+    }
+}
+
+impl Patch for EventInstant {
+    type Patch = Self;
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        match data {
+            ParamData::InstantSeconds(s) => Ok(EventInstant::Seconds(*s)),
+            ParamData::InstantSamples(s) => Ok(EventInstant::Samples(*s)),
+            ParamData::InstantMusical(s) => Ok(EventInstant::Musical(*s)),
+            _ => Err(crate::diff::PatchError::InvalidData),
+        }
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
+}
+
+/// An absolute audio clock instant in units of seconds.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct ClockSeconds(pub f64);
+pub struct InstantSeconds(pub f64);
 
-impl ClockSeconds {
+impl InstantSeconds {
     pub const ZERO: Self = Self(0.0);
 
-    pub fn to_samples(self, sample_rate: NonZeroU32) -> ClockSamples {
-        let seconds_i64 = self.0.floor() as i64;
-        let fract_samples_i64 = (self.0.fract() * f64::from(sample_rate.get())).round() as i64;
+    pub const fn new(seconds: f64) -> Self {
+        Self(seconds)
+    }
 
-        ClockSamples((seconds_i64 * i64::from(sample_rate.get())) + fract_samples_i64)
+    pub fn to_samples(self, sample_rate: NonZeroU32) -> InstantSamples {
+        InstantSamples(seconds_to_samples(self.0, sample_rate))
     }
 
     /// Convert to the corresponding musical time.
     pub fn to_musical(
         self,
         transport: &MusicalTransport,
-        transport_start: ClockSeconds,
-    ) -> MusicalTime {
+        transport_start: InstantSeconds,
+    ) -> InstantMusical {
         transport.seconds_to_musical(self, transport_start)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    ///
+    /// If `earlier` is later than this one, then the returned value will be negative.
+    pub const fn duration_since(&self, earlier: Self) -> DurationSeconds {
+        DurationSeconds(self.0 - earlier.0)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or
+    /// `None`` if that instant is later than this one.
+    pub fn checked_duration_since(&self, earlier: Self) -> Option<DurationSeconds> {
+        (self.0 >= earlier.0).then(|| DurationSeconds(self.0 - earlier.0))
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or
+    /// zero` if that instant is later than this one.
+    pub const fn saturating_duration_since(&self, earlier: Self) -> DurationSeconds {
+        DurationSeconds((self.0 - earlier.0).max(0.0))
     }
 }
 
-impl Add for ClockSeconds {
+impl Diff for InstantSeconds {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            event_queue.push_param(*self, path);
+        }
+    }
+}
+
+impl Patch for InstantSeconds {
+    type Patch = Self;
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        data.try_into()
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
+}
+
+/// An audio clock duration in units of seconds.
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct DurationSeconds(pub f64);
+
+impl DurationSeconds {
+    pub const ZERO: Self = Self(0.0);
+
+    pub const fn new(seconds: f64) -> Self {
+        Self(seconds)
+    }
+
+    pub fn to_samples(self, sample_rate: NonZeroU32) -> DurationSamples {
+        DurationSamples(seconds_to_samples(self.0, sample_rate))
+    }
+}
+
+impl Diff for DurationSeconds {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            event_queue.push_param(*self, path);
+        }
+    }
+}
+
+impl Patch for DurationSeconds {
+    type Patch = Self;
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        data.try_into()
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
+}
+
+fn seconds_to_samples(seconds: f64, sample_rate: NonZeroU32) -> i64 {
+    let seconds_i64 = seconds.floor() as i64;
+    let fract_samples_i64 = (seconds.fract() * f64::from(sample_rate.get())).round() as i64;
+
+    (seconds_i64 * i64::from(sample_rate.get())) + fract_samples_i64
+}
+
+impl Add<DurationSeconds> for InstantSeconds {
+    type Output = InstantSeconds;
+    fn add(self, rhs: DurationSeconds) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Sub<DurationSeconds> for InstantSeconds {
+    type Output = InstantSeconds;
+    fn sub(self, rhs: DurationSeconds) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl AddAssign<DurationSeconds> for InstantSeconds {
+    fn add_assign(&mut self, rhs: DurationSeconds) {
+        *self = *self + rhs;
+    }
+}
+
+impl SubAssign<DurationSeconds> for InstantSeconds {
+    fn sub_assign(&mut self, rhs: DurationSeconds) {
+        *self = *self - rhs;
+    }
+}
+
+impl Sub<InstantSeconds> for InstantSeconds {
+    type Output = DurationSeconds;
+    fn sub(self, rhs: Self) -> Self::Output {
+        DurationSeconds(self.0 - rhs.0)
+    }
+}
+
+impl Add for DurationSeconds {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
         Self(self.0 + rhs.0)
     }
 }
 
-impl Sub for ClockSeconds {
+impl Sub for DurationSeconds {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
         Self(self.0 - rhs.0)
     }
 }
 
-impl AddAssign for ClockSeconds {
+impl AddAssign for DurationSeconds {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
     }
 }
 
-impl SubAssign for ClockSeconds {
+impl SubAssign for DurationSeconds {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
     }
 }
 
-impl From<f64> for ClockSeconds {
+impl Mul<f64> for DurationSeconds {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}
+
+impl Div<f64> for DurationSeconds {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self::Output {
+        Self(self.0 / rhs)
+    }
+}
+
+impl MulAssign<f64> for DurationSeconds {
+    fn mul_assign(&mut self, rhs: f64) {
+        self.0 *= rhs;
+    }
+}
+
+impl DivAssign<f64> for DurationSeconds {
+    fn div_assign(&mut self, rhs: f64) {
+        self.0 /= rhs;
+    }
+}
+
+impl From<f64> for InstantSeconds {
     fn from(value: f64) -> Self {
         Self(value)
     }
 }
 
-impl Into<f64> for ClockSeconds {
+impl Into<f64> for InstantSeconds {
     fn into(self) -> f64 {
         self.0
     }
 }
 
-/// An absolute clock time in units of samples (in a single channel of audio).
+impl From<f64> for DurationSeconds {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl Into<f64> for DurationSeconds {
+    fn into(self) -> f64 {
+        self.0
+    }
+}
+
+/// An absolute audio clock instant in units of samples (in a single channel of audio).
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ClockSamples(pub i64);
+pub struct InstantSamples(pub i64);
 
-impl ClockSamples {
+impl InstantSamples {
     pub const ZERO: Self = Self(0);
 
     pub const fn new(samples: i64) -> Self {
@@ -201,96 +402,273 @@ impl ClockSamples {
 
     /// (whole seconds, samples *after* whole seconds)
     pub fn whole_seconds_and_fract(&self, sample_rate: NonZeroU32) -> (i64, u32) {
-        // Provide optimized implementations for common sample rates.
-        let (whole_seconds, fract_samples) = match sample_rate.get() {
-            44100 => (self.0 / 44100, self.0 % 44100),
-            48000 => (self.0 / 48000, self.0 % 48000),
-            sample_rate => (
-                self.0 / i64::from(sample_rate),
-                self.0 % i64::from(sample_rate),
-            ),
-        };
-
-        if fract_samples < 0 {
-            (
-                whole_seconds - 1,
-                sample_rate.get() - (fract_samples.abs() as u32),
-            )
-        } else {
-            (whole_seconds, fract_samples as u32)
-        }
+        whole_seconds_and_fract(self.0, sample_rate)
     }
 
     pub fn fract_second_samples(&self, sample_rate: NonZeroU32) -> u32 {
-        match sample_rate.get() {
-            44100 => (self.0 % 44100) as u32,
-            48000 => (self.0 % 48000) as u32,
-            sample_rate => (self.0 % i64::from(sample_rate)) as u32,
-        }
+        fract_second_samples(self.0, sample_rate)
     }
 
-    pub fn to_seconds(self, sample_rate: NonZeroU32, sample_rate_recip: f64) -> ClockSeconds {
-        // Provide optimized implementations for common sample rates.
-        let (whole_seconds, fract_samples) = self.whole_seconds_and_fract(sample_rate);
-
-        ClockSeconds(whole_seconds as f64 + (fract_samples as f64 * sample_rate_recip))
+    pub fn to_seconds(self, sample_rate: NonZeroU32, sample_rate_recip: f64) -> InstantSeconds {
+        InstantSeconds(samples_to_seconds(self.0, sample_rate, sample_rate_recip))
     }
 
     /// Convert to the corresponding musical time.
     pub fn to_musical(
         self,
         transport: &MusicalTransport,
-        transport_start: ClockSamples,
+        transport_start: InstantSamples,
         sample_rate: NonZeroU32,
         sample_rate_recip: f64,
-    ) -> MusicalTime {
+    ) -> InstantMusical {
         transport.samples_to_musical(self, transport_start, sample_rate, sample_rate_recip)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    ///
+    /// If `earlier` is later than this one, then the returned value will be negative.
+    pub const fn duration_since(&self, earlier: Self) -> DurationSamples {
+        DurationSamples(self.0 - earlier.0)
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or
+    /// `None`` if that instant is later than this one.
+    pub fn checked_duration_since(&self, earlier: Self) -> Option<DurationSamples> {
+        (self.0 >= earlier.0).then(|| DurationSamples(self.0 - earlier.0))
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one, or
+    /// zero` if that instant is later than this one.
+    pub fn saturating_duration_since(&self, earlier: Self) -> DurationSamples {
+        DurationSamples((self.0 - earlier.0).max(0))
     }
 }
 
-impl Add for ClockSamples {
+impl Diff for InstantSamples {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            event_queue.push_param(*self, path);
+        }
+    }
+}
+
+impl Patch for InstantSamples {
+    type Patch = Self;
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        data.try_into()
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
+}
+
+/// An audio clock duration in units of samples (in a single channel of audio).
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DurationSamples(pub i64);
+
+impl DurationSamples {
+    pub const ZERO: Self = Self(0);
+
+    pub const fn new(samples: i64) -> Self {
+        Self(samples)
+    }
+
+    /// (whole seconds, samples *after* whole seconds)
+    pub fn whole_seconds_and_fract(&self, sample_rate: NonZeroU32) -> (i64, u32) {
+        whole_seconds_and_fract(self.0, sample_rate)
+    }
+
+    pub fn fract_second_samples(&self, sample_rate: NonZeroU32) -> u32 {
+        fract_second_samples(self.0, sample_rate)
+    }
+
+    pub fn to_seconds(self, sample_rate: NonZeroU32, sample_rate_recip: f64) -> DurationSeconds {
+        DurationSeconds(samples_to_seconds(self.0, sample_rate, sample_rate_recip))
+    }
+}
+
+impl Diff for DurationSamples {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            event_queue.push_param(*self, path);
+        }
+    }
+}
+
+impl Patch for DurationSamples {
+    type Patch = Self;
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        data.try_into()
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
+}
+
+/// (whole seconds, samples *after* whole seconds)
+fn whole_seconds_and_fract(samples: i64, sample_rate: NonZeroU32) -> (i64, u32) {
+    // Provide optimized implementations for common sample rates.
+    let (whole_seconds, fract_samples) = match sample_rate.get() {
+        44100 => (samples / 44100, samples % 44100),
+        48000 => (samples / 48000, samples % 48000),
+        sample_rate => (
+            samples / i64::from(sample_rate),
+            samples % i64::from(sample_rate),
+        ),
+    };
+
+    if fract_samples < 0 {
+        (
+            whole_seconds - 1,
+            sample_rate.get() - (fract_samples.abs() as u32),
+        )
+    } else {
+        (whole_seconds, fract_samples as u32)
+    }
+}
+
+fn fract_second_samples(samples: i64, sample_rate: NonZeroU32) -> u32 {
+    match sample_rate.get() {
+        44100 => (samples % 44100) as u32,
+        48000 => (samples % 48000) as u32,
+        sample_rate => (samples % i64::from(sample_rate)) as u32,
+    }
+}
+
+fn samples_to_seconds(samples: i64, sample_rate: NonZeroU32, sample_rate_recip: f64) -> f64 {
+    let (whole_seconds, fract_samples) = whole_seconds_and_fract(samples, sample_rate);
+    whole_seconds as f64 + (fract_samples as f64 * sample_rate_recip)
+}
+
+impl Add<DurationSamples> for InstantSamples {
+    type Output = InstantSamples;
+    fn add(self, rhs: DurationSamples) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Sub<DurationSamples> for InstantSamples {
+    type Output = InstantSamples;
+    fn sub(self, rhs: DurationSamples) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl AddAssign<DurationSamples> for InstantSamples {
+    fn add_assign(&mut self, rhs: DurationSamples) {
+        *self = *self + rhs;
+    }
+}
+
+impl SubAssign<DurationSamples> for InstantSamples {
+    fn sub_assign(&mut self, rhs: DurationSamples) {
+        *self = *self - rhs;
+    }
+}
+
+impl Sub<InstantSamples> for InstantSamples {
+    type Output = DurationSamples;
+    fn sub(self, rhs: Self) -> Self::Output {
+        DurationSamples(self.0 - rhs.0)
+    }
+}
+
+impl Add for DurationSamples {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
         Self(self.0 + rhs.0)
     }
 }
 
-impl Sub for ClockSamples {
+impl Sub for DurationSamples {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
         Self(self.0 - rhs.0)
     }
 }
 
-impl AddAssign for ClockSamples {
+impl AddAssign for DurationSamples {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
     }
 }
 
-impl SubAssign for ClockSamples {
+impl SubAssign for DurationSamples {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
     }
 }
 
-impl From<i64> for ClockSamples {
+impl Mul<i64> for DurationSamples {
+    type Output = Self;
+    fn mul(self, rhs: i64) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}
+
+impl Div<i64> for DurationSamples {
+    type Output = Self;
+    fn div(self, rhs: i64) -> Self::Output {
+        Self(self.0 / rhs)
+    }
+}
+
+impl MulAssign<i64> for DurationSamples {
+    fn mul_assign(&mut self, rhs: i64) {
+        self.0 *= rhs;
+    }
+}
+
+impl DivAssign<i64> for DurationSamples {
+    fn div_assign(&mut self, rhs: i64) {
+        self.0 /= rhs;
+    }
+}
+
+impl From<i64> for InstantSamples {
     fn from(value: i64) -> Self {
         Self(value)
     }
 }
 
-impl Into<i64> for ClockSamples {
+impl Into<i64> for InstantSamples {
     fn into(self) -> i64 {
         self.0
     }
 }
 
-/// Musical time in units of beats.
-#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct MusicalTime(pub f64);
+impl From<i64> for DurationSamples {
+    fn from(value: i64) -> Self {
+        Self(value)
+    }
+}
 
-impl MusicalTime {
+impl Into<i64> for DurationSamples {
+    fn into(self) -> i64 {
+        self.0
+    }
+}
+
+/// An absolute audio clock instant in units of musical beats.
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct InstantMusical(pub f64);
+
+impl InstantMusical {
     pub const ZERO: Self = Self(0.0);
 
     pub const fn new(beats: f64) -> Self {
@@ -298,18 +676,18 @@ impl MusicalTime {
     }
 
     /// Convert to the corresponding time in seconds.
-    pub fn to_seconds(&self, beats_per_minute: f64) -> ClockSeconds {
-        ClockSeconds(self.0 * 60.0 / beats_per_minute)
+    pub fn to_seconds(&self, beats_per_minute: f64) -> InstantSeconds {
+        InstantSeconds(self.0 * 60.0 / beats_per_minute)
     }
 
     /// Convert to the corresponding time in samples.
-    pub fn to_sample_time(&self, beats_per_minute: f64, sample_rate: NonZeroU32) -> ClockSamples {
+    pub fn to_sample_time(&self, beats_per_minute: f64, sample_rate: NonZeroU32) -> InstantSamples {
         self.to_seconds(beats_per_minute).to_samples(sample_rate)
     }
 
     /// Convert to the corresponding time in seconds.
-    pub fn to_seconds_with_spb(&self, seconds_per_beat: f64) -> ClockSeconds {
-        ClockSeconds(self.0 * seconds_per_beat)
+    pub fn to_seconds_with_spb(&self, seconds_per_beat: f64) -> InstantSeconds {
+        InstantSeconds(self.0 * seconds_per_beat)
     }
 
     /// Convert to the corresponding time in samples.
@@ -317,43 +695,181 @@ impl MusicalTime {
         &self,
         seconds_per_beat: f64,
         sample_rate: NonZeroU32,
-    ) -> ClockSamples {
+    ) -> InstantSamples {
         self.to_seconds_with_spb(seconds_per_beat)
             .to_samples(sample_rate)
     }
 }
 
-pub fn seconds_per_beat(beats_per_minute: f64) -> f64 {
-    60.0 / beats_per_minute
+impl Diff for InstantMusical {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            event_queue.push_param(*self, path);
+        }
+    }
 }
 
-pub fn beats_per_second(beats_per_minute: f64) -> f64 {
-    beats_per_minute * (1.0 / 60.0)
+impl Patch for InstantMusical {
+    type Patch = Self;
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        data.try_into()
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
 }
 
-impl Add for MusicalTime {
+/// An audio clock duration in units of musical beats.
+#[repr(transparent)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub struct DurationMusical(pub f64);
+
+impl DurationMusical {
+    pub const ZERO: Self = Self(0.0);
+
+    pub const fn new(beats: f64) -> Self {
+        Self(beats)
+    }
+}
+
+impl Diff for DurationMusical {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            event_queue.push_param(*self, path);
+        }
+    }
+}
+
+impl Patch for DurationMusical {
+    type Patch = Self;
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        data.try_into()
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
+}
+
+impl Add<DurationMusical> for InstantMusical {
+    type Output = InstantMusical;
+    fn add(self, rhs: DurationMusical) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Sub<DurationMusical> for InstantMusical {
+    type Output = InstantMusical;
+    fn sub(self, rhs: DurationMusical) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
+}
+
+impl AddAssign<DurationMusical> for InstantMusical {
+    fn add_assign(&mut self, rhs: DurationMusical) {
+        *self = *self + rhs;
+    }
+}
+
+impl SubAssign<DurationMusical> for InstantMusical {
+    fn sub_assign(&mut self, rhs: DurationMusical) {
+        *self = *self - rhs;
+    }
+}
+
+impl Sub<InstantMusical> for InstantMusical {
+    type Output = DurationMusical;
+    fn sub(self, rhs: Self) -> Self::Output {
+        DurationMusical(self.0 - rhs.0)
+    }
+}
+
+impl Add for DurationMusical {
     type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
         Self(self.0 + rhs.0)
     }
 }
 
-impl Sub for MusicalTime {
+impl Sub for DurationMusical {
     type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
         Self(self.0 - rhs.0)
     }
 }
 
-impl AddAssign for MusicalTime {
+impl AddAssign for DurationMusical {
     fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
     }
 }
 
-impl SubAssign for MusicalTime {
+impl SubAssign for DurationMusical {
     fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
+    }
+}
+
+impl Mul<f64> for DurationMusical {
+    type Output = Self;
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}
+
+impl Div<f64> for DurationMusical {
+    type Output = Self;
+    fn div(self, rhs: f64) -> Self::Output {
+        Self(self.0 / rhs)
+    }
+}
+
+impl MulAssign<f64> for DurationMusical {
+    fn mul_assign(&mut self, rhs: f64) {
+        self.0 *= rhs;
+    }
+}
+
+impl DivAssign<f64> for DurationMusical {
+    fn div_assign(&mut self, rhs: f64) {
+        self.0 /= rhs;
+    }
+}
+
+impl From<f64> for InstantMusical {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl Into<f64> for InstantMusical {
+    fn into(self) -> f64 {
+        self.0
+    }
+}
+
+impl From<f64> for DurationMusical {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl Into<f64> for DurationMusical {
+    fn into(self) -> f64 {
+        self.0
     }
 }
 
@@ -373,9 +889,9 @@ impl Default for MusicalTransport {
 impl MusicalTransport {
     pub fn musical_to_seconds(
         &self,
-        musical: MusicalTime,
-        transport_start: ClockSeconds,
-    ) -> ClockSeconds {
+        musical: InstantMusical,
+        transport_start: InstantSeconds,
+    ) -> InstantSeconds {
         match self {
             MusicalTransport::Static(s) => s.musical_to_seconds(musical, transport_start),
         }
@@ -383,10 +899,10 @@ impl MusicalTransport {
 
     pub fn musical_to_samples(
         &self,
-        musical: MusicalTime,
-        transport_start: ClockSamples,
+        musical: InstantMusical,
+        transport_start: InstantSamples,
         sample_rate: NonZeroU32,
-    ) -> ClockSamples {
+    ) -> InstantSamples {
         match self {
             MusicalTransport::Static(s) => {
                 s.musical_to_samples(musical, transport_start, sample_rate)
@@ -396,11 +912,11 @@ impl MusicalTransport {
 
     pub fn samples_to_musical(
         &self,
-        sample_time: ClockSamples,
-        transport_start: ClockSamples,
+        sample_time: InstantSamples,
+        transport_start: InstantSamples,
         sample_rate: NonZeroU32,
         sample_rate_recip: f64,
-    ) -> MusicalTime {
+    ) -> InstantMusical {
         match self {
             MusicalTransport::Static(s) => {
                 s.samples_to_musical(sample_time, transport_start, sample_rate, sample_rate_recip)
@@ -410,9 +926,9 @@ impl MusicalTransport {
 
     pub fn seconds_to_musical(
         &self,
-        seconds: ClockSeconds,
-        transport_start: ClockSeconds,
-    ) -> MusicalTime {
+        seconds: InstantSeconds,
+        transport_start: InstantSeconds,
+    ) -> InstantMusical {
         match self {
             MusicalTransport::Static(s) => s.seconds_to_musical(seconds, transport_start),
         }
@@ -422,28 +938,43 @@ impl MusicalTransport {
     /// given `from` timestamp.
     pub fn delta_seconds_from(
         &self,
-        from: MusicalTime,
-        delta_seconds: ClockSeconds,
-    ) -> MusicalTime {
+        from: InstantMusical,
+        delta_seconds: DurationSeconds,
+    ) -> InstantMusical {
         match self {
             MusicalTransport::Static(s) => s.delta_seconds_from(from, delta_seconds),
         }
     }
 
     /// Return the tempo in beats per minute at the given musical time.
-    pub fn bpm_at_musical(&self, _musical: MusicalTime) -> f64 {
+    pub fn bpm_at_musical(&self, _musical: InstantMusical) -> f64 {
         match self {
             MusicalTransport::Static(s) => s.beats_per_minute(),
         }
     }
 
-    pub fn proc_transport_info(&self, frames: usize, _playhead: MusicalTime) -> ProcTransportInfo {
+    pub fn proc_transport_info(
+        &self,
+        frames: usize,
+        _playhead: InstantMusical,
+    ) -> ProcTransportInfo {
         match self {
             MusicalTransport::Static(s) => ProcTransportInfo {
                 frames,
                 beats_per_minute: s.beats_per_minute,
                 delta_beats_per_minute: 0.0,
             },
+        }
+    }
+
+    pub fn transport_start(
+        &self,
+        now: InstantSamples,
+        playhead: InstantMusical,
+        sample_rate: NonZeroU32,
+    ) -> InstantSamples {
+        match self {
+            MusicalTransport::Static(s) => s.transport_start(now, playhead, sample_rate),
         }
     }
 }
@@ -502,29 +1033,30 @@ impl StaticTransport {
 
     pub fn musical_to_seconds(
         &self,
-        musical: MusicalTime,
-        transport_start: ClockSeconds,
-    ) -> ClockSeconds {
-        ClockSeconds(musical.0 * self.seconds_per_beat()) + transport_start
+        musical: InstantMusical,
+        transport_start: InstantSeconds,
+    ) -> InstantSeconds {
+        transport_start + DurationSeconds(musical.0 * self.seconds_per_beat())
     }
 
     pub fn musical_to_samples(
         &self,
-        musical: MusicalTime,
-        transport_start: ClockSamples,
+        musical: InstantMusical,
+        transport_start: InstantSamples,
         sample_rate: NonZeroU32,
-    ) -> ClockSamples {
-        ClockSeconds(musical.0 * self.seconds_per_beat()).to_samples(sample_rate) + transport_start
+    ) -> InstantSamples {
+        transport_start
+            + DurationSeconds(musical.0 * self.seconds_per_beat()).to_samples(sample_rate)
     }
 
     pub fn samples_to_musical(
         &self,
-        sample_time: ClockSamples,
-        transport_start: ClockSamples,
+        sample_time: InstantSamples,
+        transport_start: InstantSamples,
         sample_rate: NonZeroU32,
         sample_rate_recip: f64,
-    ) -> MusicalTime {
-        MusicalTime(
+    ) -> InstantMusical {
+        InstantMusical(
             (sample_time - transport_start)
                 .to_seconds(sample_rate, sample_rate_recip)
                 .0
@@ -534,20 +1066,29 @@ impl StaticTransport {
 
     pub fn seconds_to_musical(
         &self,
-        seconds: ClockSeconds,
-        transport_start: ClockSeconds,
-    ) -> MusicalTime {
-        MusicalTime((seconds - transport_start).0 * self.beats_per_second())
+        seconds: InstantSeconds,
+        transport_start: InstantSeconds,
+    ) -> InstantMusical {
+        InstantMusical((seconds - transport_start).0 * self.beats_per_second())
     }
 
     /// Return the musical time that occurs `delta_seconds` seconds after the
     /// given `from` timestamp.
     pub fn delta_seconds_from(
         &self,
-        from: MusicalTime,
-        delta_seconds: ClockSeconds,
-    ) -> MusicalTime {
-        from + self.seconds_to_musical(delta_seconds, ClockSeconds::ZERO)
+        from: InstantMusical,
+        delta_seconds: DurationSeconds,
+    ) -> InstantMusical {
+        from + DurationMusical(delta_seconds.0 * self.beats_per_second())
+    }
+
+    pub fn transport_start(
+        &self,
+        now: InstantSamples,
+        playhead: InstantMusical,
+        sample_rate: NonZeroU32,
+    ) -> InstantSamples {
+        now - DurationSeconds(playhead.0 * self.seconds_per_beat()).to_samples(sample_rate)
     }
 }
 
@@ -743,7 +1284,7 @@ pub struct AudioClock {
     /// does *NOT* account for any output underflows (underruns) that may have
     /// occured. For applications where the timing of audio events is critical (i.e.
     /// a rythm game), sync the game to this audio clock.
-    pub samples: ClockSamples,
+    pub samples: InstantSamples,
 
     /// The timestamp from the audio stream, equal to the number of seconds of
     /// data that have been processed since the Firewheel context was first started.
@@ -752,7 +1293,7 @@ pub struct AudioClock {
     /// does *NOT* account for any output underflows (underruns) that may have
     /// occured. For applications where the timing of audio events is critical (i.e.
     /// a rythm game), sync the game to this audio clock.
-    pub seconds: ClockSeconds,
+    pub seconds: InstantSeconds,
 
     /// The current time of the playhead of the musical transport.
     ///
@@ -762,7 +1303,7 @@ pub struct AudioClock {
     /// does *NOT* account for any output underflows (underruns) that may have
     /// occured. For applications where the timing of audio events is critical (i.e.
     /// a rythm game), sync the game to this audio clock.
-    pub musical: Option<MusicalTime>,
+    pub musical: Option<InstantMusical>,
 
     /// This is `true` if a musical transport is present and it is not paused,
     /// `false` otherwise.
@@ -789,16 +1330,16 @@ pub struct TransportState {
     pub playing: Notify<bool>,
 
     /// The playhead of the musical transport.
-    pub playhead: Notify<MusicalTime>,
+    pub playhead: Notify<InstantMusical>,
 
     /// If this is `Some`, then the transport will automatically stop when the playhead
     /// reaches the given musical time.
     ///
     /// This has no effect if [`TransportState::loop_range`] is `Some`.
-    pub stop_at: Option<MusicalTime>,
+    pub stop_at: Option<InstantMusical>,
 
     /// If this is `Some`, then the transport will continously loop the given region.
-    pub loop_range: Option<Range<MusicalTime>>,
+    pub loop_range: Option<Range<InstantMusical>>,
 }
 
 impl Default for TransportState {
@@ -806,9 +1347,17 @@ impl Default for TransportState {
         Self {
             transport: None,
             playing: Notify::new(false),
-            playhead: Notify::new(MusicalTime::ZERO),
+            playhead: Notify::new(InstantMusical::ZERO),
             stop_at: None,
             loop_range: None,
         }
     }
+}
+
+pub fn seconds_per_beat(beats_per_minute: f64) -> f64 {
+    60.0 / beats_per_minute
+}
+
+pub fn beats_per_second(beats_per_minute: f64) -> f64 {
+    beats_per_minute * (1.0 / 60.0)
 }

--- a/crates/firewheel-core/src/event.rs
+++ b/crates/firewheel-core/src/event.rs
@@ -2,7 +2,15 @@ use core::any::Any;
 
 pub use glam::{Vec2, Vec3};
 
-use crate::{diff::ParamPath, dsp::volume::Volume, node::NodeID};
+use crate::{
+    clock::{
+        DurationMusical, DurationSamples, DurationSeconds, InstantMusical, InstantSamples,
+        InstantSeconds,
+    },
+    diff::ParamPath,
+    dsp::volume::Volume,
+    node::NodeID,
+};
 
 /// An event sent to an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
 pub struct NodeEvent {
@@ -42,6 +50,12 @@ pub enum ParamData {
     Bool(bool),
     Vector2D(Vec2),
     Vector3D(Vec3),
+    InstantSeconds(InstantSeconds),
+    DurationSeconds(DurationSeconds),
+    InstantSamples(InstantSamples),
+    DurationSamples(DurationSamples),
+    InstantMusical(InstantMusical),
+    DurationMusical(DurationMusical),
     Any(Box<Box<dyn Any + Send + Sync>>),
 }
 
@@ -93,6 +107,12 @@ param_data_from!(u64, U64);
 param_data_from!(bool, Bool);
 param_data_from!(Vec2, Vector2D);
 param_data_from!(Vec3, Vector3D);
+param_data_from!(InstantSeconds, InstantSeconds);
+param_data_from!(DurationSeconds, DurationSeconds);
+param_data_from!(InstantSamples, InstantSamples);
+param_data_from!(DurationSamples, DurationSamples);
+param_data_from!(InstantMusical, InstantMusical);
+param_data_from!(DurationMusical, DurationMusical);
 
 /// A list of events for an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
 pub struct NodeEventList<'a> {

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -3,7 +3,7 @@ use core::{any::Any, fmt::Debug, hash::Hash, num::NonZeroU32, ops::Range};
 
 use crate::{
     channel_config::{ChannelConfig, ChannelCount},
-    clock::{ClockSamples, ClockSeconds, MusicalTime, MusicalTransport},
+    clock::{InstantMusical, InstantSamples, InstantSeconds, MusicalTransport},
     dsp::declick::DeclickValues,
     event::{NodeEvent, NodeEventList, NodeEventType},
     SilenceMask, StreamInfo,
@@ -460,7 +460,7 @@ pub struct ProcInfo<'a> {
     /// Note, generally this value will always count up, but there may be
     /// a few edge cases that cause this value to be less than the previous
     /// block, such as when the sample rate of the stream has been changed.
-    pub audio_clock_samples: Range<ClockSamples>,
+    pub clock_samples: Range<InstantSamples>,
 
     /// The current time of the audio clock, equal to the total amount of
     /// data in seconds that have been processed since this Firewheel
@@ -472,7 +472,7 @@ pub struct ProcInfo<'a> {
     ///
     /// Note, this value does *NOT* account for any output underflows
     /// (underruns) that may have occured.
-    pub audio_clock_seconds: Range<ClockSeconds>,
+    pub clock_seconds: Range<InstantSeconds>,
 
     /// The instant the the Firewheel processor's `process` method was
     /// invoked.
@@ -522,7 +522,7 @@ pub struct TransportInfo<'a> {
     ///
     /// Note, this value does *NOT* account for any output underflows
     /// (underruns) that may have occured.
-    pub clock_musical: Range<MusicalTime>,
+    pub clock_musical: Range<InstantMusical>,
 
     /// Whether or not the transport is currently playing (true) or paused
     /// (false).
@@ -532,7 +532,7 @@ pub struct TransportInfo<'a> {
     /// `ClockSamples`.
     ///
     /// If the transport is not currently playing, then this will be `None`.
-    pub start_clock_samples: Option<ClockSamples>,
+    pub start_clock_samples: Option<InstantSamples>,
 
     /// The beats per minute at the first frame of this process block.
     pub beats_per_minute: f64,

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -528,6 +528,12 @@ pub struct TransportInfo<'a> {
     /// (false).
     pub playing: bool,
 
+    /// The instant that `MusicaltTime::ZERO` occured in units of
+    /// `ClockSamples`.
+    ///
+    /// If the transport is not currently playing, then this will be `None`.
+    pub start_clock_samples: Option<ClockSamples>,
+
     /// The beats per minute at the first frame of this process block.
     pub beats_per_minute: f64,
 

--- a/crates/firewheel-graph/src/context.rs
+++ b/crates/firewheel-graph/src/context.rs
@@ -2,10 +2,10 @@ use bevy_platform::time::Instant;
 use core::cell::RefCell;
 use core::num::NonZeroU32;
 use core::{any::Any, f64};
-use firewheel_core::clock::TransportState;
+use firewheel_core::clock::{DurationSeconds, TransportState};
 use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
-    clock::{AudioClock, ClockSeconds},
+    clock::AudioClock,
     collector::Collector,
     dsp::declick::DeclickValues,
     event::{NodeEvent, NodeEventType},
@@ -369,7 +369,7 @@ impl<B: AudioBackend> FirewheelCtx<B> {
         };
 
         // Account for the delay between when the clock was last updated and now.
-        let delta_seconds = ClockSeconds(update_instant.elapsed().as_secs_f64());
+        let delta_seconds = DurationSeconds(update_instant.elapsed().as_secs_f64());
         let samples = clock.clock_samples + delta_seconds.to_samples(self.sample_rate);
 
         let musical = clock.musical_time.map(|musical_time| {

--- a/crates/firewheel-graph/src/context.rs
+++ b/crates/firewheel-graph/src/context.rs
@@ -379,7 +379,7 @@ impl<B: AudioBackend> FirewheelCtx<B> {
         };
 
         // Account for the delay between when the clock was last updated and now.
-        let delta_seconds = DurationSeconds(update_instant.elapsed().as_secs_f64());
+        let delta_seconds = DurationSeconds(delay.as_secs_f64());
 
         let samples = clock.clock_samples + delta_seconds.to_samples(self.sample_rate);
 

--- a/crates/firewheel-graph/src/processor.rs
+++ b/crates/firewheel-graph/src/processor.rs
@@ -418,8 +418,7 @@ impl FirewheelProcessorInner {
             out_silence_mask: SilenceMask::default(),
             sample_rate,
             sample_rate_recip,
-            clock_samples: clock_samples
-                ..(clock_samples + DurationSamples(block_frames as i64)),
+            clock_samples: clock_samples..(clock_samples + DurationSamples(block_frames as i64)),
             clock_seconds: clock_seconds.clone(),
             process_timestamp,
             transport_info,

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -176,9 +176,9 @@ impl SamplerNode {
     /// beginning when the instant occurs. If this instant is in the past when
     /// the node receives this event, then the sequence will skip ahead as if
     /// it started playing from that instant in the past.
-    pub fn start_or_restart(&mut self, play_from_instant: Option<EventInstant>) {
+    pub fn start_or_restart(&mut self, instant: Option<EventInstant>) {
         *self.playhead = Playhead::default();
-        *self.playback = PlaybackState::Play { play_from_instant };
+        *self.playback = PlaybackState::Play { instant };
     }
 
     /// Pause sequence playback.
@@ -188,9 +188,7 @@ impl SamplerNode {
 
     /// Resume sequence playback.
     pub fn resume(&mut self) {
-        *self.playback = PlaybackState::Play {
-            play_from_instant: None,
-        };
+        *self.playback = PlaybackState::Play { instant: None };
     }
 
     /// Stop sequence playback.
@@ -357,7 +355,7 @@ pub enum PlaybackState {
         /// beginning when the instant occurs. If this instant is in the past when
         /// this node receives this event, then the sequence will skip ahead as if
         /// it started playing from that instant in the past.
-        play_from_instant: Option<EventInstant>,
+        instant: Option<EventInstant>,
     },
 }
 
@@ -947,10 +945,10 @@ impl AudioNodeProcessor for SamplerProcessor {
                         self.playback_pause_time_frames = proc_info.audio_clock_samples.start;
                     }
                 }
-                PlaybackState::Play { play_from_instant } => {
-                    self.playback_state = PlaybackState::Play {
-                        play_from_instant: None,
-                    };
+                PlaybackState::Play {
+                    instant: play_from_instant,
+                } => {
+                    self.playback_state = PlaybackState::Play { instant: None };
 
                     // Crossfade with the previous sample.
                     if self.config.crossfade_on_restart && self.num_active_stop_declickers > 0 {

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -985,11 +985,10 @@ impl AudioNodeProcessor for SamplerProcessor {
                         self.play_from_instant = None;
 
                         if let Some(state) = &mut self.loaded_sample_state {
-                            state.playhead = ((proc_info.clock_samples.start
-                                - instant_clock_samples)
-                                .0 as u64
-                                + self.params.playhead.as_frames(proc_info.sample_rate))
-                            .min(state.sample_len_frames);
+                            state.playhead =
+                                ((proc_info.clock_samples.start - instant_clock_samples).0 as u64
+                                    + self.params.playhead.as_frames(proc_info.sample_rate))
+                                .min(state.sample_len_frames);
                             state.num_times_looped_back = 0;
                         }
 
@@ -1010,10 +1009,7 @@ impl AudioNodeProcessor for SamplerProcessor {
                             state.num_times_looped_back = 0;
                         }
 
-                        Some(
-                            (instant_clock_samples - proc_info.clock_samples.start).0
-                                as usize,
-                        )
+                        Some((instant_clock_samples - proc_info.clock_samples.start).0 as usize)
                     }
                 })
         } else {

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -990,7 +990,7 @@ impl AudioNodeProcessor for SamplerProcessor {
                             state.playhead = ((proc_info.audio_clock_samples.start
                                 - instant_clock_samples)
                                 .0 as u64)
-                                .max(state.sample_len_frames);
+                                .min(state.sample_len_frames);
                             state.num_times_looped_back = 0;
                         }
 

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -989,8 +989,9 @@ impl AudioNodeProcessor for SamplerProcessor {
                         if let Some(state) = &mut self.loaded_sample_state {
                             state.playhead = ((proc_info.audio_clock_samples.start
                                 - instant_clock_samples)
-                                .0 as u64)
-                                .min(state.sample_len_frames);
+                                .0 as u64
+                                + self.params.playhead.as_frames(proc_info.sample_rate))
+                            .min(state.sample_len_frames);
                             state.num_times_looped_back = 0;
                         }
 
@@ -1003,7 +1004,11 @@ impl AudioNodeProcessor for SamplerProcessor {
                         self.play_from_instant = None;
 
                         if let Some(state) = &mut self.loaded_sample_state {
-                            state.playhead = 0;
+                            state.playhead = self
+                                .params
+                                .playhead
+                                .as_frames(proc_info.sample_rate)
+                                .min(state.sample_len_frames);
                             state.num_times_looped_back = 0;
                         }
 

--- a/examples/sampler_test/src/system.rs
+++ b/examples/sampler_test/src/system.rs
@@ -127,7 +127,7 @@ impl AudioSystem {
     pub fn resume(&mut self, sampler_i: usize) {
         let sampler = &mut self.samplers[sampler_i];
 
-        sampler.params.resume(None);
+        sampler.params.resume();
 
         sampler
             .params

--- a/src/sampler_pool.rs
+++ b/src/sampler_pool.rs
@@ -2,7 +2,6 @@ use core::num::NonZeroU32;
 
 use firewheel_core::{
     channel_config::NonZeroChannelCount,
-    clock::EventDelay,
     diff::{Diff, PathBuilder},
     node::NodeID,
 };
@@ -265,19 +264,14 @@ impl<FX: FxChain> SamplerPool<FX> {
     /// Resume the given worker.
     ///
     /// Returns `true` if a worker with the given ID exists, `false` otherwise.
-    pub fn resume(
-        &mut self,
-        worker_id: WorkerID,
-        delay: Option<EventDelay>,
-        cx: &mut FirewheelContext,
-    ) -> bool {
+    pub fn resume(&mut self, worker_id: WorkerID, cx: &mut FirewheelContext) -> bool {
         let Some(idx) = self.worker_ids.get(worker_id.0).copied() else {
             return false;
         };
 
         let worker = &mut self.workers[idx];
 
-        worker.params.resume(delay);
+        worker.params.resume();
         cx.queue_event_for(worker.sampler_id, worker.params.sync_playback_event());
 
         true
@@ -317,10 +311,10 @@ impl<FX: FxChain> SamplerPool<FX> {
     }
 
     /// Resume all workers.
-    pub fn resume_all(&mut self, delay: Option<EventDelay>, cx: &mut FirewheelContext) {
+    pub fn resume_all(&mut self, cx: &mut FirewheelContext) {
         for worker in self.workers.iter_mut() {
             if worker.assigned_worker_id.is_some() {
-                worker.params.resume(delay);
+                worker.params.resume();
                 cx.queue_event_for(worker.sampler_id, worker.params.sync_playback_event());
             }
         }


### PR DESCRIPTION
This adds support for samples to be played "in the past".

I have also made some other changes:
* `EventDelay` has been renamed to `EventInstant` for clarity.
* Converting between `MusicalTime` and the other clock units now correctly requires a `transport_start` offset.
* Removed unnecessary `delay` when resuming a sample. 

I have not tested this yet.