### PR TITLE
Add optional timing information to node events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ log = "0.4"
 ringbuf = { version = "0.4", features = ["portable-atomic"] }
 triple_buffer = "8"
 thiserror = "2"
+itertools = "0.14"
 smallvec = "1"
 arrayvec = "0.7"
 bitflags = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewheel"
-version = "0.5.0-beta.0"
+version = "0.6.0-beta.0"
 description = "Flexible, high-performance, and libre audio engine for games (WIP)"
 repository.workspace = true
 edition.workspace = true
@@ -92,10 +92,10 @@ bevy = ["firewheel-nodes/bevy", "firewheel-core/bevy"]
 wasm-bindgen = ["firewheel-cpal/wasm-bindgen"]
 
 [dependencies]
-firewheel-core = { path = "crates/firewheel-core", version = "0.5.0-beta.0" }
-firewheel-graph = { path = "crates/firewheel-graph", version = "0.5.0-beta.0" }
-firewheel-cpal = { path = "crates/firewheel-cpal", version = "0.5.0-beta.0", default-features = false, optional = true }
-firewheel-nodes = { path = "crates/firewheel-nodes", version = "0.5.0-beta.0", default-features = false }
+firewheel-core = { path = "crates/firewheel-core", version = "0.6.0-beta.0" }
+firewheel-graph = { path = "crates/firewheel-graph", version = "0.6.0-beta.0" }
+firewheel-cpal = { path = "crates/firewheel-cpal", version = "0.6.0-beta.0", default-features = false, optional = true }
+firewheel-nodes = { path = "crates/firewheel-nodes", version = "0.6.0-beta.0", default-features = false }
 thunderdome = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 thiserror.workspace = true
@@ -112,7 +112,7 @@ bitflags = "2"
 thunderdome = "0.6"
 crossbeam-utils = "0.8"
 fast-interleave = "0.1"
-firewheel-macros = { path = "crates/firewheel-macros", version = "0.1.1" }
+firewheel-macros = { path = "crates/firewheel-macros", version = "0.2.0" }
 bevy_platform = "0.16.0"
 
 # Optimize all dependencies in debug builds:

--- a/benches/core.rs
+++ b/benches/core.rs
@@ -104,7 +104,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("patching shallow", |b| {
         b.iter(|| {
-            for message in &messages {
+            for message in messages.drain(..) {
                 target.apply(ShallowParams::patch_event(message).unwrap());
                 black_box(&target);
             }
@@ -125,7 +125,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("patching three", |b| {
         b.iter(|| {
-            for message in &messages {
+            for message in messages.drain(..) {
                 target.apply(DoubleNesting::patch_event(message).unwrap());
                 black_box(&target);
             }
@@ -149,7 +149,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             }
 
             for message in messages.drain(..) {
-                target.apply(ShallowParams::patch_event(&message).unwrap());
+                target.apply(ShallowParams::patch_event(message).unwrap());
                 black_box(&target);
             }
         })
@@ -171,7 +171,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             }
 
             for message in messages.drain(..) {
-                target.apply(DoubleNesting::patch_event(&message).unwrap());
+                target.apply(DoubleNesting::patch_event(message).unwrap());
                 black_box(&target);
             }
         })
@@ -193,7 +193,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             }
 
             for message in messages.drain(..) {
-                target.apply(QuadNesting::patch_event(&message).unwrap());
+                target.apply(QuadNesting::patch_event(message).unwrap());
                 black_box(&target);
             }
         })

--- a/crates/firewheel-core/Cargo.toml
+++ b/crates/firewheel-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewheel-core"
-version = "0.5.0-beta.0"
+version = "0.6.0-beta.0"
 description = "Shared types for Firewheel crates"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-core"
 repository.workspace = true

--- a/crates/firewheel-core/src/channel_config.rs
+++ b/crates/firewheel-core/src/channel_config.rs
@@ -1,5 +1,7 @@
 use core::{error::Error, fmt, num::NonZeroU32};
 
+pub const MAX_CHANNELS: usize = 64;
+
 /// A supported number of channels on an audio node.
 ///
 /// This number cannot be greater than `64`.
@@ -11,7 +13,7 @@ impl ChannelCount {
     pub const ZERO: Self = Self(0);
     pub const MONO: Self = Self(1);
     pub const STEREO: Self = Self(2);
-    pub const MAX: Self = Self(64);
+    pub const MAX: Self = Self(MAX_CHANNELS as u32);
 
     /// Create a new [`ChannelCount`].
     ///

--- a/crates/firewheel-core/src/clock.rs
+++ b/crates/firewheel-core/src/clock.rs
@@ -31,6 +31,24 @@ pub enum EventInstant {
     Musical(InstantMusical),
 }
 
+impl From<InstantSeconds> for EventInstant {
+    fn from(value: InstantSeconds) -> Self {
+        Self::Seconds(value)
+    }
+}
+
+impl From<InstantSamples> for EventInstant {
+    fn from(value: InstantSamples) -> Self {
+        Self::Samples(value)
+    }
+}
+
+impl From<InstantMusical> for EventInstant {
+    fn from(value: InstantMusical) -> Self {
+        Self::Musical(value)
+    }
+}
+
 impl EventInstant {
     /// Convert this instant to units of `ClockSamples`.
     ///

--- a/crates/firewheel-core/src/clock.rs
+++ b/crates/firewheel-core/src/clock.rs
@@ -2,9 +2,9 @@ use bevy_platform::time::Instant;
 use core::num::NonZeroU32;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Range, Sub, SubAssign};
 
-use crate::diff::{Diff, Patch};
+use crate::diff::{Diff, Notify, Patch};
 use crate::event::ParamData;
-use crate::{diff::Notify, node::ProcInfo};
+use crate::node::ProcInfo;
 
 pub const MAX_PROC_TRANSPORT_KEYFRAMES: usize = 16;
 
@@ -31,6 +31,29 @@ pub enum EventInstant {
     Musical(InstantMusical),
 }
 
+impl EventInstant {
+    pub fn is_musical(&self) -> bool {
+        if let EventInstant::Musical(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Convert the instant to the given time in samples.
+    ///
+    /// If this instant is of type [`EventInstant::Musical`] and either
+    /// there is no musical transport or the musical transport is not
+    /// currently playing, then this will return `None`.
+    pub fn to_samples(&self, proc_info: &ProcInfo) -> Option<InstantSamples> {
+        match self {
+            EventInstant::Samples(samples) => Some(*samples),
+            EventInstant::Seconds(seconds) => Some(seconds.to_samples(proc_info.sample_rate)),
+            EventInstant::Musical(musical) => proc_info.musical_to_samples(*musical),
+        }
+    }
+}
+
 impl From<InstantSeconds> for EventInstant {
     fn from(value: InstantSeconds) -> Self {
         Self::Seconds(value)
@@ -46,101 +69,6 @@ impl From<InstantSamples> for EventInstant {
 impl From<InstantMusical> for EventInstant {
     fn from(value: InstantMusical) -> Self {
         Self::Musical(value)
-    }
-}
-
-impl EventInstant {
-    /// Convert this instant to units of `ClockSamples`.
-    ///
-    /// If this is of type `Event::Instant::Musical` and if either there
-    /// is no transport or the transport is currently paused, then this
-    /// will return `None`.
-    pub fn to_samples(&self, proc_info: &ProcInfo) -> Option<InstantSamples> {
-        match self {
-            EventInstant::Seconds(seconds) => Some(seconds.to_samples(proc_info.sample_rate)),
-            EventInstant::Samples(samples) => Some(*samples),
-            EventInstant::Musical(musical) => {
-                proc_info.transport_info.as_ref().and_then(|transport| {
-                    transport.start_clock_samples.map(|transport_start| {
-                        transport.transport.musical_to_samples(
-                            *musical,
-                            transport_start,
-                            proc_info.sample_rate,
-                        )
-                    })
-                })
-            }
-        }
-    }
-
-    pub fn elapsed_this_block(&self, proc_info: &ProcInfo) -> bool {
-        match self {
-            EventInstant::Seconds(seconds) => *seconds < proc_info.clock_seconds.end,
-            EventInstant::Samples(samples) => *samples < proc_info.clock_samples.end,
-            EventInstant::Musical(musical) => {
-                if let Some(transport) = &proc_info.transport_info {
-                    transport.playing && *musical < transport.clock_musical.end
-                } else {
-                    false
-                }
-            }
-        }
-    }
-
-    pub fn elapsed_on_frame(&self, proc_info: &ProcInfo, sample_rate: NonZeroU32) -> Option<usize> {
-        match self {
-            EventInstant::Seconds(seconds) => {
-                if *seconds <= proc_info.clock_seconds.start {
-                    Some(0)
-                } else if *seconds >= proc_info.clock_seconds.end {
-                    None
-                } else {
-                    let frame = ((seconds.0 - proc_info.clock_seconds.start.0)
-                        * f64::from(sample_rate.get()))
-                    .round() as usize;
-
-                    if frame < proc_info.frames {
-                        Some(frame)
-                    } else {
-                        None
-                    }
-                }
-            }
-            EventInstant::Samples(samples) => {
-                if *samples <= proc_info.clock_samples.start {
-                    Some(0)
-                } else if *samples >= proc_info.clock_samples.end {
-                    None
-                } else {
-                    Some((*samples - proc_info.clock_samples.start).0 as usize)
-                }
-            }
-            EventInstant::Musical(musical) => {
-                let Some(transport_info) = &proc_info.transport_info else {
-                    return None;
-                };
-
-                if !transport_info.playing || *musical > transport_info.clock_musical.end {
-                    return None;
-                } else if *musical <= transport_info.clock_musical.start {
-                    return Some(0);
-                }
-
-                let frames = (transport_info.transport.musical_to_samples(
-                    *musical,
-                    transport_info.start_clock_samples.unwrap(),
-                    proc_info.sample_rate,
-                ) - proc_info.clock_samples.start)
-                    .0
-                    .max(0) as usize;
-
-                if frames < proc_info.frames {
-                    Some(frames as usize)
-                } else {
-                    None
-                }
-            }
-        }
     }
 }
 
@@ -164,11 +92,46 @@ impl Diff for EventInstant {
 impl Patch for EventInstant {
     type Patch = Self;
 
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+    fn patch(data: ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
         match data {
-            ParamData::InstantSeconds(s) => Ok(EventInstant::Seconds(*s)),
-            ParamData::InstantSamples(s) => Ok(EventInstant::Samples(*s)),
-            ParamData::InstantMusical(s) => Ok(EventInstant::Musical(*s)),
+            ParamData::InstantSeconds(s) => Ok(EventInstant::Seconds(s)),
+            ParamData::InstantSamples(s) => Ok(EventInstant::Samples(s)),
+            ParamData::InstantMusical(s) => Ok(EventInstant::Musical(s)),
+            _ => Err(crate::diff::PatchError::InvalidData),
+        }
+    }
+
+    fn apply(&mut self, patch: Self::Patch) {
+        *self = patch;
+    }
+}
+
+impl Diff for Option<EventInstant> {
+    fn diff<E: crate::diff::EventQueue>(
+        &self,
+        baseline: &Self,
+        path: crate::diff::PathBuilder,
+        event_queue: &mut E,
+    ) {
+        if self != baseline {
+            match self {
+                Some(EventInstant::Seconds(s)) => event_queue.push_param(*s, path),
+                Some(EventInstant::Samples(s)) => event_queue.push_param(*s, path),
+                Some(EventInstant::Musical(m)) => event_queue.push_param(*m, path),
+                None => event_queue.push_param(ParamData::None, path),
+            }
+        }
+    }
+}
+
+impl Patch for Option<EventInstant> {
+    type Patch = Self;
+
+    fn patch(data: ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
+        match data {
+            ParamData::InstantSeconds(s) => Ok(Some(EventInstant::Seconds(s))),
+            ParamData::InstantSamples(s) => Ok(Some(EventInstant::Samples(s))),
+            ParamData::InstantMusical(s) => Ok(Some(EventInstant::Musical(s))),
             _ => Err(crate::diff::PatchError::InvalidData),
         }
     }
@@ -223,31 +186,6 @@ impl InstantSeconds {
     }
 }
 
-impl Diff for InstantSeconds {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self, path);
-        }
-    }
-}
-
-impl Patch for InstantSeconds {
-    type Patch = Self;
-
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
-        data.try_into()
-    }
-
-    fn apply(&mut self, patch: Self::Patch) {
-        *self = patch;
-    }
-}
-
 /// An audio clock duration in units of seconds.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
@@ -262,31 +200,6 @@ impl DurationSeconds {
 
     pub fn to_samples(self, sample_rate: NonZeroU32) -> DurationSamples {
         DurationSamples(seconds_to_samples(self.0, sample_rate))
-    }
-}
-
-impl Diff for DurationSeconds {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self, path);
-        }
-    }
-}
-
-impl Patch for DurationSeconds {
-    type Patch = Self;
-
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
-        data.try_into()
-    }
-
-    fn apply(&mut self, patch: Self::Patch) {
-        *self = patch;
     }
 }
 
@@ -413,6 +326,7 @@ pub struct InstantSamples(pub i64);
 
 impl InstantSamples {
     pub const ZERO: Self = Self(0);
+    pub const MAX: Self = Self(i64::MAX);
 
     pub const fn new(samples: i64) -> Self {
         Self(samples)
@@ -462,31 +376,6 @@ impl InstantSamples {
     }
 }
 
-impl Diff for InstantSamples {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self, path);
-        }
-    }
-}
-
-impl Patch for InstantSamples {
-    type Patch = Self;
-
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
-        data.try_into()
-    }
-
-    fn apply(&mut self, patch: Self::Patch) {
-        *self = patch;
-    }
-}
-
 /// An audio clock duration in units of samples (in a single channel of audio).
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -510,31 +399,6 @@ impl DurationSamples {
 
     pub fn to_seconds(self, sample_rate: NonZeroU32, sample_rate_recip: f64) -> DurationSeconds {
         DurationSeconds(samples_to_seconds(self.0, sample_rate, sample_rate_recip))
-    }
-}
-
-impl Diff for DurationSamples {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self, path);
-        }
-    }
-}
-
-impl Patch for DurationSamples {
-    type Patch = Self;
-
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
-        data.try_into()
-    }
-
-    fn apply(&mut self, patch: Self::Patch) {
-        *self = patch;
     }
 }
 
@@ -719,31 +583,6 @@ impl InstantMusical {
     }
 }
 
-impl Diff for InstantMusical {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self, path);
-        }
-    }
-}
-
-impl Patch for InstantMusical {
-    type Patch = Self;
-
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
-        data.try_into()
-    }
-
-    fn apply(&mut self, patch: Self::Patch) {
-        *self = patch;
-    }
-}
-
 /// An audio clock duration in units of musical beats.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
@@ -754,31 +593,6 @@ impl DurationMusical {
 
     pub const fn new(beats: f64) -> Self {
         Self(beats)
-    }
-}
-
-impl Diff for DurationMusical {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self, path);
-        }
-    }
-}
-
-impl Patch for DurationMusical {
-    type Patch = Self;
-
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
-        data.try_into()
-    }
-
-    fn apply(&mut self, patch: Self::Patch) {
-        *self = patch;
     }
 }
 
@@ -1016,6 +830,16 @@ pub struct ProcTransportInfo {
     /// each frame, and if this is `-0.1`, then the bpm decreased by `0.1`
     /// each frame.
     pub delta_beats_per_minute: f64,
+}
+
+impl ProcTransportInfo {
+    /// Get the BPM at the given frame.
+    ///
+    /// Returns `None` if `frame >= self.frames`.
+    pub fn bpm_at_frame(&self, frame: usize) -> Option<f64> {
+        (frame < self.frames)
+            .then(|| self.beats_per_minute + (self.delta_beats_per_minute * frame as f64))
+    }
 }
 
 /// A musical transport with a single static tempo in beats per minute.

--- a/crates/firewheel-core/src/diff/collections.rs
+++ b/crates/firewheel-core/src/diff/collections.rs
@@ -16,7 +16,7 @@ macro_rules! sequence_diff {
         impl<$gen: Patch> Patch for $ty {
             type Patch = (usize, $gen::Patch);
 
-            fn patch(data: &ParamData, path: &[u32]) -> Result<Self::Patch, PatchError> {
+            fn patch(data: ParamData, path: &[u32]) -> Result<Self::Patch, PatchError> {
                 let first = *path.first().ok_or(PatchError::InvalidPath)?;
                 let inner = $gen::patch(data, &path[1..])?;
 
@@ -45,7 +45,7 @@ impl<T: Diff, const LEN: usize> Diff for [T; LEN] {
 impl<T: Patch, const LEN: usize> Patch for [T; LEN] {
     type Patch = (usize, T::Patch);
 
-    fn patch(data: &ParamData, path: &[u32]) -> Result<Self::Patch, PatchError> {
+    fn patch(data: ParamData, path: &[u32]) -> Result<Self::Patch, PatchError> {
         let first = *path.first().ok_or(PatchError::InvalidPath)? as usize;
         if first >= LEN {
             return Err(PatchError::InvalidPath);
@@ -82,7 +82,7 @@ macro_rules! tuple_diff {
         impl<$($gen: Patch),*> Patch for ($($gen,)*) {
             type Patch = $tup<$($gen),*>;
 
-            fn patch(data: &ParamData, path: &[u32]) -> Result<Self::Patch, PatchError> {
+            fn patch(data: ParamData, path: &[u32]) -> Result<Self::Patch, PatchError> {
                 match path {
                     $(
                         [$index, tail @ ..] => Ok($tup::$gen($gen::patch(data, tail)?)),

--- a/crates/firewheel-core/src/diff/mod.rs
+++ b/crates/firewheel-core/src/diff/mod.rs
@@ -423,7 +423,7 @@ impl core::ops::Deref for ParamPath {
 ///         mut events: NodeEventList,
 ///     ) -> ProcessStatus {
 ///         // Synchronize `params` from the event list.
-///         events.for_each_patch::<MyParams>(|patch| self.params.apply(patch));
+///         events.for_each_patch::<MyParams>(|patch| self.params.apply(patch.event));
 ///
 ///         // ...
 ///
@@ -455,7 +455,7 @@ impl core::ops::Deref for ParamPath {
 ///         events.for_each_patch::<MyParams>(|mut patch| {
 ///             // When you derive `Patch`, it creates an enum with variants
 ///             // for each field.
-///             match &mut patch {
+///             match &mut patch.event {
 ///                 MyParamsPatch::A(a) => {
 ///                     // You can mutate the patch itself if you want
 ///                     // to constrain or modify values.
@@ -465,7 +465,7 @@ impl core::ops::Deref for ParamPath {
 ///             }
 ///
 ///             // And / or apply it directly.
-///             self.params.apply(patch);
+///             self.params.apply(patch.event);
 ///         });
 ///
 ///         // ...
@@ -563,7 +563,7 @@ pub trait Patch {
     /// let mut filter_params = FilterParams::default();
     ///
     /// event_list.for_each(|e| {
-    ///     match e {
+    ///     match e.event {
     ///         NodeEventType::Param { data, path } => {
     ///             let Ok(patch) = FilterParams::patch(data, path) else {
     ///                 return;
@@ -617,7 +617,7 @@ pub trait Patch {
     /// }
     ///
     /// let mut filter_params = FilterParams::default();
-    /// event_list.for_each_patch::<FilterParams>(|patch| filter_params.apply(patch));
+    /// event_list.for_each_patch::<FilterParams>(|patch| filter_params.apply(patch.event));
     /// # }
     /// ```
     ///

--- a/crates/firewheel-core/src/diff/mod.rs
+++ b/crates/firewheel-core/src/diff/mod.rs
@@ -201,6 +201,8 @@
 //! However, if your invariants are safety-critical, you _must_
 //! implement [`Patch`] manually.
 
+use bevy_platform::sync::Arc;
+
 use crate::{
     collector::ArcGc,
     event::{NodeEventType, ParamData},
@@ -217,7 +219,7 @@ pub use memo::Memo;
 pub use notify::Notify;
 
 /// Derive macros for diffing and patching.
-pub use firewheel_macros::{Diff, Patch};
+pub use firewheel_macros::{Diff, Patch, RealtimeClone};
 
 /// Fine-grained parameter diffing.
 ///
@@ -367,7 +369,7 @@ pub trait Diff {
 }
 
 /// A path of indices that uniquely describes an arbitrarily nested field.
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum ParamPath {
     /// A path of one element.
     ///
@@ -377,7 +379,7 @@ pub enum ParamPath {
     /// When paths are more than one element, this variant keeps
     /// the stack size to two pointers while avoiding double-indirection
     /// in the range 2..=4.
-    Multi(ArcGc<SmallVec<[u32; 4]>>),
+    Multi(ArcGc<[u32]>),
 }
 
 impl core::ops::Deref for ParamPath {
@@ -587,15 +589,15 @@ pub trait Patch {
     /// });
     /// # }
     /// ```
-    fn patch(data: &ParamData, path: &[u32]) -> Result<Self::Patch, PatchError>;
+    fn patch(data: ParamData, path: &[u32]) -> Result<Self::Patch, PatchError>;
 
     /// Construct a patch from a node event.
     ///
     /// This is a convenience wrapper around [`patch`][Patch::patch], discarding
     /// errors and node events besides [`NodeEventType::Param`].
-    fn patch_event(event: &NodeEventType) -> Option<Self::Patch> {
+    fn patch_event(event: NodeEventType) -> Option<Self::Patch> {
         match event {
-            NodeEventType::Param { data, path } => Some(Self::patch(data, path).ok()?),
+            NodeEventType::Param { data, path } => Some(Self::patch(data, &path).ok()?),
             _ => None,
         }
     }
@@ -624,6 +626,14 @@ pub trait Patch {
     /// [`for_each_patch`]: crate::event::NodeEventList::for_each_patch
     fn apply(&mut self, patch: Self::Patch);
 }
+
+/// A trait which signifies that a struct implements `Clone`, cloning
+/// does not allocate or deallocate data, and the data will not be
+/// dropped on the audio thread if the struct is dropped.
+pub trait RealtimeClone: Clone {}
+
+//impl<T: Copy> RealtimeClone for T {}
+impl<T: ?Sized + Send + Sync + 'static> RealtimeClone for ArcGc<T> {}
 
 // NOTE: Using a `SmallVec` instead of a `Box<[u32]>` yields
 // around an 8% performance uplift for cases where the path
@@ -669,7 +679,7 @@ impl PathBuilder {
         if self.0.len() == 1 {
             ParamPath::Single(self.0[0])
         } else {
-            ParamPath::Multi(ArcGc::new(self.0.clone()))
+            ParamPath::Multi(ArcGc::new_unsized(|| Arc::<[u32]>::from(self.0.as_slice())))
         }
     }
 }
@@ -731,7 +741,7 @@ mod test {
 
         assert_eq!(patches.len(), 1);
 
-        for patch in &patches {
+        for patch in patches {
             let patch = StructDiff::patch_event(patch).unwrap();
 
             assert!(matches!(patch, StructDiffPatch::A(a) if a == 0.5));
@@ -758,7 +768,7 @@ mod test {
         value.diff(&baseline, PathBuilder::default(), &mut messages);
 
         assert_eq!(messages.len(), 1);
-        baseline.apply(DiffingExample::patch_event(&messages[0]).unwrap());
+        baseline.apply(DiffingExample::patch_event(messages.pop().unwrap()).unwrap());
         assert_eq!(baseline, value);
     }
 
@@ -771,7 +781,7 @@ mod test {
         value.diff(&baseline, PathBuilder::default(), &mut messages);
 
         assert_eq!(messages.len(), 1);
-        baseline.apply(DiffingExample::patch_event(&messages[0]).unwrap());
+        baseline.apply(DiffingExample::patch_event(messages.pop().unwrap()).unwrap());
         assert_eq!(baseline, value);
     }
 }

--- a/crates/firewheel-core/src/dsp/volume.rs
+++ b/crates/firewheel-core/src/dsp/volume.rs
@@ -1,11 +1,6 @@
 pub const DEFAULT_AMP_EPSILON: f32 = 0.00001;
 pub const DEFAULT_DB_EPSILON: f32 = -100.0;
 
-use crate::{
-    diff::{Diff, Patch},
-    event::ParamData,
-};
-
 /// A value representing a volume (gain) applied to an audio signal.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Volume {
@@ -116,31 +111,6 @@ impl Volume {
 impl Default for Volume {
     fn default() -> Self {
         Self::UNITY_GAIN
-    }
-}
-
-impl Diff for Volume {
-    fn diff<E: crate::diff::EventQueue>(
-        &self,
-        baseline: &Self,
-        path: crate::diff::PathBuilder,
-        event_queue: &mut E,
-    ) {
-        if self != baseline {
-            event_queue.push_param(*self, path);
-        }
-    }
-}
-
-impl Patch for Volume {
-    type Patch = Self;
-
-    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, crate::diff::PatchError> {
-        data.try_into()
-    }
-
-    fn apply(&mut self, patch: Self::Patch) {
-        *self = patch;
     }
 }
 

--- a/crates/firewheel-core/src/event.rs
+++ b/crates/firewheel-core/src/event.rs
@@ -7,9 +7,10 @@ use crate::{
         DurationMusical, DurationSamples, DurationSeconds, EventInstant, InstantMusical,
         InstantSamples, InstantSeconds,
     },
-    diff::ParamPath,
+    collector::{ArcGc, OwnedGc},
+    diff::{Notify, ParamPath},
     dsp::volume::Volume,
-    node::{NodeID, ProcInfo},
+    node::NodeID,
 };
 
 /// An event sent to an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
@@ -23,6 +24,14 @@ pub struct NodeEvent {
     pub event: NodeEventType,
 }
 
+impl NodeEvent {
+    pub const DUMMY: Self = Self {
+        node_id: NodeID::DANGLING,
+        time: None,
+        event: NodeEventType::Dummy,
+    };
+}
+
 /// An event type associated with an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
 #[non_exhaustive]
 pub enum NodeEventType {
@@ -32,46 +41,103 @@ pub enum NodeEventType {
         /// The path to the parameter.
         path: ParamPath,
     },
-    /// Custom event type.
-    Custom(Box<dyn Any + Send + Sync>),
+    /// Custom event type stored on the heap.
+    Custom(OwnedGc<Box<dyn Any + Send + 'static>>),
     /// Custom event type stored on the stack as raw bytes.
-    CustomBytes([u8; 16]),
+    CustomBytes([u8; 36]),
+    /// Event which does nothing. Used internally.
+    Dummy,
+}
+
+impl NodeEventType {
+    pub fn custom<T: Send + 'static>(value: T) -> Self {
+        Self::Custom(OwnedGc::new(Box::new(value)))
+    }
+
+    /// Try to downcast the custom event to an immutable reference to `T`.
+    ///
+    /// If this does not contain [`NodeEventType::Custom`] or if the
+    /// downcast failed, then this returns `None`.
+    pub fn downcast_ref<T: Send + 'static>(&self) -> Option<&T> {
+        if let Self::Custom(owned) = self {
+            owned.downcast_ref()
+        } else {
+            None
+        }
+    }
+
+    /// Try to downcast the custom event to a mutable reference to `T`.
+    ///
+    /// If this does not contain [`NodeEventType::Custom`] or if the
+    /// downcast failed, then this returns `None`.
+    pub fn downcast_mut<T: Send + 'static>(&mut self) -> Option<&mut T> {
+        if let Self::Custom(owned) = self {
+            owned.downcast_mut()
+        } else {
+            None
+        }
+    }
 }
 
 /// Data that can be used to patch an individual parameter.
-///
-/// The [`ParamData::Any`] variant is double-boxed to keep
-/// its size small on the stack.
 #[non_exhaustive]
 pub enum ParamData {
-    Volume(Volume),
     F32(f32),
     F64(f64),
     I32(i32),
     U32(u32),
+    I64(i64),
     U64(u64),
     Bool(bool),
+    Volume(Volume),
     Vector2D(Vec2),
     Vector3D(Vec3),
+
+    NotifyF32(Notify<f32>),
+    NotifyF64(Notify<f64>),
+    NotifyI32(Notify<i32>),
+    NotifyU32(Notify<u32>),
+    NotifyI64(Notify<i64>),
+    NotifyU64(Notify<u64>),
+    NotifyBool(Notify<bool>),
+
+    EventInstant(EventInstant),
     InstantSeconds(InstantSeconds),
     DurationSeconds(DurationSeconds),
     InstantSamples(InstantSamples),
     DurationSamples(DurationSamples),
     InstantMusical(InstantMusical),
     DurationMusical(DurationMusical),
-    Any(Box<Box<dyn Any + Send + Sync>>),
+
+    /// Custom type stored on the heap.
+    Any(ArcGc<dyn Any + Send + Sync>),
+
+    /// Custom type stored on the stack as raw bytes.
+    CustomBytes([u8; 20]),
+
+    /// No data (i.e. the type is `None`).
+    None,
 }
 
 impl ParamData {
     /// Construct a [`ParamData::Any`] variant.
-    pub fn any<T: Any + Send + Sync>(value: T) -> Self {
-        Self::Any(Box::new(Box::new(value)))
+    pub fn any<T: Send + Sync + 'static>(value: T) -> Self {
+        Self::Any(ArcGc::new_any(value))
+    }
+
+    /// Construct a [`ParamData::OptAny`] variant.
+    pub fn opt_any<T: Any + Send + Sync + 'static>(value: Option<T>) -> Self {
+        if let Some(value) = value {
+            Self::any(value)
+        } else {
+            Self::None
+        }
     }
 
     /// Try to downcast [`ParamData::Any`] into `T`.
     ///
-    /// If this enum doesn't hold [`ParamData::Any`] or
-    /// the downcast fails, this returns `None`.
+    /// If this enum doesn't hold [`ParamData::Any`] or the downcast fails,
+    /// then this returns `None`.
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         match self {
             Self::Any(any) => any.downcast_ref(),
@@ -88,12 +154,34 @@ macro_rules! param_data_from {
             }
         }
 
-        impl TryInto<$ty> for &ParamData {
+        impl TryInto<$ty> for ParamData {
             type Error = crate::diff::PatchError;
 
             fn try_into(self) -> Result<$ty, crate::diff::PatchError> {
                 match self {
-                    ParamData::$variant(value) => Ok(*value),
+                    ParamData::$variant(value) => Ok(value),
+                    _ => Err(crate::diff::PatchError::InvalidData),
+                }
+            }
+        }
+
+        impl From<Option<$ty>> for ParamData {
+            fn from(value: Option<$ty>) -> Self {
+                if let Some(value) = value {
+                    Self::$variant(value)
+                } else {
+                    Self::None
+                }
+            }
+        }
+
+        impl TryInto<Option<$ty>> for ParamData {
+            type Error = crate::diff::PatchError;
+
+            fn try_into(self) -> Result<Option<$ty>, crate::diff::PatchError> {
+                match self {
+                    ParamData::$variant(value) => Ok(Some(value)),
+                    ParamData::None => Ok(None),
                     _ => Err(crate::diff::PatchError::InvalidData),
                 }
             }
@@ -106,10 +194,19 @@ param_data_from!(f32, F32);
 param_data_from!(f64, F64);
 param_data_from!(i32, I32);
 param_data_from!(u32, U32);
+param_data_from!(i64, I64);
 param_data_from!(u64, U64);
 param_data_from!(bool, Bool);
 param_data_from!(Vec2, Vector2D);
 param_data_from!(Vec3, Vector3D);
+param_data_from!(Notify<f32>, NotifyF32);
+param_data_from!(Notify<f64>, NotifyF64);
+param_data_from!(Notify<i32>, NotifyI32);
+param_data_from!(Notify<u32>, NotifyU32);
+param_data_from!(Notify<i64>, NotifyI64);
+param_data_from!(Notify<u64>, NotifyU64);
+param_data_from!(Notify<bool>, NotifyBool);
+param_data_from!(EventInstant, EventInstant);
 param_data_from!(InstantSeconds, InstantSeconds);
 param_data_from!(DurationSeconds, DurationSeconds);
 param_data_from!(InstantSamples, InstantSamples);
@@ -119,31 +216,20 @@ param_data_from!(DurationMusical, DurationMusical);
 
 /// A list of events for an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].
 pub struct NodeEventList<'a> {
-    event_buffer: &'a mut [NodeEvent],
-    indices: &'a [u32],
-}
-
-pub struct ScheduledEvent<E> {
-    pub time: Option<EventInstant>,
-    pub event: E,
-}
-
-impl<E> ScheduledEvent<E> {
-    pub fn before(&self, time: EventInstant, proc_info: &ProcInfo) -> bool {
-        match (
-            time.to_samples(proc_info),
-            self.time.and_then(|time| time.to_samples(proc_info)),
-        ) {
-            (Some(check_time), Some(this_time)) => check_time <= this_time,
-            _ => true,
-        }
-    }
+    immediate_event_buffer: &'a mut [Option<NodeEvent>],
+    scheduled_event_arena: &'a mut [Option<NodeEvent>],
+    indices: &'a mut Vec<NodeEventListIndex>,
 }
 
 impl<'a> NodeEventList<'a> {
-    pub fn new(event_buffer: &'a mut [NodeEvent], indices: &'a [u32]) -> Self {
+    pub fn new(
+        immediate_event_buffer: &'a mut [Option<NodeEvent>],
+        scheduled_event_arena: &'a mut [Option<NodeEvent>],
+        indices: &'a mut Vec<NodeEventListIndex>,
+    ) -> Self {
         Self {
-            event_buffer,
+            immediate_event_buffer,
+            scheduled_event_arena,
             indices,
         }
     }
@@ -152,28 +238,25 @@ impl<'a> NodeEventList<'a> {
         self.indices.len()
     }
 
-    pub fn get_event(&mut self, index: usize) -> Option<ScheduledEvent<&mut NodeEventType>> {
-        self.indices.get(index).map(|idx| {
-            let event = &mut self.event_buffer[*idx as usize];
-            ScheduledEvent {
-                time: event.time,
-                event: &mut event.event,
+    /// Iterate over all events, draining the events from the list.
+    pub fn drain<'b>(&'b mut self) -> impl IntoIterator<Item = NodeEventType> + use<'b> {
+        self.indices.drain(..).map(|i1| match i1 {
+            NodeEventListIndex::Immediate(i2) => {
+                self.immediate_event_buffer[i2 as usize]
+                    .take()
+                    .unwrap()
+                    .event
+            }
+            NodeEventListIndex::Scheduled(i2) => {
+                self.scheduled_event_arena[i2 as usize]
+                    .take()
+                    .unwrap()
+                    .event
             }
         })
     }
 
-    pub fn for_each(&mut self, mut f: impl FnMut(ScheduledEvent<&mut NodeEventType>)) {
-        for &idx in self.indices {
-            if let Some(event) = self.event_buffer.get_mut(idx as usize) {
-                (f)(ScheduledEvent {
-                    time: event.time,
-                    event: &mut event.event,
-                });
-            }
-        }
-    }
-
-    /// Iterate over patches for `T`.
+    /// Iterate over patches for `T`, draining the events from the list.
     ///
     /// ```
     /// # use firewheel_core::{diff::*, event::NodeEventList};
@@ -184,33 +267,39 @@ impl<'a> NodeEventList<'a> {
     ///     quality: f32,
     /// }
     ///
+    /// let mut node = FilterNode::default();
+    ///
     /// // You can match on individual patch variants.
-    /// event_list.for_each_patch::<FilterNode>(|patch| match patch.event {
-    ///     FilterNodePatch::Frequency(frequency) => {}
-    ///     FilterNodePatch::Quality(quality) => {}
-    /// });
+    /// for patch in event_list.iter_patch::<FilterNode>() {
+    ///     match patch {
+    ///         FilterNodePatch::Frequency(frequency) => {
+    ///             node.frequency = frequency;
+    ///         }
+    ///         FilterNodePatch::Quality(quality) => {
+    ///             node.quality = quality;
+    ///         }
+    ///     }
+    /// }
     ///
     /// // Or simply apply all of them.
-    /// let mut node = FilterNode::default();
-    /// event_list.for_each_patch::<FilterNode>(|patch| node.apply(patch.event));
+    /// for patch in event_list.iter_patch::<FilterNode>() { node.apply(patch); }
     /// # }
     /// ```
     ///
     /// Errors produced while constructing patches are simply skipped.
-    pub fn for_each_patch<T: crate::diff::Patch>(
-        &mut self,
-        mut f: impl FnMut(ScheduledEvent<T::Patch>),
-    ) {
-        // Ideally this would parameterise the `FnMut` over some `impl From<PatchEvent<T>>` but it would require a marker trait
-        // for the `diff::Patch::Patch` assoc type to prevent overlapping impls.
-        for &idx in self.indices {
-            if let Some((time, Some(patch))) = self
-                .event_buffer
-                .get_mut(idx as usize)
-                .map(|e| (e.time, T::patch_event(&e.event)))
-            {
-                (f)(ScheduledEvent { time, event: patch });
-            }
-        }
+    pub fn drain_patches<'b, T: crate::diff::Patch>(
+        &'b mut self,
+    ) -> impl IntoIterator<Item = <T as crate::diff::Patch>::Patch> + use<'b, T> {
+        // Ideally this would parameterise the `FnMut` over some `impl From<PatchEvent<T>>`
+        // but it would require a marker trait for the `diff::Patch::Patch` assoc type to
+        // prevent overlapping impls.
+        self.drain().into_iter().filter_map(|e| T::patch_event(e))
     }
+}
+
+/// Used internally by the Firewheel processor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeEventListIndex {
+    Immediate(u32),
+    Scheduled(u32),
 }

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -663,7 +663,7 @@ impl<'a, 'b, 'c, 'd> GetChannels for (&mut ProcBuffers<'a, 'b, 'c, 'd>, Range<us
 /// Helper trait for nodes that want to process scheduled patch events but don't care about the details.
 pub trait SimpleAudioProcessor {
     /// The node type that created this processor, for which the processor should receive patch events for.
-    type Node: crate::diff::Patch;
+    type Params: crate::diff::Patch;
 
     /// Whether a patch will do anything if applied.
     ///
@@ -674,7 +674,7 @@ pub trait SimpleAudioProcessor {
     ///
     /// This is called on the audio thread, and should never allocate/deallocate or perform other non-realtime-safe methods.
     #[inline]
-    fn can_skip_patch(&self, patch: &<Self::Node as crate::diff::Patch>::Patch) -> bool {
+    fn can_skip_patch(&self, patch: &<Self::Params as crate::diff::Patch>::Patch) -> bool {
         let _ = patch;
         false
     }
@@ -683,7 +683,7 @@ pub trait SimpleAudioProcessor {
     ///
     /// This is called on the audio thread, and should never allocate/deallocate or perform other non-realtime-safe methods.
     #[inline]
-    fn apply_patch(&mut self, patch: <Self::Node as crate::diff::Patch>::Patch) {
+    fn apply_patch(&mut self, patch: <Self::Params as crate::diff::Patch>::Patch) {
         let _ = patch;
     }
 
@@ -755,7 +755,7 @@ where
         let mut start = 0;
         let mut status = None;
 
-        events.for_each_patch::<<Self as SimpleAudioProcessor>::Node>(|patch| {
+        events.for_each_patch::<<Self as SimpleAudioProcessor>::Params>(|patch| {
             'process_range: {
                 if let Some(time) = patch.time.and_then(|time| time.to_samples(proc_info)) {
                     if self.can_skip_patch(&patch.event) {

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -1,10 +1,11 @@
 use core::time::Duration;
-use core::{any::Any, fmt::Debug, hash::Hash, num::NonZeroU32, ops::Range};
+use core::{any::Any, fmt::Debug, hash::Hash, num::NonZeroU32};
+use std::ops::Range;
 
-use crate::clock::EventInstant;
+use crate::clock::{DurationSamples, EventInstant, InstantMusical, InstantSeconds};
 use crate::{
     channel_config::{ChannelConfig, ChannelCount},
-    clock::{InstantMusical, InstantSamples, InstantSeconds, MusicalTransport},
+    clock::{InstantSamples, MusicalTransport},
     dsp::declick::DeclickValues,
     event::{NodeEvent, NodeEventList, NodeEventType},
     SilenceMask, StreamInfo,
@@ -34,9 +35,9 @@ impl Default for NodeID {
 pub struct AudioNodeInfo {
     debug_name: &'static str,
     channel_config: ChannelConfig,
-    uses_events: bool,
     call_update_method: bool,
     custom_state: Option<Box<dyn Any>>,
+    latency_frames: u32,
 }
 
 impl AudioNodeInfo {
@@ -48,9 +49,9 @@ impl AudioNodeInfo {
                 num_inputs: ChannelCount::ZERO,
                 num_outputs: ChannelCount::ZERO,
             },
-            uses_events: false,
             call_update_method: false,
             custom_state: None,
+            latency_frames: 0,
         }
     }
 
@@ -66,17 +67,6 @@ impl AudioNodeInfo {
     /// channels.
     pub const fn channel_config(mut self, channel_config: ChannelConfig) -> Self {
         self.channel_config = channel_config;
-        self
-    }
-
-    /// Set to `true` if this node type uses events, `false` otherwise.
-    ///
-    /// Setting to `false` will help the system save some memory by not
-    /// allocating an event buffer for this node.
-    ///
-    /// By default this is set to `false`.
-    pub const fn uses_events(mut self, uses_events: bool) -> Self {
-        self.uses_events = uses_events;
         self
     }
 
@@ -98,16 +88,14 @@ impl AudioNodeInfo {
         self.custom_state = Some(Box::new(custom_state));
         self
     }
-}
 
-/// Information about an [`AudioNode`]. Used internally by the Firewheel context.
-#[derive(Debug)]
-pub struct AudioNodeInfoInner {
-    pub debug_name: &'static str,
-    pub channel_config: ChannelConfig,
-    pub uses_events: bool,
-    pub call_update_method: bool,
-    pub custom_state: Option<Box<dyn Any>>,
+    /// Set the latency of this node in frames (samples in a single channel of audio).
+    ///
+    /// By default this is set to `0`.
+    pub const fn latency_frames(mut self, latency_frames: u32) -> Self {
+        self.latency_frames = latency_frames;
+        self
+    }
 }
 
 impl Into<AudioNodeInfoInner> for AudioNodeInfo {
@@ -115,11 +103,21 @@ impl Into<AudioNodeInfoInner> for AudioNodeInfo {
         AudioNodeInfoInner {
             debug_name: self.debug_name,
             channel_config: self.channel_config,
-            uses_events: self.uses_events,
             call_update_method: self.call_update_method,
             custom_state: self.custom_state,
+            latency_frames: self.latency_frames,
         }
     }
+}
+
+/// Information about an [`AudioNode`]. Used internally by the Firewheel context.
+#[derive(Debug)]
+pub struct AudioNodeInfoInner {
+    pub debug_name: &'static str,
+    pub channel_config: ChannelConfig,
+    pub call_update_method: bool,
+    pub custom_state: Option<Box<dyn Any>>,
+    pub latency_frames: u32,
 }
 
 /// A trait representing a node in a Firewheel audio graph.
@@ -393,7 +391,7 @@ pub trait AudioNodeProcessor: 'static + Send {
         &mut self,
         buffers: ProcBuffers,
         proc_info: &ProcInfo,
-        events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus;
 
     /// Called when the audio stream has been stopped.
@@ -421,7 +419,7 @@ pub struct ProcBuffers<'a, 'b, 'c, 'd> {
     /// Each channel slice will have a length of [`ProcInfo::frames`].
     pub inputs: &'a [&'b [f32]],
 
-    /// The audio input buffers.
+    /// The audio output buffers.
     ///
     /// The number of channels will always equal the [`ChannelConfig::num_outputs`]
     /// value that was returned in [`AudioNode::info`].
@@ -464,13 +462,10 @@ pub struct ProcInfo<'a> {
     /// division and improve performance.
     pub sample_rate_recip: f64,
 
-    /// The current time of the audio clock, equal to the total number of
-    /// frames (samples in a single channel of audio) that have been
-    /// processed since this Firewheel context was first started.
-    ///
-    /// The start of the range is the instant of time at the first frame
-    /// in the block (inclusive), and the end of the range is the instant
-    /// of time at the end of the block (exclusive).
+    /// The current time of the audio clock at the first frame in this
+    /// processing block, equal to the total number of frames (samples in
+    /// a single channel of audio) that have been processed since this
+    /// Firewheel context was first started.
     ///
     /// Note, this value does *NOT* account for any output underflows
     /// (underruns) that may have occured.
@@ -478,19 +473,7 @@ pub struct ProcInfo<'a> {
     /// Note, generally this value will always count up, but there may be
     /// a few edge cases that cause this value to be less than the previous
     /// block, such as when the sample rate of the stream has been changed.
-    pub clock_samples: Range<InstantSamples>,
-
-    /// The current time of the audio clock, equal to the total amount of
-    /// data in seconds that have been processed since this Firewheel
-    /// context was first started.
-    ///
-    /// The start of the range is the instant of time at the first frame
-    /// in the block (inclusive), and the end of the range is the instant
-    /// of time at the end of the block (exclusive).
-    ///
-    /// Note, this value does *NOT* account for any output underflows
-    /// (underruns) that may have occured.
-    pub clock_seconds: Range<InstantSeconds>,
+    pub clock_samples: InstantSamples,
 
     /// The duration between when the stream was started an when the
     /// Firewheel processor's `process` method was called.
@@ -525,26 +508,113 @@ pub struct ProcInfo<'a> {
     pub declick_values: &'a DeclickValues,
 }
 
-#[derive(Clone)]
-pub struct TransportInfo<'a> {
-    /// The current transport.
-    pub transport: &'a MusicalTransport,
-
-    /// The current time of the musical transport.
-    ///
-    /// The start of the range is the instant of time at the first frame in
-    /// the block (inclusive), and the end of the range is the instant of
-    /// time at the end of the block (exclusive).
-    ///
-    /// This will be `None` if no musical clock is currently present.
+impl<'a> ProcInfo<'a> {
+    /// The current time of the audio clock at the first frame in this
+    /// processing block, equal to the total number of seconds of data that
+    /// have been processed since this Firewheel context was first started.
     ///
     /// Note, this value does *NOT* account for any output underflows
     /// (underruns) that may have occured.
-    pub clock_musical: Range<InstantMusical>,
+    ///
+    /// Note, generally this value will always count up, but there may be
+    /// a few edge cases that cause this value to be less than the previous
+    /// block, such as when the sample rate of the stream has been changed.
+    pub fn clock_seconds(&self) -> InstantSeconds {
+        self.clock_samples
+            .to_seconds(self.sample_rate, self.sample_rate_recip)
+    }
 
-    /// Whether or not the transport is currently playing (true) or paused
-    /// (false).
-    pub playing: bool,
+    /// Get the current time of the audio clock in frames as a range for this
+    /// processing block.
+    pub fn clock_samples_range(&self) -> Range<InstantSamples> {
+        self.clock_samples..self.clock_samples + DurationSamples(self.frames as i64)
+    }
+
+    /// Get the current time of the audio clock in frames as a range for this
+    /// processing block.
+    pub fn clock_seconds_range(&self) -> Range<InstantSeconds> {
+        self.clock_seconds()
+            ..(self.clock_samples + DurationSamples(self.frames as i64))
+                .to_seconds(self.sample_rate, self.sample_rate_recip)
+    }
+
+    /// Get the playhead of the transport at the first frame in this processing
+    /// block.
+    ///
+    /// If there is no active transport, or if the transport is not currently
+    /// playing, then this will return `None`.
+    pub fn playhead(&self) -> Option<InstantMusical> {
+        self.transport_info.as_ref().and_then(|transport_info| {
+            transport_info
+                .start_clock_samples
+                .map(|start_clock_samples| {
+                    transport_info.transport.samples_to_musical(
+                        self.clock_samples,
+                        start_clock_samples,
+                        self.sample_rate,
+                        self.sample_rate_recip,
+                    )
+                })
+        })
+    }
+
+    /// Get the playhead of the transport as a range for this processing
+    /// block.
+    ///
+    /// If there is no active transport, or if the transport is not currently
+    /// playing, then this will return `None`.
+    pub fn playhead_range(&self) -> Option<Range<InstantMusical>> {
+        self.transport_info.as_ref().and_then(|transport_info| {
+            transport_info
+                .start_clock_samples
+                .map(|start_clock_samples| {
+                    transport_info.transport.samples_to_musical(
+                        self.clock_samples,
+                        start_clock_samples,
+                        self.sample_rate,
+                        self.sample_rate_recip,
+                    )
+                        ..transport_info.transport.samples_to_musical(
+                            self.clock_samples + DurationSamples(self.frames as i64),
+                            start_clock_samples,
+                            self.sample_rate,
+                            self.sample_rate_recip,
+                        )
+                })
+        })
+    }
+
+    /// Returns `true` if there is a transport and that transport is playing,
+    /// `false` otherwise.
+    pub fn transport_is_playing(&self) -> bool {
+        self.transport_info
+            .as_ref()
+            .map(|t| t.playing())
+            .unwrap_or(false)
+    }
+
+    /// Converts the given musical time to the corresponding time in samples.
+    ///
+    /// If there is no musical transport or the transport is not currently playing,
+    /// then this will return `None`.
+    pub fn musical_to_samples(&self, musical: InstantMusical) -> Option<InstantSamples> {
+        self.transport_info.as_ref().and_then(|transport_info| {
+            transport_info
+                .start_clock_samples
+                .map(|start_clock_samples| {
+                    transport_info.transport.musical_to_samples(
+                        musical,
+                        start_clock_samples,
+                        self.sample_rate,
+                    )
+                })
+        })
+    }
+}
+
+pub struct TransportInfo<'a> {
+    /// The current transport.
+    pub transport: &'a MusicalTransport,
 
     /// The instant that `MusicaltTime::ZERO` occured in units of
     /// `ClockSamples`.
@@ -565,6 +635,14 @@ pub struct TransportInfo<'a> {
     /// each frame, and if this is `-0.1`, then the bpm decreased by `0.1`
     /// each frame.
     pub delta_bpm_per_frame: f64,
+}
+
+impl<'a> TransportInfo<'a> {
+    /// Whether or not the transport is currently playing (true) or paused
+    /// (false).
+    pub const fn playing(&self) -> bool {
+        self.start_clock_samples.is_some()
+    }
 }
 
 bitflags::bitflags! {
@@ -609,248 +687,5 @@ impl ProcessStatus {
     /// All output buffers were filled with data.
     pub const fn outputs_modified(out_silence_mask: SilenceMask) -> Self {
         Self::OutputsModified { out_silence_mask }
-    }
-}
-
-/// A range of buffers.
-pub struct BufferRange<I, O, S> {
-    /// The number of elements in each channel.
-    pub frames: usize,
-    /// Input buffers.
-    pub inputs: I,
-    /// Output buffers.
-    pub outputs: O,
-    /// Scratch buffers. This is _all_ the scratch buffers, and so may be more than `frames` in length.
-    pub scratch_buffers: S,
-}
-
-/// Trait for reading input, output and scratch buffers.
-///
-/// This is used in [`SimpleAudioProcessor`] to read a range from the input/output buffers.
-pub trait GetChannels {
-    /// Get a range of channels. Should be cheaply callable multiple times.
-    fn channels(
-        &mut self,
-    ) -> BufferRange<
-        impl ExactSizeIterator<Item = &'_ [f32]>,
-        impl ExactSizeIterator<Item = &'_ mut [f32]>,
-        impl ExactSizeIterator<Item = &'_ mut [f32]>,
-    >;
-}
-
-impl<'a, 'b, 'c, 'd> GetChannels for (&mut ProcBuffers<'a, 'b, 'c, 'd>, Range<usize>) {
-    #[inline]
-    fn channels(
-        &mut self,
-    ) -> BufferRange<
-        impl ExactSizeIterator<Item = &'_ [f32]>,
-        impl ExactSizeIterator<Item = &'_ mut [f32]>,
-        impl ExactSizeIterator<Item = &'_ mut [f32]>,
-    > {
-        BufferRange {
-            frames: self.1.len(),
-            inputs: self.0.inputs.iter().map(|chan| &chan[self.1.clone()]),
-            outputs: self
-                .0
-                .outputs
-                .iter_mut()
-                .map(|chan| &mut chan[self.1.clone()]),
-            scratch_buffers: self.0.scratch_buffers.iter_mut().map(|chan| &mut chan[..]),
-        }
-    }
-}
-
-/// Helper trait for nodes that want to process scheduled patch events but don't care about the details.
-pub trait SimpleAudioProcessor {
-    /// The node type that created this processor, for which the processor should receive patch events for.
-    type Params: crate::diff::Patch;
-
-    /// Whether a patch will do anything if applied.
-    ///
-    /// As an optimization, we can skip applying patches that won't actually do anything if applied. It is
-    /// always safe to return `false` from this method, but returning `true` will skip the patch from being
-    /// applied. As a `SimpleAudioProcessor` may process a buffer in chunks if it receives scheduled events,
-    /// returning `true` here may allow it to process larger chunks.
-    ///
-    /// This is called on the audio thread, and should never allocate/deallocate or perform other non-realtime-safe methods.
-    #[inline]
-    fn can_skip_patch(&self, patch: &<Self::Params as crate::diff::Patch>::Patch) -> bool {
-        let _ = patch;
-        false
-    }
-
-    /// Apply a single patch message.
-    ///
-    /// This is called on the audio thread, and should never allocate/deallocate or perform other non-realtime-safe methods.
-    #[inline]
-    fn apply_patch(&mut self, patch: <Self::Params as crate::diff::Patch>::Patch) {
-        let _ = patch;
-    }
-
-    /// Process the given range of audio. Only process data in the
-    /// buffers up to `samples`.
-    ///
-    /// The node *MUST* either return `ProcessStatus::ClearAllOutputs`
-    /// or fill all output buffers with data.
-    ///
-    /// If any output buffers contain all zeros up to `samples` (silent),
-    /// then mark that buffer as silent in [`ProcInfo::out_silence_mask`].
-    ///
-    /// * `buffers` - A range within a buffer to process.
-    /// * `proc_info` - Additional information about the process.
-    fn process<B>(&mut self, buffers: B, info: &ProcInfo) -> ProcessStatus
-    where
-        B: GetChannels;
-
-    /// Called when the audio stream has been stopped.
-    #[inline]
-    fn stream_stopped(&mut self) {}
-
-    /// Called when a new audio stream has been started after a previous
-    /// call to [`AudioNodeProcessor::stream_stopped`].
-    ///
-    /// Note, this method gets called on the main thread, not the audio
-    /// thread. So it is safe to allocate/deallocate here.
-    #[inline]
-    fn new_stream(&mut self, stream_info: &StreamInfo) {
-        let _ = stream_info;
-    }
-}
-
-impl<T> AudioNodeProcessor for T
-where
-    T: SimpleAudioProcessor + Send + 'static,
-{
-    fn process(
-        &mut self,
-        mut buffers: ProcBuffers,
-        proc_info: &ProcInfo,
-        mut events: NodeEventList,
-    ) -> ProcessStatus {
-        /// As a `SimpleAudioProcessor` may handle a buffer period in multiple chunks,
-        /// we need some way to combine the previous and current statuses in order to
-        /// create a status that can be returned from `AudioNodeProcessor::process`.
-        fn combine_statuses(lhs: ProcessStatus, rhs: ProcessStatus) -> ProcessStatus {
-            match (lhs, rhs) {
-                (ProcessStatus::ClearAllOutputs, ProcessStatus::ClearAllOutputs) => {
-                    ProcessStatus::ClearAllOutputs
-                }
-                (ProcessStatus::Bypass, ProcessStatus::Bypass) => ProcessStatus::Bypass,
-                (
-                    ProcessStatus::OutputsModified {
-                        out_silence_mask: mask_a,
-                    },
-                    ProcessStatus::OutputsModified {
-                        out_silence_mask: mask_b,
-                    },
-                ) => ProcessStatus::OutputsModified {
-                    out_silence_mask: SilenceMask(mask_a.0 & mask_b.0),
-                },
-                _ => ProcessStatus::OutputsModified {
-                    out_silence_mask: SilenceMask::NONE_SILENT,
-                },
-            }
-        }
-
-        let mut start = 0;
-        let mut status = None;
-
-        events.for_each_patch::<<Self as SimpleAudioProcessor>::Params>(|patch| {
-            'process_range: {
-                if let Some(time) = patch.time.and_then(|time| time.to_samples(proc_info)) {
-                    if self.can_skip_patch(&patch.event) {
-                        // Optimization: if the patch event applying is a no-op, we can combine this chunk with the next.
-                        // As this only saves time if we need to process a chunk before applying the patch, we only check
-                        // this method here.
-                        return;
-                    }
-
-                    let end = time.0 - proc_info.clock_samples.start.0;
-                    debug_assert!((start as i64..proc_info.frames as i64).contains(&end));
-                    let range = start..end.max(start as i64) as usize;
-
-                    // Multiple events with the same time were scheduled, or the events were
-                    // received out of order.
-                    if range.is_empty() {
-                        break 'process_range;
-                    }
-
-                    // Process the buffer up until the time of the event - we know that the pre-application state
-                    // is valid at least until this event's scheduled time, so we process that chunk before applying
-                    // it.
-                    let result = SimpleAudioProcessor::process(
-                        self,
-                        (&mut buffers, range.clone()),
-                        proc_info,
-                    );
-
-                    let result = if let Some(status) = status {
-                        let combined = combine_statuses(result, status);
-
-                        // If one range returns `Bypass` but another returns `ClearAllOutputs`, we need to handle
-                        // that since the context will no longer know to handle setting the output buffers to
-                        // the relevant data itself.
-                        //
-                        // This should never process the same range of the buffer twice, as if `combined != result`
-                        // then `combined` must be `ProcessStatus::OutputsModified` (see the implementation of
-                        // `combine_statuses`), and so `status` will only be `ProcessStatus::Bypass` or
-                        // `ProcessStatus::ClearAllOutputs` precisely once.
-                        if combined != result {
-                            // We first need to handle the point up until the most-recently-processed range,
-                            // then the most-recently-processed range.
-                            for (status, range) in
-                                [(result, range.clone()), (status, 0..range.start)]
-                            {
-                                let mut buffer_range = (&mut buffers, range);
-                                let buffer_range = buffer_range.channels();
-
-                                match status {
-                                    // Processing this range returned `Bypass`, copy the range verbatim.
-                                    ProcessStatus::Bypass => {
-                                        for (i_chan, o_chan) in
-                                            buffer_range.inputs.zip(buffer_range.outputs)
-                                        {
-                                            o_chan.copy_from_slice(i_chan);
-                                        }
-                                    }
-                                    // Processing this range returned `ClearAllOutputs`, clear the range.
-                                    ProcessStatus::ClearAllOutputs => {
-                                        for o in buffer_range.outputs {
-                                            o.fill(0.);
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-
-                        combined
-                    } else {
-                        result
-                    };
-
-                    status = Some(result);
-                    start = range.end;
-                }
-            }
-
-            self.apply_patch(patch.event);
-        });
-
-        // Finally, process the rest of the buffer using the processor state after all patches have been applied.
-        let result =
-            SimpleAudioProcessor::process(self, (&mut buffers, start..proc_info.frames), proc_info);
-
-        status
-            .map(|status| combine_statuses(status, result))
-            .unwrap_or(result)
-    }
-
-    fn stream_stopped(&mut self) {
-        SimpleAudioProcessor::stream_stopped(self)
-    }
-
-    fn new_stream(&mut self, stream_info: &firewheel_core::StreamInfo) {
-        SimpleAudioProcessor::new_stream(self, stream_info)
     }
 }

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -1,6 +1,7 @@
 use core::time::Duration;
 use core::{any::Any, fmt::Debug, hash::Hash, num::NonZeroU32, ops::Range};
 
+use crate::clock::EventInstant;
 use crate::{
     channel_config::{ChannelConfig, ChannelCount},
     clock::{InstantMusical, InstantSamples, InstantSeconds, MusicalTransport},
@@ -270,6 +271,16 @@ impl<'a> UpdateContext<'a> {
     pub fn queue_event(&mut self, event: NodeEventType) {
         self.event_queue.push(NodeEvent {
             node_id: self.node_id,
+            time: None,
+            event,
+        });
+    }
+
+    /// Queue an event to send to this node's processor counterpart, at a certain time.
+    pub fn schedule_event(&mut self, event: NodeEventType, time: EventInstant) {
+        self.event_queue.push(NodeEvent {
+            node_id: self.node_id,
+            time: Some(time),
             event,
         });
     }

--- a/crates/firewheel-core/src/node/dummy.rs
+++ b/crates/firewheel-core/src/node/dummy.rs
@@ -22,7 +22,6 @@ impl AudioNode for DummyNode {
         AudioNodeInfo::new()
             .debug_name("dummy")
             .channel_config(config.channel_config)
-            .uses_events(false)
     }
 
     fn construct_processor(
@@ -41,7 +40,7 @@ impl AudioNodeProcessor for DummyProcessor {
         &mut self,
         _buffers: ProcBuffers,
         _proc_info: &ProcInfo,
-        _events: NodeEventList,
+        _events: &mut NodeEventList,
     ) -> ProcessStatus {
         ProcessStatus::Bypass
     }

--- a/crates/firewheel-core/src/silence_mask.rs
+++ b/crates/firewheel-core/src/silence_mask.rs
@@ -71,4 +71,12 @@ impl SilenceMask {
             self.0 &= !(0b1 << i);
         }
     }
+
+    pub const fn union(self, other: Self) -> Self {
+        SilenceMask(self.0 & other.0)
+    }
+
+    pub fn union_with(&mut self, other: Self) {
+        self.0 &= other.0;
+    }
 }

--- a/crates/firewheel-core/src/sync_wrapper.rs
+++ b/crates/firewheel-core/src/sync_wrapper.rs
@@ -23,6 +23,13 @@ impl<T> SyncWrapper<T> {
         self.0.take()
     }
 
+    /// Obtain an imutable reference to the inner value.
+    ///
+    /// If `take` has been called previously, this returns `None`.
+    pub fn get(&mut self) -> Option<&T> {
+        self.0.as_ref()
+    }
+
     /// Obtain a mutable reference to the inner value.
     ///
     /// If `take` has been called previously, this returns `None`.

--- a/crates/firewheel-cpal/Cargo.toml
+++ b/crates/firewheel-cpal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewheel-cpal"
-version = "0.5.0-beta.0"
+version = "0.6.0-beta.0"
 description = "cpal backend for Firewheel"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-cpal"
 repository.workspace = true
@@ -20,8 +20,8 @@ resample_inputs = ["fixed-resample/fft-resampler"]
 wasm-bindgen = ["cpal/wasm-bindgen"]
 
 [dependencies]
-firewheel-core = { path = "../firewheel-core", version = "0.5.0-beta.0" }
-firewheel-graph = { path = "../firewheel-graph", version = "0.5.0-beta.0" }
+firewheel-core = { path = "../firewheel-core", version = "0.6.0-beta.0" }
+firewheel-graph = { path = "../firewheel-graph", version = "0.6.0-beta.0" }
 cpal = "0.16.0"
 log.workspace = true
 ringbuf.workspace = true

--- a/crates/firewheel-graph/Cargo.toml
+++ b/crates/firewheel-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewheel-graph"
-version = "0.5.0-beta.0"
+version = "0.6.0-beta.0"
 description = "Core audio graph algorithm and executor for Firewheel"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-graph"
 repository.workspace = true
@@ -16,7 +16,7 @@ exclude.workspace = true
 all-features = true
 
 [dependencies]
-firewheel-core = { path = "../firewheel-core", version = "0.5.0-beta.0" }
+firewheel-core = { path = "../firewheel-core", version = "0.6.0-beta.0" }
 log.workspace = true
 ringbuf.workspace = true
 triple_buffer.workspace = true

--- a/crates/firewheel-graph/src/processor.rs
+++ b/crates/firewheel-graph/src/processor.rs
@@ -1,25 +1,31 @@
-use core::{num::NonZeroU32, ops::Range, time::Duration};
+use core::{num::NonZeroU32, time::Duration};
+use std::usize;
 
-use ringbuf::traits::{Consumer, Producer};
+use ringbuf::traits::Producer;
+use smallvec::SmallVec;
 use thunderdome::Arena;
 
 use crate::{
     backend::AudioBackend,
-    graph::{NodeHeapData, ScheduleHeapData},
+    context::ClearScheduledEventsType,
+    graph::ScheduleHeapData,
+    processor::{
+        event_scheduler::{EventScheduler, NodeEventSchedulerData},
+        transport::ProcTransportState,
+    },
 };
 use firewheel_core::{
-    clock::{
-        DurationSamples, DurationSeconds, InstantMusical, InstantSamples, InstantSeconds,
-        ProcTransportInfo, TransportState,
-    },
+    clock::{InstantMusical, InstantSamples, TransportState},
     dsp::{buffer::ChannelBuffer, declick::DeclickValues},
-    event::{NodeEvent, NodeEventList},
-    node::{
-        AudioNodeProcessor, NodeID, ProcBuffers, ProcInfo, ProcessStatus, StreamStatus,
-        TransportInfo, NUM_SCRATCH_BUFFERS,
-    },
-    SilenceMask, StreamInfo,
+    event::{NodeEvent, NodeEventListIndex},
+    node::{AudioNodeProcessor, NodeID, StreamStatus, NUM_SCRATCH_BUFFERS},
+    StreamInfo,
 };
+
+mod event_scheduler;
+mod handle_messages;
+mod process;
+mod transport;
 
 pub struct FirewheelProcessor<B: AudioBackend> {
     inner: Option<FirewheelProcessorInner<B>>,
@@ -90,7 +96,8 @@ pub(crate) struct FirewheelProcessorInner<B: AudioBackend> {
     from_graph_rx: ringbuf::HeapCons<ContextToProcessorMsg>,
     to_graph_tx: ringbuf::HeapProd<ProcessorToContextMsg>,
 
-    event_buffer: Vec<NodeEvent>,
+    event_scheduler: EventScheduler,
+    node_event_queue: Vec<NodeEventListIndex>,
 
     sample_rate: NonZeroU32,
     sample_rate_recip: f64,
@@ -118,16 +125,24 @@ impl<B: AudioBackend> FirewheelProcessorInner<B> {
         from_graph_rx: ringbuf::HeapCons<ContextToProcessorMsg>,
         to_graph_tx: ringbuf::HeapProd<ProcessorToContextMsg>,
         shared_clock_input: triple_buffer::Input<SharedClock<B::Instant>>,
-        node_capacity: usize,
+        immediate_event_buffer_capacity: usize,
+        scheduled_event_buffer_capacity: usize,
+        node_event_buffer_capacity: usize,
         stream_info: &StreamInfo,
         hard_clip_outputs: bool,
+        buffer_out_of_space_mode: BufferOutOfSpaceMode,
     ) -> Self {
         Self {
-            nodes: Arena::with_capacity(node_capacity * 2),
+            nodes: Arena::new(),
             schedule_data: None,
             from_graph_rx,
             to_graph_tx,
-            event_buffer: Vec::new(),
+            event_scheduler: EventScheduler::new(
+                immediate_event_buffer_capacity,
+                scheduled_event_buffer_capacity,
+                buffer_out_of_space_mode,
+            ),
+            node_event_queue: Vec::with_capacity(node_event_buffer_capacity),
             sample_rate: stream_info.sample_rate,
             sample_rate_recip: stream_info.sample_rate_recip,
             max_block_frames: stream_info.max_block_frames.get() as usize,
@@ -140,413 +155,12 @@ impl<B: AudioBackend> FirewheelProcessorInner<B> {
             poisoned: false,
         }
     }
-
-    // TODO: Add a `process_deinterleaved` method.
-
-    /// Process the given buffers of audio data.
-    fn process_interleaved(
-        &mut self,
-        input: &[f32],
-        output: &mut [f32],
-        num_in_channels: usize,
-        num_out_channels: usize,
-        frames: usize,
-        process_timestamp: B::Instant,
-        duration_since_stream_start: Duration,
-        mut stream_status: StreamStatus,
-        mut dropped_frames: u32,
-    ) {
-        // --- Poll messages ------------------------------------------------------------------
-
-        self.poll_messages();
-
-        // --- Increment the clock for the next process cycle ---------------------------------
-
-        let mut clock_samples = self.clock_samples;
-
-        // The sample clock is ultimately used as the "source of truth".
-        let mut clock_seconds = clock_samples.to_seconds(self.sample_rate, self.sample_rate_recip);
-
-        self.clock_samples += DurationSamples(frames as i64);
-
-        self.sync_shared_clock(Some(process_timestamp));
-
-        // --- Process the audio graph in blocks ----------------------------------------------
-
-        if self.schedule_data.is_none() || frames == 0 {
-            output.fill(0.0);
-            return;
-        };
-
-        assert_eq!(input.len(), frames * num_in_channels);
-        assert_eq!(output.len(), frames * num_out_channels);
-
-        let mut frames_processed = 0;
-        while frames_processed < frames {
-            let mut block_frames = (frames - frames_processed).min(self.max_block_frames);
-
-            let (playhead, proc_transport_info) = self.proc_transport_state.process_block(
-                block_frames,
-                clock_samples,
-                self.sample_rate,
-                self.sample_rate_recip,
-            );
-
-            // If the transport info changes this block, process up to that change.
-            block_frames = proc_transport_info.frames;
-
-            // Prepare graph input buffers.
-            self.schedule_data
-                .as_mut()
-                .unwrap()
-                .schedule
-                .prepare_graph_inputs(
-                    block_frames,
-                    num_in_channels,
-                    |channels: &mut [&mut [f32]]| -> SilenceMask {
-                        firewheel_core::dsp::interleave::deinterleave(
-                            channels,
-                            0,
-                            &input[frames_processed * num_in_channels
-                                ..(frames_processed + block_frames) * num_in_channels],
-                            num_in_channels,
-                            true,
-                        )
-                    },
-                );
-
-            let next_clock_seconds =
-                clock_seconds + DurationSeconds(block_frames as f64 * self.sample_rate_recip);
-
-            self.process_block(
-                block_frames,
-                self.sample_rate,
-                self.sample_rate_recip,
-                self.clock_samples,
-                clock_seconds..next_clock_seconds,
-                duration_since_stream_start,
-                stream_status,
-                dropped_frames,
-                playhead,
-                proc_transport_info,
-            );
-
-            // Copy the output of the graph to the output buffer.
-            self.schedule_data
-                .as_mut()
-                .unwrap()
-                .schedule
-                .read_graph_outputs(
-                    block_frames,
-                    num_out_channels,
-                    |channels: &[&[f32]], silence_mask| {
-                        firewheel_core::dsp::interleave::interleave(
-                            channels,
-                            0,
-                            &mut output[frames_processed * num_out_channels
-                                ..(frames_processed + block_frames) * num_out_channels],
-                            num_out_channels,
-                            Some(silence_mask),
-                        );
-                    },
-                );
-
-            frames_processed += block_frames;
-            clock_samples += DurationSamples(block_frames as i64);
-            clock_seconds = next_clock_seconds;
-            stream_status = StreamStatus::empty();
-            dropped_frames = 0;
-        }
-
-        // --- Hard clip outputs --------------------------------------------------------------
-
-        if self.hard_clip_outputs {
-            for s in output.iter_mut() {
-                *s = s.fract();
-            }
-        }
-
-        // --- Return the allocated event buffer to be reused ---------------------------------
-
-        if self.event_buffer.capacity() > 0 {
-            let mut event_group = Vec::new();
-            core::mem::swap(&mut self.event_buffer, &mut event_group);
-
-            let _ = self
-                .to_graph_tx
-                .try_push(ProcessorToContextMsg::ReturnEventGroup(event_group));
-        }
-    }
-
-    fn poll_messages(&mut self) {
-        for msg in self.from_graph_rx.pop_iter() {
-            match msg {
-                ContextToProcessorMsg::EventGroup(mut event_group) => {
-                    let num_existing_events = self.event_buffer.len();
-
-                    if self.event_buffer.capacity() == 0 {
-                        core::mem::swap(&mut self.event_buffer, &mut event_group);
-                    } else {
-                        self.event_buffer.append(&mut event_group);
-
-                        let _ = self
-                            .to_graph_tx
-                            .try_push(ProcessorToContextMsg::ReturnEventGroup(event_group));
-                    }
-
-                    for (i, event) in self.event_buffer[num_existing_events..].iter().enumerate() {
-                        if let Some(node_entry) = self.nodes.get_mut(event.node_id.0) {
-                            node_entry
-                                .event_indices
-                                .push((i + num_existing_events) as u32);
-                        }
-                    }
-                }
-                ContextToProcessorMsg::NewSchedule(mut new_schedule_data) => {
-                    assert_eq!(
-                        new_schedule_data.schedule.max_block_frames(),
-                        self.max_block_frames
-                    );
-
-                    if let Some(mut old_schedule_data) = self.schedule_data.take() {
-                        core::mem::swap(
-                            &mut old_schedule_data.removed_nodes,
-                            &mut new_schedule_data.removed_nodes,
-                        );
-
-                        for node_id in new_schedule_data.nodes_to_remove.iter() {
-                            if let Some(node_entry) = self.nodes.remove(node_id.0) {
-                                old_schedule_data.removed_nodes.push(NodeHeapData {
-                                    id: *node_id,
-                                    processor: node_entry.processor,
-                                    event_buffer_indices: node_entry.event_indices,
-                                });
-                            }
-                        }
-
-                        let _ = self
-                            .to_graph_tx
-                            .try_push(ProcessorToContextMsg::ReturnSchedule(old_schedule_data));
-                    }
-
-                    for n in new_schedule_data.new_node_processors.drain(..) {
-                        assert!(self
-                            .nodes
-                            .insert_at(
-                                n.id.0,
-                                NodeEntry {
-                                    processor: n.processor,
-                                    event_indices: n.event_buffer_indices,
-                                }
-                            )
-                            .is_none());
-                    }
-
-                    self.schedule_data = Some(new_schedule_data);
-                }
-                ContextToProcessorMsg::HardClipOutputs(hard_clip_outputs) => {
-                    self.hard_clip_outputs = hard_clip_outputs;
-                }
-                ContextToProcessorMsg::SetTransportState(mut new_transport_state) => {
-                    self.proc_transport_state.update(
-                        &mut new_transport_state,
-                        self.clock_samples,
-                        self.sample_rate,
-                        self.sample_rate_recip,
-                    );
-
-                    let _ = self
-                        .to_graph_tx
-                        .try_push(ProcessorToContextMsg::ReturnTransportState(
-                            new_transport_state,
-                        ));
-                }
-            }
-        }
-    }
-
-    fn process_block(
-        &mut self,
-        block_frames: usize,
-        sample_rate: NonZeroU32,
-        sample_rate_recip: f64,
-        clock_samples: InstantSamples,
-        clock_seconds: Range<InstantSeconds>,
-        duration_since_stream_start: Duration,
-        stream_status: StreamStatus,
-        dropped_frames: u32,
-        playhead: InstantMusical,
-        proc_transport_info: ProcTransportInfo,
-    ) {
-        if self.schedule_data.is_none() {
-            return;
-        }
-        let schedule_data = self.schedule_data.as_mut().unwrap();
-
-        let mut scratch_buffers = self.scratch_buffers.get_mut(self.max_block_frames);
-
-        let transport_info = self
-            .proc_transport_state
-            .transport_state
-            .transport
-            .as_ref()
-            .map(|transport| {
-                let end_beat = if *self.proc_transport_state.transport_state.playing {
-                    self.proc_transport_state
-                        .playhead(
-                            clock_samples + DurationSamples(block_frames as i64),
-                            self.sample_rate,
-                            self.sample_rate_recip,
-                        )
-                        .unwrap()
-                } else {
-                    playhead
-                };
-
-                TransportInfo {
-                    clock_musical: playhead..end_beat,
-                    transport,
-                    playing: *self.proc_transport_state.transport_state.playing,
-                    start_clock_samples: self
-                        .proc_transport_state
-                        .transport_state
-                        .playing
-                        .then(|| self.proc_transport_state.start_clock_samples),
-                    beats_per_minute: proc_transport_info.beats_per_minute,
-                    delta_bpm_per_frame: proc_transport_info.delta_beats_per_minute,
-                }
-            });
-
-        let mut proc_info = ProcInfo {
-            frames: block_frames,
-            in_silence_mask: SilenceMask::default(),
-            out_silence_mask: SilenceMask::default(),
-            sample_rate,
-            sample_rate_recip,
-            clock_samples: clock_samples..(clock_samples + DurationSamples(block_frames as i64)),
-            clock_seconds: clock_seconds.clone(),
-            duration_since_stream_start,
-            transport_info,
-            stream_status,
-            dropped_frames,
-            declick_values: &self.declick_values,
-        };
-
-        schedule_data.schedule.process(
-            block_frames,
-            &mut scratch_buffers,
-            |node_id: NodeID,
-             in_silence_mask: SilenceMask,
-             out_silence_mask: SilenceMask,
-             proc_buffers: ProcBuffers|
-             -> ProcessStatus {
-                let Some(node_entry) = self.nodes.get_mut(node_id.0) else {
-                    return ProcessStatus::Bypass;
-                };
-
-                // This should be done when pushing an event, but for the sake of an MVP it's done here.
-                node_entry.event_indices.sort_unstable_by_key(|id| {
-                    self.event_buffer
-                        .get(*id as usize)
-                        .and_then(|ev| ev.time)
-                        .map(|time| time.to_samples(&proc_info))
-                });
-
-                let events = NodeEventList::new(&mut self.event_buffer, &node_entry.event_indices);
-
-                proc_info.in_silence_mask = in_silence_mask;
-                proc_info.out_silence_mask = out_silence_mask;
-
-                let status = node_entry
-                    .processor
-                    .process(proc_buffers, &proc_info, events);
-
-                node_entry.event_indices.clear();
-
-                status
-            },
-        );
-    }
-
-    fn sync_shared_clock(&mut self, process_timestamp: Option<B::Instant>) {
-        let (musical_time, transport_is_playing) = if self
-            .proc_transport_state
-            .transport_state
-            .transport
-            .is_some()
-        {
-            if *self.proc_transport_state.transport_state.playing {
-                (
-                    self.proc_transport_state.playhead(
-                        self.clock_samples,
-                        self.sample_rate,
-                        self.sample_rate_recip,
-                    ),
-                    true,
-                )
-            } else {
-                (
-                    Some(self.proc_transport_state.paused_at_musical_time),
-                    false,
-                )
-            }
-        } else {
-            (None, false)
-        };
-
-        self.shared_clock_input.write(SharedClock {
-            clock_samples: self.clock_samples,
-            musical_time,
-            transport_is_playing,
-            process_timestamp,
-        });
-    }
-
-    fn stream_stopped(&mut self) {
-        self.sync_shared_clock(None);
-
-        for (_, node) in self.nodes.iter_mut() {
-            node.processor.stream_stopped();
-        }
-    }
-
-    /// Called when a new audio stream has been started to replace the old one.
-    ///
-    /// Note, this method gets called on the main thread, not the audio thread.
-    pub(crate) fn new_stream(&mut self, stream_info: &StreamInfo) {
-        for (_, node) in self.nodes.iter_mut() {
-            node.processor.new_stream(stream_info);
-        }
-
-        if self.sample_rate != stream_info.sample_rate {
-            self.clock_samples = self
-                .clock_samples
-                .to_seconds(self.sample_rate, self.sample_rate_recip)
-                .to_samples(stream_info.sample_rate);
-
-            self.proc_transport_state.update_sample_rate(
-                self.sample_rate,
-                self.sample_rate_recip,
-                stream_info.sample_rate,
-            );
-
-            self.sample_rate = stream_info.sample_rate;
-            self.sample_rate_recip = stream_info.sample_rate_recip;
-
-            self.declick_values = DeclickValues::new(stream_info.declick_frames);
-        }
-
-        if self.max_block_frames != stream_info.max_block_frames.get() as usize {
-            self.max_block_frames = stream_info.max_block_frames.get() as usize;
-
-            self.scratch_buffers = ChannelBuffer::new(stream_info.max_block_frames.get() as usize);
-        }
-    }
 }
 
 pub(crate) struct NodeEntry {
     pub processor: Box<dyn AudioNodeProcessor>,
-    pub event_indices: Vec<u32>,
+
+    event_data: NodeEventSchedulerData,
 }
 
 pub(crate) enum ContextToProcessorMsg {
@@ -554,12 +168,20 @@ pub(crate) enum ContextToProcessorMsg {
     NewSchedule(Box<ScheduleHeapData>),
     HardClipOutputs(bool),
     SetTransportState(Box<TransportState>),
+    ClearScheduledEvents(SmallVec<[ClearScheduledEventsEvent; 1]>),
 }
 
 pub(crate) enum ProcessorToContextMsg {
     ReturnEventGroup(Vec<NodeEvent>),
     ReturnSchedule(Box<ScheduleHeapData>),
     ReturnTransportState(Box<TransportState>),
+    ReturnClearScheduledEvents(SmallVec<[ClearScheduledEventsEvent; 1]>),
+}
+
+pub(crate) struct ClearScheduledEventsEvent {
+    /// If `None`, then clear events for all nodes.
+    pub node_id: Option<NodeID>,
+    pub event_type: ClearScheduledEventsType,
 }
 
 #[derive(Clone)]
@@ -581,213 +203,22 @@ impl<I: Clone> Default for SharedClock<I> {
     }
 }
 
-struct ProcTransportState {
-    transport_state: Box<TransportState>,
-    start_clock_samples: InstantSamples,
-    paused_at_clock_samples: InstantSamples,
-    paused_at_musical_time: InstantMusical,
-}
-
-impl ProcTransportState {
-    fn new() -> Self {
-        Self {
-            transport_state: Box::new(TransportState::default()),
-            start_clock_samples: InstantSamples(0),
-            paused_at_clock_samples: InstantSamples(0),
-            paused_at_musical_time: InstantMusical(0.0),
-        }
-    }
-
-    fn playhead(
-        &self,
-        clock_samples: InstantSamples,
-        sample_rate: NonZeroU32,
-        sample_rate_recip: f64,
-    ) -> Option<InstantMusical> {
-        self.transport_state.transport.as_ref().map(|transport| {
-            transport.samples_to_musical(
-                clock_samples,
-                self.start_clock_samples,
-                sample_rate,
-                sample_rate_recip,
-            )
-        })
-    }
-
-    fn update(
-        &mut self,
-        new_transport_state: &mut Box<TransportState>,
-        clock_samples: InstantSamples,
-        sample_rate: NonZeroU32,
-        sample_rate_recip: f64,
-    ) {
-        let mut did_pause = false;
-
-        if let Some(new_transport) = &new_transport_state.transport {
-            if self.transport_state.playhead != new_transport_state.playhead
-                || self.transport_state.transport.is_none()
-            {
-                self.start_clock_samples = new_transport.transport_start(
-                    clock_samples,
-                    *new_transport_state.playhead,
-                    sample_rate,
-                );
-            } else {
-                let old_transport = self.transport_state.transport.as_ref().unwrap();
-
-                if *new_transport_state.playing {
-                    if !*self.transport_state.playing {
-                        // Resume
-                        if old_transport == new_transport {
-                            self.start_clock_samples +=
-                                clock_samples - self.paused_at_clock_samples;
-                        } else {
-                            self.start_clock_samples = new_transport.transport_start(
-                                clock_samples,
-                                self.paused_at_musical_time,
-                                sample_rate,
-                            );
-                        }
-                    } else if old_transport != new_transport {
-                        // Continue where the previous left off
-                        let current_playhead = old_transport.samples_to_musical(
-                            clock_samples,
-                            self.start_clock_samples,
-                            sample_rate,
-                            sample_rate_recip,
-                        );
-                        self.start_clock_samples = new_transport.transport_start(
-                            clock_samples,
-                            current_playhead,
-                            sample_rate,
-                        );
-                    }
-                } else if *self.transport_state.playing {
-                    // Pause
-                    did_pause = true;
-
-                    self.paused_at_clock_samples = clock_samples;
-                    self.paused_at_musical_time = old_transport.samples_to_musical(
-                        clock_samples,
-                        self.start_clock_samples,
-                        sample_rate,
-                        sample_rate_recip,
-                    );
-                }
-            }
-        }
-
-        if !did_pause {
-            self.paused_at_clock_samples = clock_samples;
-            self.paused_at_musical_time = *new_transport_state.playhead;
-        }
-
-        core::mem::swap(new_transport_state, &mut self.transport_state);
-    }
-
-    /// Update the transport
+/// How to handle event buffers on the audio thread running out of space.
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+pub enum BufferOutOfSpaceMode {
+    #[default]
+    /// If an event buffer on the audio thread ran out of space to fit new
+    /// events, reallocate on the audio thread to fit the new items. If this
+    /// happens, it may cause underruns (audio glitches), and a warning will
+    /// be logged.
+    AllocateOnAudioThread,
+    /// If an event buffer on the audio thread ran out of space to fit new
+    /// events, then panic.
+    Panic,
+    /// If an event buffer on the audio thread ran out of space to fit new
+    /// events, drop those events to avoid allocating on the audio thread.
+    /// If this happens, a warning will be logged.
     ///
-    /// Returns (playhead, proc_transport_info)
-    fn process_block(
-        &mut self,
-        frames: usize,
-        clock_samples: InstantSamples,
-        sample_rate: NonZeroU32,
-        sample_rate_recip: f64,
-    ) -> (InstantMusical, ProcTransportInfo) {
-        let Some(transport) = &self.transport_state.transport else {
-            return (
-                InstantMusical::ZERO,
-                ProcTransportInfo {
-                    frames,
-                    beats_per_minute: 0.0,
-                    delta_beats_per_minute: 0.0,
-                },
-            );
-        };
-
-        let mut playhead = transport.samples_to_musical(
-            clock_samples,
-            self.start_clock_samples,
-            sample_rate,
-            sample_rate_recip,
-        );
-        let beats_per_minute = transport.bpm_at_musical(playhead);
-
-        if !*self.transport_state.playing {
-            return (
-                playhead,
-                ProcTransportInfo {
-                    frames,
-                    beats_per_minute,
-                    delta_beats_per_minute: 0.0,
-                },
-            );
-        }
-
-        let mut loop_end_clock_samples = InstantSamples::default();
-        let mut stop_at_clock_samples = InstantSamples::default();
-
-        if let Some(loop_range) = &self.transport_state.loop_range {
-            loop_end_clock_samples =
-                transport.musical_to_samples(loop_range.end, self.start_clock_samples, sample_rate);
-
-            if clock_samples >= loop_end_clock_samples {
-                // Loop back to start of loop.
-                self.start_clock_samples =
-                    transport.transport_start(clock_samples, loop_range.start, sample_rate);
-                playhead = loop_range.start;
-            }
-        } else if let Some(stop_at) = self.transport_state.stop_at {
-            stop_at_clock_samples =
-                transport.musical_to_samples(stop_at, self.start_clock_samples, sample_rate);
-
-            if clock_samples >= stop_at_clock_samples {
-                // Stop the transport.
-                *self.transport_state.playing = false;
-                return (
-                    stop_at,
-                    ProcTransportInfo {
-                        frames,
-                        beats_per_minute,
-                        delta_beats_per_minute: 0.0,
-                    },
-                );
-            }
-        }
-
-        let mut info = transport.proc_transport_info(frames, playhead);
-
-        let proc_end_samples = clock_samples + DurationSamples(info.frames as i64);
-
-        if self.transport_state.loop_range.is_some() {
-            if proc_end_samples > loop_end_clock_samples {
-                // End of the loop reached.
-                info.frames = (loop_end_clock_samples - clock_samples).0.max(0) as usize;
-            }
-        } else if self.transport_state.stop_at.is_some() {
-            if proc_end_samples > stop_at_clock_samples {
-                // End of the transport reached.
-                info.frames = (stop_at_clock_samples - clock_samples).0.max(0) as usize;
-            }
-        }
-
-        (playhead, info)
-    }
-
-    fn update_sample_rate(
-        &mut self,
-        old_sample_rate: NonZeroU32,
-        old_sample_rate_recip: f64,
-        new_sample_rate: NonZeroU32,
-    ) {
-        self.start_clock_samples = self
-            .start_clock_samples
-            .to_seconds(old_sample_rate, old_sample_rate_recip)
-            .to_samples(new_sample_rate);
-        self.paused_at_clock_samples = self
-            .paused_at_clock_samples
-            .to_seconds(old_sample_rate, old_sample_rate_recip)
-            .to_samples(new_sample_rate);
-    }
+    /// (Not generally recommended, but the option is here if you want it.)
+    DropEvents,
 }

--- a/crates/firewheel-graph/src/processor.rs
+++ b/crates/firewheel-graph/src/processor.rs
@@ -444,6 +444,14 @@ impl<B: AudioBackend> FirewheelProcessorInner<B> {
                     return ProcessStatus::Bypass;
                 };
 
+                // This should be done when pushing an event, but for the sake of an MVP it's done here.
+                node_entry.event_indices.sort_unstable_by_key(|id| {
+                    self.event_buffer
+                        .get(*id as usize)
+                        .and_then(|ev| ev.time)
+                        .map(|time| time.to_samples(&proc_info))
+                });
+
                 let events = NodeEventList::new(&mut self.event_buffer, &node_entry.event_indices);
 
                 proc_info.in_silence_mask = in_silence_mask;

--- a/crates/firewheel-graph/src/processor/event_scheduler.rs
+++ b/crates/firewheel-graph/src/processor/event_scheduler.rs
@@ -1,0 +1,679 @@
+use std::{num::NonZeroU32, ops::Range};
+
+use arrayvec::ArrayVec;
+use firewheel_core::{
+    clock::{DurationSamples, EventInstant, InstantSamples, MusicalTransport},
+    event::{NodeEvent, NodeEventList, NodeEventListIndex},
+    node::{NodeID, ProcBuffers, ProcInfo},
+};
+use thunderdome::Arena;
+
+use crate::{
+    context::ClearScheduledEventsType,
+    processor::{BufferOutOfSpaceMode, ClearScheduledEventsEvent, NodeEntry, ProcTransportState},
+};
+
+const MAX_CLUMP_INDICES: usize = 8;
+
+pub(super) struct EventScheduler {
+    immediate_event_buffer: Vec<Option<NodeEvent>>,
+    immediate_event_buffer_capacity: usize,
+
+    // A slab allocator arena for scheduled node events.
+    scheduled_event_arena: Vec<Option<NodeEvent>>,
+    scheduled_event_arena_free_slots: Vec<u32>,
+
+    // Sorting this Vec is much faster than sorting `scheduled_event_arena`
+    // directly since its data type is smaller and it implements `Copy`.
+    sorted_event_buffer_indices: Vec<(u32, InstantSamples)>,
+    scheduled_events_need_sorting: bool,
+    num_elapsed_sorted_events: usize,
+
+    num_scheduled_musical_events: usize,
+    num_scheduled_non_musical_events: usize,
+
+    buffer_out_of_space_mode: BufferOutOfSpaceMode,
+}
+
+impl EventScheduler {
+    pub fn new(
+        immediate_event_buffer_capacity: usize,
+        scheduled_event_buffer_capacity: usize,
+        buffer_out_of_space_mode: BufferOutOfSpaceMode,
+    ) -> Self {
+        let mut scheduled_event_arena = Vec::new();
+        scheduled_event_arena.resize_with(scheduled_event_buffer_capacity, || None);
+
+        Self {
+            immediate_event_buffer: Vec::with_capacity(immediate_event_buffer_capacity),
+            immediate_event_buffer_capacity,
+
+            scheduled_event_arena,
+            scheduled_event_arena_free_slots: (0..scheduled_event_buffer_capacity as u32)
+                .rev()
+                .collect(),
+
+            sorted_event_buffer_indices: Vec::with_capacity(scheduled_event_buffer_capacity),
+            scheduled_events_need_sorting: false,
+            num_scheduled_non_musical_events: 0,
+
+            num_elapsed_sorted_events: 0,
+            num_scheduled_musical_events: 0,
+
+            buffer_out_of_space_mode,
+        }
+    }
+
+    pub fn push_event_group(
+        &mut self,
+        event_group: &mut Vec<NodeEvent>,
+        nodes: &mut Arena<NodeEntry>,
+        sample_rate: NonZeroU32,
+        proc_transport_state: &ProcTransportState,
+    ) {
+        self.truncate_elapsed_events();
+
+        for event in event_group.drain(..) {
+            if let Some(node_entry) = nodes.get_mut(event.node_id.0) {
+                self.push_event(
+                    event,
+                    &mut node_entry.event_data,
+                    sample_rate,
+                    proc_transport_state,
+                );
+            }
+        }
+    }
+
+    fn push_event(
+        &mut self,
+        event: NodeEvent,
+        node_data: &mut NodeEventSchedulerData,
+        sample_rate: NonZeroU32,
+        proc_transport_state: &ProcTransportState,
+    ) {
+        if let Some(event_instant) = event.time {
+            let slot = if let Some(slot) = self.scheduled_event_arena_free_slots.pop() {
+                slot
+            } else {
+                let drop_event = self.extend_scheduled_event_buffer();
+                if drop_event {
+                    return;
+                }
+
+                self.scheduled_event_arena_free_slots.pop().unwrap()
+            };
+
+            let time_samples = match event_instant {
+                EventInstant::Samples(samples) => {
+                    self.num_scheduled_non_musical_events += 1;
+                    node_data.num_scheduled_non_musical_events += 1;
+
+                    samples
+                }
+                EventInstant::Seconds(seconds) => {
+                    self.num_scheduled_non_musical_events += 1;
+                    node_data.num_scheduled_non_musical_events += 1;
+
+                    seconds.to_samples(sample_rate)
+                }
+                EventInstant::Musical(musical) => {
+                    self.num_scheduled_musical_events += 1;
+                    node_data.num_scheduled_musical_events += 1;
+
+                    // Set to `InstantSamples::MAX` to "unschedule" the event.
+                    proc_transport_state
+                        .musical_to_samples(musical, sample_rate)
+                        .unwrap_or(InstantSamples::MAX)
+                }
+            };
+
+            if !self.scheduled_events_need_sorting {
+                if let Some((_, last_instant)) = self.sorted_event_buffer_indices.last() {
+                    if time_samples > *last_instant {
+                        self.scheduled_events_need_sorting = true;
+                    }
+                }
+            }
+
+            self.scheduled_event_arena[slot as usize] = Some(event);
+
+            self.sorted_event_buffer_indices.push((slot, time_samples));
+        } else {
+            if self.immediate_event_buffer.len() == self.immediate_event_buffer_capacity {
+                match self.buffer_out_of_space_mode {
+                    BufferOutOfSpaceMode::AllocateOnAudioThread => {
+                        // TODO: Realtime-safe logging
+                        log::warn!("Firewheel immediate event buffer is full! Please increase FirewheelConfig::immediate_event_capacity to avoid allocations on the audio thread.");
+                    }
+                    BufferOutOfSpaceMode::Panic => {
+                        panic!("Firewheel immediate event buffer is full! Please increase FirewheelConfig::immediate_event_capacity.");
+                    }
+                    BufferOutOfSpaceMode::DropEvents => {
+                        // TODO: Realtime-safe logging
+                        log::warn!(
+                            "Firewheel immediate event buffer is full and event was dropped! Please increase FirewheelConfig::immediate_event_capacity."
+                        );
+                        return;
+                    }
+                }
+            }
+
+            // Because immediate events for a node are likely to be clumped together,
+            // the linear search is optimized by storing the starting index of each
+            // new clump.
+            let is_new_clump = self
+                .immediate_event_buffer
+                .last()
+                .map(|prev_event| prev_event.as_ref().unwrap().node_id != event.node_id)
+                .unwrap_or(true);
+            if is_new_clump {
+                let _ = node_data
+                    .immediate_event_clump_indices
+                    .try_push(self.immediate_event_buffer.len() as u32);
+            }
+
+            node_data.num_immediate_events += 1;
+
+            self.immediate_event_buffer.push(Some(event));
+        }
+    }
+
+    pub fn node_has_scheduled_events(&self, node_entry: &NodeEntry) -> bool {
+        node_entry.event_data.num_scheduled_musical_events > 0
+            || node_entry.event_data.num_scheduled_non_musical_events > 0
+    }
+
+    pub fn remove_events_from_removed_nodes(&mut self, nodes: &Arena<NodeEntry>) {
+        self.truncate_elapsed_events();
+
+        self.sorted_event_buffer_indices.retain(|(event_i, _)| {
+            let event = self.scheduled_event_arena[*event_i as usize]
+                .as_ref()
+                .unwrap();
+
+            if nodes.contains(event.node_id.0) {
+                true
+            } else {
+                if event.time.unwrap().is_musical() {
+                    self.num_scheduled_musical_events -= 1;
+                } else {
+                    self.num_scheduled_non_musical_events -= 1;
+                }
+
+                // Clear any `ArcGc`s this event may have had.
+                self.scheduled_event_arena[*event_i as usize] = None;
+
+                self.scheduled_event_arena_free_slots.push(*event_i);
+
+                false
+            }
+        });
+    }
+
+    pub fn sync_scheduled_events(
+        &mut self,
+        transport_and_start_clock_samples: Option<(&MusicalTransport, InstantSamples)>,
+        sample_rate: NonZeroU32,
+    ) {
+        if self.num_scheduled_musical_events == 0 {
+            return;
+        }
+
+        self.truncate_elapsed_events();
+
+        if let Some((transport, start_clock_samples)) = transport_and_start_clock_samples {
+            for (event_i, time_samples) in self.sorted_event_buffer_indices.iter_mut() {
+                let event = self.scheduled_event_arena[*event_i as usize]
+                    .as_ref()
+                    .unwrap();
+
+                if let Some(EventInstant::Musical(musical)) = event.time {
+                    *time_samples =
+                        transport.musical_to_samples(musical, start_clock_samples, sample_rate);
+                }
+            }
+        } else {
+            for (event_i, time_samples) in self.sorted_event_buffer_indices.iter_mut() {
+                let event = self.scheduled_event_arena[*event_i as usize]
+                    .as_ref()
+                    .unwrap();
+
+                if let Some(EventInstant::Musical(_)) = event.time {
+                    // Set to `MAX` to effectively de-schedule the event.
+                    *time_samples = InstantSamples::MAX;
+                }
+            }
+        }
+
+        self.scheduled_events_need_sorting = true;
+    }
+
+    pub fn handle_clear_scheduled_events_event(
+        &mut self,
+        msgs: &[ClearScheduledEventsEvent],
+        nodes: &mut Arena<NodeEntry>,
+    ) {
+        self.truncate_elapsed_events();
+
+        // TODO: This could be optimized by doing a single linear search and
+        // a hash set.
+        for msg in msgs.iter() {
+            if let Some(node_id) = msg.node_id {
+                let Some(node_entry) = nodes.get(node_id.0) else {
+                    continue;
+                };
+
+                match msg.event_type {
+                    ClearScheduledEventsType::All => {
+                        if node_entry.event_data.num_scheduled_musical_events == 0
+                            && node_entry.event_data.num_scheduled_non_musical_events == 0
+                        {
+                            continue;
+                        }
+                    }
+                    ClearScheduledEventsType::MusicalOnly => {
+                        if node_entry.event_data.num_scheduled_musical_events == 0 {
+                            continue;
+                        }
+                    }
+                    ClearScheduledEventsType::NonMusicalOnly => {
+                        if node_entry.event_data.num_scheduled_non_musical_events == 0 {
+                            continue;
+                        }
+                    }
+                }
+            } else {
+                // Else `None` means to clear scheduled events for all nodes.
+                match msg.event_type {
+                    ClearScheduledEventsType::All => {
+                        if self.num_scheduled_musical_events == 0
+                            && self.num_scheduled_non_musical_events == 0
+                        {
+                            continue;
+                        }
+                    }
+                    ClearScheduledEventsType::MusicalOnly => {
+                        if self.num_scheduled_musical_events == 0 {
+                            continue;
+                        }
+                    }
+                    ClearScheduledEventsType::NonMusicalOnly => {
+                        if self.num_scheduled_non_musical_events == 0 {
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            self.sorted_event_buffer_indices.retain(|(event_i, _)| {
+                let event = self.scheduled_event_arena[*event_i as usize]
+                    .as_ref()
+                    .unwrap();
+
+                if let Some(node_id) = msg.node_id {
+                    if event.node_id != node_id {
+                        return true;
+                    }
+                }
+                // Else `None` means to remove scheduled events for all nodes.
+
+                if event.time.unwrap().is_musical() {
+                    if let ClearScheduledEventsType::NonMusicalOnly = msg.event_type {
+                        return true;
+                    }
+
+                    self.num_scheduled_musical_events -= 1;
+                    nodes[event.node_id.0]
+                        .event_data
+                        .num_scheduled_musical_events -= 1;
+                } else {
+                    if let ClearScheduledEventsType::MusicalOnly = msg.event_type {
+                        return true;
+                    }
+
+                    self.num_scheduled_non_musical_events -= 1;
+                    nodes[event.node_id.0]
+                        .event_data
+                        .num_scheduled_non_musical_events -= 1;
+                }
+
+                // Clear any `ArcGc`s this event may have had.
+                self.scheduled_event_arena[*event_i as usize] = None;
+
+                self.scheduled_event_arena_free_slots.push(*event_i);
+
+                false
+            });
+        }
+    }
+
+    pub fn sample_rate_changed(
+        &mut self,
+        old_sample_rate: NonZeroU32,
+        old_sample_rate_recip: f64,
+        new_sample_rate: NonZeroU32,
+    ) {
+        for (_, time_samples) in self.sorted_event_buffer_indices.iter_mut() {
+            if *time_samples != InstantSamples::MAX {
+                *time_samples = time_samples
+                    .to_seconds(old_sample_rate, old_sample_rate_recip)
+                    .to_samples(new_sample_rate);
+            }
+        }
+    }
+
+    /// Find scheduled events that have elapsed this processing block
+    pub fn prepare_process_block(&mut self, proc_info: &ProcInfo, nodes: &mut Arena<NodeEntry>) {
+        self.sort_events();
+
+        let end_samples = proc_info.clock_samples_range().end;
+
+        for (sorted_i, (event_i, time_samples)) in self
+            .sorted_event_buffer_indices
+            .iter()
+            .enumerate()
+            .skip(self.num_elapsed_sorted_events)
+        {
+            if *time_samples < end_samples {
+                let event = self.scheduled_event_arena[*event_i as usize]
+                    .as_ref()
+                    .unwrap();
+
+                if event.time.unwrap().is_musical() {
+                    self.num_scheduled_musical_events -= 1;
+                } else {
+                    self.num_scheduled_non_musical_events -= 1;
+                }
+
+                self.scheduled_event_arena_free_slots.push(*event_i);
+
+                if let Some(node_entry) = nodes.get_mut(event.node_id.0) {
+                    if node_entry.event_data.num_scheduled_events_this_block == 0 {
+                        // Optimize the linear search a bit by starting at the index
+                        // of the first known scheduled event for this node.
+                        node_entry.event_data.first_sorted_event_index = sorted_i;
+                    }
+
+                    // Keep track of the number of elapsed schedueld events this
+                    // block to further optimize the linear search.
+                    node_entry.event_data.num_scheduled_events_this_block += 1;
+                } else {
+                    self.scheduled_event_arena[*event_i as usize] = None;
+                }
+
+                self.num_elapsed_sorted_events += 1;
+            } else {
+                // The event happens after this processing block, so we are done
+                // searching.
+                break;
+            }
+        }
+    }
+
+    /// Process in sub-chunks for each new scheduled event (or process a single
+    /// chunk if there are no scheduled events).
+    pub fn process_node(
+        &mut self,
+        node_id: NodeID,
+        node_entry: &mut NodeEntry,
+        block_frames: usize,
+        clock_samples: InstantSamples,
+        proc_info: &mut ProcInfo,
+        node_event_queue: &mut Vec<NodeEventListIndex>,
+        mut proc_buffers: ProcBuffers,
+        mut on_sub_chunk: impl FnMut(
+            SubChunkInfo,
+            &mut NodeEntry,
+            &mut ProcInfo,
+            &mut NodeEventList,
+            &mut ProcBuffers,
+        ),
+    ) {
+        let push_event = |node_event_queue: &mut Vec<NodeEventListIndex>,
+                          event: NodeEventListIndex| {
+            if node_event_queue.len() == node_event_queue.capacity() {
+                match self.buffer_out_of_space_mode {
+                    BufferOutOfSpaceMode::AllocateOnAudioThread => {
+                        // TODO: realtime safe logging
+                        log::warn!("Firewheel event queue is full! Please increase FirewheelConfig::event_queue_capacity to avoid allocations on the audio thread.");
+                    }
+                    BufferOutOfSpaceMode::Panic => {
+                        panic!("Firewheel event queue is full! Please increase FirewheelConfig::event_queue_capacity.");
+                    }
+                    BufferOutOfSpaceMode::DropEvents => {
+                        // TODO: realtime safe logging
+                        log::warn!("Firewheel event queue is full and event was dropped! Please increase FirewheelConfig::event_queue_capacity.");
+                    }
+                }
+            }
+
+            node_event_queue.push(event);
+        };
+
+        // Optimize the linear search a bit by starting at the index of the
+        // first known scheduled event for this node.
+        let mut sorted_event_i = node_entry.event_data.first_sorted_event_index;
+
+        let mut sub_clock_samples = clock_samples;
+        let mut frames_processed = 0;
+        while frames_processed < block_frames {
+            let mut sub_chunk_frames = block_frames - frames_processed;
+
+            // Add scheduled events to the processing queue.
+            let mut upcoming_event_i = None;
+            while node_entry.event_data.num_scheduled_events_this_block > 0 {
+                let (event_i, time_samples) = self.sorted_event_buffer_indices[sorted_event_i];
+                let event = self.scheduled_event_arena[event_i as usize]
+                    .as_ref()
+                    .unwrap();
+
+                sorted_event_i += 1;
+
+                if event.node_id != node_id {
+                    continue;
+                }
+
+                node_entry.event_data.num_scheduled_events_this_block -= 1;
+                if event.time.unwrap().is_musical() {
+                    node_entry.event_data.num_scheduled_musical_events -= 1;
+                } else {
+                    node_entry.event_data.num_scheduled_non_musical_events -= 1;
+                }
+
+                if time_samples <= sub_clock_samples {
+                    // If the scheduled event elapses on or before the start of this
+                    // sub-chunk, add it to the processing queue.
+                    push_event(node_event_queue, NodeEventListIndex::Scheduled(event_i));
+                } else {
+                    // Else set the length of this sub-chunk to process up to this event.
+                    // Once this sub-chunk has been processed, add it to the processing
+                    // queue for the next sub-chunk.
+                    sub_chunk_frames =
+                        ((time_samples - sub_clock_samples).0 as usize).min(sub_chunk_frames);
+                    upcoming_event_i = Some(event_i);
+
+                    break;
+                }
+            }
+
+            // If this is the first (or only) sub-chunk, add all of the immediate events
+            // to the processing queue.
+            //
+            // Because immediate events for a node are likely to be clumped together,
+            // the linear search is optimized by storing the starting index of each new
+            // clump.
+            //
+            // Note, this is done after the scheduled events because immediate events
+            // take priority in determining the final state of a node's parameters.
+            for (clump_i, clump_event_start_i) in node_entry
+                .event_data
+                .immediate_event_clump_indices
+                .iter()
+                .enumerate()
+            {
+                push_event(
+                    node_event_queue,
+                    NodeEventListIndex::Immediate(*clump_event_start_i),
+                );
+
+                node_entry.event_data.num_immediate_events -= 1;
+                if node_entry.event_data.num_immediate_events == 0 {
+                    break;
+                }
+
+                for (event_i, event) in self
+                    .immediate_event_buffer
+                    .iter()
+                    .enumerate()
+                    .skip(*clump_event_start_i as usize + 1)
+                    .filter_map(|(event_i, event)| event.as_ref().map(|event| (event_i, event)))
+                {
+                    if event.node_id == node_id {
+                        push_event(
+                            node_event_queue,
+                            NodeEventListIndex::Immediate(event_i as u32),
+                        );
+
+                        node_entry.event_data.num_immediate_events -= 1;
+                        if node_entry.event_data.num_immediate_events == 0 {
+                            break;
+                        }
+                    } else if clump_i
+                        != node_entry.event_data.immediate_event_clump_indices.len() - 1
+                    {
+                        break;
+                    }
+                }
+            }
+            node_entry.event_data.immediate_event_clump_indices.clear();
+
+            let mut node_event_list = NodeEventList::new(
+                &mut self.immediate_event_buffer,
+                &mut self.scheduled_event_arena,
+                node_event_queue,
+            );
+
+            (on_sub_chunk)(
+                SubChunkInfo {
+                    sub_chunk_range: frames_processed..frames_processed + sub_chunk_frames,
+                    sub_clock_samples,
+                },
+                node_entry,
+                proc_info,
+                &mut node_event_list,
+                &mut proc_buffers,
+            );
+
+            // Ensure that all `ArcGc`s have been cleaned up.
+            for event in node_event_list.drain() {
+                let _ = event;
+            }
+
+            node_event_queue.clear();
+
+            // If there was an upcoming scheduled event, add it to the processing queue
+            // for the next sub-chunk.
+            if let Some(event_i) = upcoming_event_i {
+                // Sanity check. There should be no upcoming event if this is the last
+                // sub-chunk.
+                assert_ne!(frames_processed + sub_chunk_frames, block_frames);
+
+                push_event(node_event_queue, NodeEventListIndex::Scheduled(event_i));
+            }
+
+            // Advance to the next sub-chunk.
+            frames_processed += sub_chunk_frames;
+            sub_clock_samples += DurationSamples(sub_chunk_frames as i64);
+        }
+
+        // Sanity check. There should be no scheduled events left.
+        assert_eq!(node_entry.event_data.num_scheduled_events_this_block, 0);
+    }
+
+    /// Clean up event buffers
+    pub fn cleanup_process_block(&mut self) {
+        self.immediate_event_buffer.clear();
+    }
+
+    fn sort_events(&mut self) {
+        if !self.scheduled_events_need_sorting {
+            return;
+        }
+        self.scheduled_events_need_sorting = false;
+
+        self.truncate_elapsed_events();
+
+        // TODO: While sorting here on the audio thread is fine for the general use
+        // case of having only a handful of scheduled events, if the user has
+        // scheduled hundreds or even thousands of events (i.e. they have scheduled
+        // a full music sequence), this may not be the best choice.
+        self.sorted_event_buffer_indices
+            .sort_unstable_by_key(|(_, time_samples)| *time_samples);
+    }
+
+    /// Truncate elapsed event slots from the sorted event buffer.
+    fn truncate_elapsed_events(&mut self) {
+        if self.num_elapsed_sorted_events == 0 {
+            return;
+        }
+
+        self.sorted_event_buffer_indices
+            .copy_within(self.num_elapsed_sorted_events.., 0);
+        self.sorted_event_buffer_indices.resize(
+            self.sorted_event_buffer_indices.len() - self.num_elapsed_sorted_events,
+            Default::default(),
+        );
+
+        self.num_elapsed_sorted_events = 0;
+    }
+
+    /// Returns `true` if the event should be dropped.
+    fn extend_scheduled_event_buffer(&mut self) -> bool {
+        match self.buffer_out_of_space_mode {
+            BufferOutOfSpaceMode::AllocateOnAudioThread => {
+                // TODO: Realtime-safe logging
+                log::warn!("Firewheel scheduled event buffer is full! Please increase FirewheelConfig::scheduled_event_capacity to avoid allocations on the audio thread.");
+
+                let old_len = self.scheduled_event_arena.len();
+
+                self.scheduled_event_arena.resize_with(old_len * 2, || None);
+
+                for i in (old_len as u32..(old_len * 2) as u32).rev() {
+                    self.scheduled_event_arena_free_slots.push(i);
+                }
+
+                self.sorted_event_buffer_indices.reserve(old_len);
+
+                false
+            }
+            BufferOutOfSpaceMode::Panic => {
+                panic!("Firewheel scheduled event buffer is full! Please increase FirewheelConfig::scheduled_event_capacity.");
+            }
+            BufferOutOfSpaceMode::DropEvents => {
+                // TODO: Realtime-safe logging
+                log::warn!("Firewheel scheduled event buffer is full and event was dropped! Please increase FirewheelConfig::scheduled_event_capacity.");
+                true
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct NodeEventSchedulerData {
+    num_immediate_events: usize,
+    /// The index of the first event in a clump of events for this node.
+    /// Events for a single node are likely to be clumped together.
+    immediate_event_clump_indices: ArrayVec<u32, MAX_CLUMP_INDICES>,
+
+    num_scheduled_musical_events: usize,
+    num_scheduled_non_musical_events: usize,
+
+    num_scheduled_events_this_block: usize,
+    first_sorted_event_index: usize,
+}
+
+pub(super) struct SubChunkInfo {
+    pub sub_chunk_range: Range<usize>,
+    pub sub_clock_samples: InstantSamples,
+}

--- a/crates/firewheel-graph/src/processor/handle_messages.rs
+++ b/crates/firewheel-graph/src/processor/handle_messages.rs
@@ -1,0 +1,185 @@
+use firewheel_core::{
+    clock::TransportState,
+    dsp::{buffer::ChannelBuffer, declick::DeclickValues},
+    StreamInfo,
+};
+use ringbuf::traits::{Consumer, Producer};
+
+use crate::{
+    backend::AudioBackend,
+    graph::{NodeHeapData, ScheduleHeapData},
+    processor::{
+        ContextToProcessorMsg, FirewheelProcessorInner, NodeEntry, NodeEventSchedulerData,
+        ProcessorToContextMsg,
+    },
+};
+
+impl<B: AudioBackend> FirewheelProcessorInner<B> {
+    pub fn poll_messages(&mut self) {
+        while let Some(msg) = self.from_graph_rx.try_pop() {
+            match msg {
+                ContextToProcessorMsg::EventGroup(mut event_group) => {
+                    self.event_scheduler.push_event_group(
+                        &mut event_group,
+                        &mut self.nodes,
+                        self.sample_rate,
+                        &self.proc_transport_state,
+                    );
+
+                    let _ = self
+                        .to_graph_tx
+                        .try_push(ProcessorToContextMsg::ReturnEventGroup(event_group));
+                }
+                ContextToProcessorMsg::NewSchedule(new_schedule_data) => {
+                    self.new_schedule(new_schedule_data);
+                }
+                ContextToProcessorMsg::HardClipOutputs(hard_clip_outputs) => {
+                    self.hard_clip_outputs = hard_clip_outputs;
+                }
+                ContextToProcessorMsg::SetTransportState(new_transport_state) => {
+                    self.set_transport_state(new_transport_state);
+                }
+                ContextToProcessorMsg::ClearScheduledEvents(msgs) => {
+                    self.event_scheduler
+                        .handle_clear_scheduled_events_event(&msgs, &mut self.nodes);
+
+                    let _ = self
+                        .to_graph_tx
+                        .try_push(ProcessorToContextMsg::ReturnClearScheduledEvents(msgs));
+                }
+            }
+        }
+    }
+
+    fn new_schedule(&mut self, mut new_schedule_data: Box<ScheduleHeapData>) {
+        assert_eq!(
+            new_schedule_data.schedule.max_block_frames(),
+            self.max_block_frames
+        );
+
+        if let Some(new_arena) = &mut new_schedule_data.new_node_arena {
+            // A new arena with a larger allocated capacity was sent.
+
+            for (index, node_entry) in self.nodes.drain() {
+                let _ = new_arena.insert_at(index, node_entry);
+            }
+
+            core::mem::swap(&mut self.nodes, new_arena);
+        }
+
+        let mut remove_old_scheduled_events = false;
+        if let Some(mut old_schedule_data) = self.schedule_data.take() {
+            core::mem::swap(
+                &mut old_schedule_data.removed_nodes,
+                &mut new_schedule_data.removed_nodes,
+            );
+
+            for node_id in new_schedule_data.nodes_to_remove.iter() {
+                if let Some(node_entry) = self.nodes.remove(node_id.0) {
+                    if self.event_scheduler.node_has_scheduled_events(&node_entry) {
+                        remove_old_scheduled_events = true;
+                    }
+
+                    old_schedule_data.removed_nodes.push(NodeHeapData {
+                        id: *node_id,
+                        processor: node_entry.processor,
+                    });
+                }
+            }
+
+            let _ = self
+                .to_graph_tx
+                .try_push(ProcessorToContextMsg::ReturnSchedule(old_schedule_data));
+        }
+
+        for n in new_schedule_data.new_node_processors.drain(..) {
+            assert!((n.id.0.slot() as usize) < self.nodes.capacity());
+
+            assert!(self
+                .nodes
+                .insert_at(
+                    n.id.0,
+                    NodeEntry {
+                        processor: n.processor,
+                        event_data: NodeEventSchedulerData::default(),
+                    }
+                )
+                .is_none());
+        }
+
+        if remove_old_scheduled_events {
+            self.event_scheduler
+                .remove_events_from_removed_nodes(&self.nodes);
+        }
+
+        self.schedule_data = Some(new_schedule_data);
+    }
+
+    fn set_transport_state(&mut self, new_transport_state: Box<TransportState>) {
+        let old_transport_state = self.proc_transport_state.set_transport_state(
+            new_transport_state,
+            self.clock_samples,
+            self.sample_rate,
+            self.sample_rate_recip,
+        );
+
+        self.event_scheduler.sync_scheduled_events(
+            self.proc_transport_state
+                .transport_and_start_clock_samples(),
+            self.sample_rate,
+        );
+
+        let _ = self
+            .to_graph_tx
+            .try_push(ProcessorToContextMsg::ReturnTransportState(
+                old_transport_state,
+            ));
+    }
+
+    pub fn stream_stopped(&mut self) {
+        self.sync_shared_clock(None);
+
+        for (_, node) in self.nodes.iter_mut() {
+            node.processor.stream_stopped();
+        }
+    }
+
+    /// Called when a new audio stream has been started to replace the old one.
+    ///
+    /// Note, this method gets called on the main thread, not the audio thread.
+    pub fn new_stream(&mut self, stream_info: &StreamInfo) {
+        for (_, node) in self.nodes.iter_mut() {
+            node.processor.new_stream(stream_info);
+        }
+
+        if self.sample_rate != stream_info.sample_rate {
+            self.clock_samples = self
+                .clock_samples
+                .to_seconds(self.sample_rate, self.sample_rate_recip)
+                .to_samples(stream_info.sample_rate);
+
+            self.proc_transport_state.update_sample_rate(
+                self.sample_rate,
+                self.sample_rate_recip,
+                stream_info.sample_rate,
+            );
+
+            self.event_scheduler.sample_rate_changed(
+                self.sample_rate,
+                self.sample_rate_recip,
+                stream_info.sample_rate,
+            );
+
+            self.sample_rate = stream_info.sample_rate;
+            self.sample_rate_recip = stream_info.sample_rate_recip;
+
+            self.declick_values = DeclickValues::new(stream_info.declick_frames);
+        }
+
+        if self.max_block_frames != stream_info.max_block_frames.get() as usize {
+            self.max_block_frames = stream_info.max_block_frames.get() as usize;
+
+            self.scratch_buffers = ChannelBuffer::new(stream_info.max_block_frames.get() as usize);
+        }
+    }
+}

--- a/crates/firewheel-graph/src/processor/process.rs
+++ b/crates/firewheel-graph/src/processor/process.rs
@@ -1,0 +1,395 @@
+use std::{num::NonZeroU32, time::Duration};
+
+use arrayvec::ArrayVec;
+use firewheel_core::{
+    channel_config::MAX_CHANNELS,
+    clock::{DurationSamples, InstantSamples, ProcTransportInfo},
+    event::NodeEventList,
+    node::{NodeID, ProcBuffers, ProcInfo, ProcessStatus, StreamStatus},
+    SilenceMask,
+};
+
+use crate::{
+    backend::AudioBackend,
+    processor::{event_scheduler::SubChunkInfo, FirewheelProcessorInner, NodeEntry, SharedClock},
+};
+
+impl<B: AudioBackend> FirewheelProcessorInner<B> {
+    // TODO: Add a `process_deinterleaved` method.
+
+    /// Process the given buffers of audio data.
+    pub fn process_interleaved(
+        &mut self,
+        input: &[f32],
+        output: &mut [f32],
+        num_in_channels: usize,
+        num_out_channels: usize,
+        frames: usize,
+        process_timestamp: B::Instant,
+        duration_since_stream_start: Duration,
+        mut stream_status: StreamStatus,
+        mut dropped_frames: u32,
+    ) {
+        // --- Poll messages ------------------------------------------------------------------
+
+        self.poll_messages();
+
+        // --- Increment the clock for the next process cycle ---------------------------------
+
+        let mut clock_samples = self.clock_samples;
+
+        self.clock_samples += DurationSamples(frames as i64);
+
+        self.sync_shared_clock(Some(process_timestamp));
+
+        // --- Process the audio graph in blocks ----------------------------------------------
+
+        if self.schedule_data.is_none() || frames == 0 {
+            output.fill(0.0);
+            return;
+        };
+
+        assert_eq!(input.len(), frames * num_in_channels);
+        assert_eq!(output.len(), frames * num_out_channels);
+
+        let mut frames_processed = 0;
+        while frames_processed < frames {
+            let mut block_frames = (frames - frames_processed).min(self.max_block_frames);
+
+            // Get the transport info for this block.
+            let proc_transport_info = self.proc_transport_state.process_block(
+                block_frames,
+                clock_samples,
+                self.sample_rate,
+                self.sample_rate_recip,
+            );
+
+            // If the transport info changes this block, process up to that change.
+            block_frames = proc_transport_info.frames;
+
+            // Prepare graph input buffers.
+            self.schedule_data
+                .as_mut()
+                .unwrap()
+                .schedule
+                .prepare_graph_inputs(
+                    block_frames,
+                    num_in_channels,
+                    |channels: &mut [&mut [f32]]| -> SilenceMask {
+                        firewheel_core::dsp::interleave::deinterleave(
+                            channels,
+                            0,
+                            &input[frames_processed * num_in_channels
+                                ..(frames_processed + block_frames) * num_in_channels],
+                            num_in_channels,
+                            true,
+                        )
+                    },
+                );
+
+            // Process the block.
+            self.process_block(
+                block_frames,
+                self.sample_rate,
+                self.sample_rate_recip,
+                clock_samples,
+                duration_since_stream_start,
+                stream_status,
+                dropped_frames,
+                &proc_transport_info,
+            );
+
+            // Copy the output of the audio graph to the output buffer.
+            self.schedule_data
+                .as_mut()
+                .unwrap()
+                .schedule
+                .read_graph_outputs(
+                    block_frames,
+                    num_out_channels,
+                    |channels: &[&[f32]], silence_mask| {
+                        firewheel_core::dsp::interleave::interleave(
+                            channels,
+                            0,
+                            &mut output[frames_processed * num_out_channels
+                                ..(frames_processed + block_frames) * num_out_channels],
+                            num_out_channels,
+                            Some(silence_mask),
+                        );
+                    },
+                );
+
+            // Advance to the next processing block.
+            frames_processed += block_frames;
+            clock_samples += DurationSamples(block_frames as i64);
+            stream_status = StreamStatus::empty();
+            dropped_frames = 0;
+        }
+
+        // --- Hard clip outputs --------------------------------------------------------------
+
+        if self.hard_clip_outputs {
+            for s in output.iter_mut() {
+                *s = s.fract();
+            }
+        }
+    }
+
+    fn process_block(
+        &mut self,
+        block_frames: usize,
+        sample_rate: NonZeroU32,
+        sample_rate_recip: f64,
+        clock_samples: InstantSamples,
+        duration_since_stream_start: Duration,
+        stream_status: StreamStatus,
+        dropped_frames: u32,
+        proc_transport_info: &ProcTransportInfo,
+    ) {
+        if self.schedule_data.is_none() {
+            return;
+        }
+        let schedule_data = self.schedule_data.as_mut().unwrap();
+
+        // -- Prepare process info ------------------------------------------------------------
+
+        let mut scratch_buffers = self.scratch_buffers.get_mut(self.max_block_frames);
+
+        let transport_info = self
+            .proc_transport_state
+            .transport_info(&proc_transport_info);
+
+        let mut proc_info = ProcInfo {
+            frames: block_frames,
+            in_silence_mask: SilenceMask::default(),
+            out_silence_mask: SilenceMask::default(),
+            sample_rate,
+            sample_rate_recip,
+            clock_samples,
+            duration_since_stream_start,
+            transport_info,
+            stream_status,
+            dropped_frames,
+            declick_values: &self.declick_values,
+        };
+
+        // -- Find scheduled events that have elapsed this block ------------------------------
+
+        self.event_scheduler
+            .prepare_process_block(&proc_info, &mut self.nodes);
+
+        // -- Audio graph node processing closure ---------------------------------------------
+
+        schedule_data.schedule.process(
+            block_frames,
+            &mut scratch_buffers,
+            |node_id: NodeID,
+             in_silence_mask: SilenceMask,
+             out_silence_mask: SilenceMask,
+             proc_buffers|
+             -> ProcessStatus {
+                let node_entry = self.nodes.get_mut(node_id.0).unwrap();
+
+                // Add the silence mask information to proc info.
+                proc_info.in_silence_mask = in_silence_mask;
+                proc_info.out_silence_mask = out_silence_mask;
+
+                // Used to keep track of what status this closure should return.
+                let mut prev_process_status = None;
+                let mut final_silence_mask = None;
+
+                // Process in sub-chunks for each new scheduled event (or process a single
+                // chunk if there are no scheduled events).
+                self.event_scheduler.process_node(
+                    node_id,
+                    node_entry,
+                    block_frames,
+                    clock_samples,
+                    &mut proc_info,
+                    &mut self.node_event_queue,
+                    proc_buffers,
+                    |sub_chunk_info: SubChunkInfo,
+                     node_entry: &mut NodeEntry,
+                     proc_info: &mut ProcInfo,
+                     events: &mut NodeEventList,
+                     proc_buffers: &mut ProcBuffers| {
+                        let SubChunkInfo {
+                            sub_chunk_range,
+                            sub_clock_samples,
+                        } = sub_chunk_info;
+                        let sub_chunk_frames = sub_chunk_range.end - sub_chunk_range.start;
+
+                        // Set the timing information for the process info for this sub-chunk.
+                        proc_info.frames = sub_chunk_frames;
+                        proc_info.clock_samples = sub_clock_samples;
+                        if let Some(transport) = &mut proc_info.transport_info {
+                            // For now this isn't really necessary, but it will be once support
+                            // for linearly automated tempo is added.
+                            transport.beats_per_minute = proc_transport_info
+                                .bpm_at_frame(sub_chunk_range.start)
+                                .unwrap();
+                        }
+
+                        // Call the node's process method.
+                        let process_status = {
+                            if sub_chunk_frames == block_frames {
+                                // If this is the only sub-chunk (because there are no scheduled
+                                // events), there is no need to edit the buffer slices.
+                                let sub_proc_buffers = ProcBuffers {
+                                    inputs: proc_buffers.inputs,
+                                    outputs: proc_buffers.outputs,
+                                    scratch_buffers: proc_buffers.scratch_buffers,
+                                };
+
+                                node_entry
+                                    .processor
+                                    .process(sub_proc_buffers, &proc_info, events)
+                            } else {
+                                // Else if there are multiple sub-chunks, edit the range of each
+                                // buffer slice to cover the range of this sub-chunk.
+
+                                let mut sub_inputs: ArrayVec<&[f32], MAX_CHANNELS> =
+                                    ArrayVec::new();
+                                let mut sub_outputs: ArrayVec<&mut [f32], MAX_CHANNELS> =
+                                    ArrayVec::new();
+
+                                // TODO: We can use unsafe slicing here since we know the range is
+                                // always valid.
+                                for ch in proc_buffers.inputs.iter() {
+                                    sub_inputs.push(&ch[sub_chunk_range.clone()]);
+                                }
+                                for ch in proc_buffers.outputs.iter_mut() {
+                                    sub_outputs.push(&mut ch[sub_chunk_range.clone()]);
+                                }
+
+                                let sub_proc_buffers = ProcBuffers {
+                                    inputs: sub_inputs.as_slice(),
+                                    outputs: sub_outputs.as_mut_slice(),
+                                    // Scratch buffers don't need to change length.
+                                    scratch_buffers: proc_buffers.scratch_buffers,
+                                };
+
+                                node_entry
+                                    .processor
+                                    .process(sub_proc_buffers, &proc_info, events)
+                            }
+                        };
+
+                        // If there are multiple sub-chunks, and the node returned a different process
+                        // status this sub-chunk than the previous sub-chunk, then we must manually
+                        // handle the process statuses.
+                        if final_silence_mask.is_none() {
+                            if let Some(prev_process_status) = prev_process_status {
+                                if prev_process_status != process_status {
+                                    // Handle the process status for the sub-chunk(s) before this
+                                    // sub-chunk.
+                                    match prev_process_status {
+                                        ProcessStatus::ClearAllOutputs => {
+                                            for out_ch in proc_buffers.outputs.iter_mut() {
+                                                out_ch[0..sub_chunk_range.start].fill(0.0);
+                                            }
+
+                                            final_silence_mask = Some(SilenceMask::new_all_silent(
+                                                proc_buffers.outputs.len(),
+                                            ));
+                                        }
+                                        ProcessStatus::Bypass => {
+                                            for (out_ch, in_ch) in proc_buffers
+                                                .outputs
+                                                .iter_mut()
+                                                .zip(proc_buffers.inputs.iter())
+                                            {
+                                                out_ch[0..sub_chunk_range.start].copy_from_slice(
+                                                    &in_ch[0..sub_chunk_range.start],
+                                                );
+                                            }
+                                            for out_ch in proc_buffers
+                                                .outputs
+                                                .iter_mut()
+                                                .skip(proc_buffers.inputs.len())
+                                            {
+                                                out_ch[0..sub_chunk_range.start].fill(0.0);
+                                            }
+
+                                            final_silence_mask = Some(in_silence_mask);
+                                        }
+                                        ProcessStatus::OutputsModified { out_silence_mask } => {
+                                            final_silence_mask = Some(out_silence_mask);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        prev_process_status = Some(process_status);
+
+                        // If we are manually handling process statuses, handle the process status
+                        // for this sub-chunk.
+                        if let Some(final_silence_mask) = &mut final_silence_mask {
+                            match process_status {
+                                ProcessStatus::ClearAllOutputs => {
+                                    for out_ch in proc_buffers.outputs.iter_mut() {
+                                        out_ch[sub_chunk_range.clone()].fill(0.0);
+                                    }
+                                }
+                                ProcessStatus::Bypass => {
+                                    for (out_ch, in_ch) in proc_buffers
+                                        .outputs
+                                        .iter_mut()
+                                        .zip(proc_buffers.inputs.iter())
+                                    {
+                                        out_ch[sub_chunk_range.clone()]
+                                            .copy_from_slice(&in_ch[sub_chunk_range.clone()]);
+                                    }
+                                    for out_ch in proc_buffers
+                                        .outputs
+                                        .iter_mut()
+                                        .skip(proc_buffers.inputs.len())
+                                    {
+                                        out_ch[sub_chunk_range.clone()].fill(0.0);
+                                    }
+
+                                    final_silence_mask.union_with(in_silence_mask);
+                                }
+                                ProcessStatus::OutputsModified { out_silence_mask } => {
+                                    final_silence_mask.union_with(out_silence_mask);
+                                }
+                            }
+                        }
+                    },
+                );
+
+                // -- Done processing in sub-chunks. Return the final process status. ---------
+
+                if let Some(final_silence_mask) = final_silence_mask {
+                    // If we manually handled process statuses, return the calculated silence
+                    // mask.
+                    ProcessStatus::OutputsModified {
+                        out_silence_mask: final_silence_mask,
+                    }
+                } else {
+                    // Else return the process status returned by the node's proces method.
+                    prev_process_status.unwrap()
+                }
+            },
+        );
+
+        // -- Clean up event buffers ----------------------------------------------------------
+
+        self.event_scheduler.cleanup_process_block();
+    }
+
+    pub fn sync_shared_clock(&mut self, process_timestamp: Option<B::Instant>) {
+        let (musical_time, transport_is_playing) = self.proc_transport_state.shared_clock_info(
+            self.clock_samples,
+            self.sample_rate,
+            self.sample_rate_recip,
+        );
+
+        self.shared_clock_input.write(SharedClock {
+            clock_samples: self.clock_samples,
+            musical_time,
+            transport_is_playing,
+            process_timestamp,
+        });
+    }
+}

--- a/crates/firewheel-graph/src/processor/transport.rs
+++ b/crates/firewheel-graph/src/processor/transport.rs
@@ -1,0 +1,261 @@
+use core::num::NonZeroU32;
+
+use firewheel_core::{
+    clock::{
+        DurationSamples, InstantMusical, InstantSamples, MusicalTransport, ProcTransportInfo,
+        TransportState,
+    },
+    node::TransportInfo,
+};
+
+pub(super) struct ProcTransportState {
+    transport_state: Box<TransportState>,
+    start_clock_samples: InstantSamples,
+    paused_at_clock_samples: InstantSamples,
+    paused_at_musical_time: InstantMusical,
+}
+
+impl ProcTransportState {
+    pub fn new() -> Self {
+        Self {
+            transport_state: Box::new(TransportState::default()),
+            start_clock_samples: InstantSamples(0),
+            paused_at_clock_samples: InstantSamples(0),
+            paused_at_musical_time: InstantMusical(0.0),
+        }
+    }
+
+    pub fn musical_to_samples(
+        &self,
+        musical: InstantMusical,
+        sample_rate: NonZeroU32,
+    ) -> Option<InstantSamples> {
+        self.transport_state
+            .transport
+            .as_ref()
+            .filter(|_| *self.transport_state.playing)
+            .map(|transport| {
+                transport.musical_to_samples(musical, self.start_clock_samples, sample_rate)
+            })
+    }
+
+    /// Returns the old transport state
+    pub fn set_transport_state(
+        &mut self,
+        mut new_transport_state: Box<TransportState>,
+        clock_samples: InstantSamples,
+        sample_rate: NonZeroU32,
+        sample_rate_recip: f64,
+    ) -> Box<TransportState> {
+        let mut did_pause = false;
+
+        if let Some(new_transport) = &new_transport_state.transport {
+            if self.transport_state.playhead != new_transport_state.playhead
+                || self.transport_state.transport.is_none()
+            {
+                self.start_clock_samples = new_transport.transport_start(
+                    clock_samples,
+                    *new_transport_state.playhead,
+                    sample_rate,
+                );
+            } else {
+                let old_transport = self.transport_state.transport.as_ref().unwrap();
+
+                if *new_transport_state.playing {
+                    if !*self.transport_state.playing {
+                        // Resume
+                        if old_transport == new_transport {
+                            self.start_clock_samples +=
+                                clock_samples - self.paused_at_clock_samples;
+                        } else {
+                            self.start_clock_samples = new_transport.transport_start(
+                                clock_samples,
+                                self.paused_at_musical_time,
+                                sample_rate,
+                            );
+                        }
+                    } else if old_transport != new_transport {
+                        // Continue where the previous left off
+                        let current_playhead = old_transport.samples_to_musical(
+                            clock_samples,
+                            self.start_clock_samples,
+                            sample_rate,
+                            sample_rate_recip,
+                        );
+                        self.start_clock_samples = new_transport.transport_start(
+                            clock_samples,
+                            current_playhead,
+                            sample_rate,
+                        );
+                    }
+                } else if *self.transport_state.playing {
+                    // Pause
+                    did_pause = true;
+
+                    self.paused_at_clock_samples = clock_samples;
+                    self.paused_at_musical_time = old_transport.samples_to_musical(
+                        clock_samples,
+                        self.start_clock_samples,
+                        sample_rate,
+                        sample_rate_recip,
+                    );
+                }
+            }
+        }
+
+        if !did_pause {
+            self.paused_at_clock_samples = clock_samples;
+            self.paused_at_musical_time = *new_transport_state.playhead;
+        }
+
+        core::mem::swap(&mut new_transport_state, &mut self.transport_state);
+        new_transport_state
+    }
+
+    pub fn process_block(
+        &mut self,
+        frames: usize,
+        clock_samples: InstantSamples,
+        sample_rate: NonZeroU32,
+        sample_rate_recip: f64,
+    ) -> ProcTransportInfo {
+        let Some(transport) = &self.transport_state.transport else {
+            return ProcTransportInfo {
+                frames,
+                beats_per_minute: 0.0,
+                delta_beats_per_minute: 0.0,
+            };
+        };
+
+        let mut playhead = transport.samples_to_musical(
+            clock_samples,
+            self.start_clock_samples,
+            sample_rate,
+            sample_rate_recip,
+        );
+        let beats_per_minute = transport.bpm_at_musical(playhead);
+
+        if !*self.transport_state.playing {
+            return ProcTransportInfo {
+                frames,
+                beats_per_minute,
+                delta_beats_per_minute: 0.0,
+            };
+        }
+
+        let mut loop_end_clock_samples = InstantSamples::default();
+        let mut stop_at_clock_samples = InstantSamples::default();
+
+        if let Some(loop_range) = &self.transport_state.loop_range {
+            loop_end_clock_samples =
+                transport.musical_to_samples(loop_range.end, self.start_clock_samples, sample_rate);
+
+            if clock_samples >= loop_end_clock_samples {
+                // Loop back to start of loop.
+                self.start_clock_samples =
+                    transport.transport_start(clock_samples, loop_range.start, sample_rate);
+                playhead = loop_range.start;
+            }
+        } else if let Some(stop_at) = self.transport_state.stop_at {
+            stop_at_clock_samples =
+                transport.musical_to_samples(stop_at, self.start_clock_samples, sample_rate);
+
+            if clock_samples >= stop_at_clock_samples {
+                // Stop the transport.
+                *self.transport_state.playing = false;
+                return ProcTransportInfo {
+                    frames,
+                    beats_per_minute,
+                    delta_beats_per_minute: 0.0,
+                };
+            }
+        }
+
+        let mut info = transport.proc_transport_info(frames, playhead);
+
+        let proc_end_samples = clock_samples + DurationSamples(info.frames as i64);
+
+        if self.transport_state.loop_range.is_some() {
+            if proc_end_samples > loop_end_clock_samples {
+                // End of the loop reached.
+                info.frames = (loop_end_clock_samples - clock_samples).0.max(0) as usize;
+            }
+        } else if self.transport_state.stop_at.is_some() {
+            if proc_end_samples > stop_at_clock_samples {
+                // End of the transport reached.
+                info.frames = (stop_at_clock_samples - clock_samples).0.max(0) as usize;
+            }
+        }
+
+        info
+    }
+
+    pub fn transport_info(
+        &mut self,
+        proc_transport_info: &ProcTransportInfo,
+    ) -> Option<TransportInfo> {
+        self.transport_state
+            .transport
+            .as_ref()
+            .map(|transport| TransportInfo {
+                transport,
+                start_clock_samples: self
+                    .transport_state
+                    .playing
+                    .then(|| self.start_clock_samples),
+                beats_per_minute: proc_transport_info.beats_per_minute,
+                delta_bpm_per_frame: proc_transport_info.delta_beats_per_minute,
+            })
+    }
+
+    /// Returns (current_playhead, transport_is_playing)
+    pub fn shared_clock_info(
+        &self,
+        clock_samples: InstantSamples,
+        sample_rate: NonZeroU32,
+        sample_rate_recip: f64,
+    ) -> (Option<InstantMusical>, bool) {
+        self.transport_state
+            .transport
+            .as_ref()
+            .map(|transport| {
+                if *self.transport_state.playing {
+                    let current_playhead = transport.samples_to_musical(
+                        clock_samples,
+                        self.start_clock_samples,
+                        sample_rate,
+                        sample_rate_recip,
+                    );
+
+                    (Some(current_playhead), true)
+                } else {
+                    (Some(self.paused_at_musical_time), false)
+                }
+            })
+            .unwrap_or((None, false))
+    }
+
+    /// Returns `Option<transport, start_clock_samples>`.
+    pub fn transport_and_start_clock_samples(&self) -> Option<(&MusicalTransport, InstantSamples)> {
+        self.transport_state
+            .transport
+            .as_ref()
+            .map(|transport| (transport, self.start_clock_samples))
+    }
+
+    pub fn update_sample_rate(
+        &mut self,
+        old_sample_rate: NonZeroU32,
+        old_sample_rate_recip: f64,
+        new_sample_rate: NonZeroU32,
+    ) {
+        self.start_clock_samples = self
+            .start_clock_samples
+            .to_seconds(old_sample_rate, old_sample_rate_recip)
+            .to_samples(new_sample_rate);
+        self.paused_at_clock_samples = self
+            .paused_at_clock_samples
+            .to_seconds(old_sample_rate, old_sample_rate_recip)
+            .to_samples(new_sample_rate);
+    }
+}

--- a/crates/firewheel-macros/Cargo.toml
+++ b/crates/firewheel-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewheel-macros"
-version = "0.1.1"
+version = "0.2.0"
 description = "Macros for Firewheel crates"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-macros"
 repository.workspace = true

--- a/crates/firewheel-macros/src/patch.rs
+++ b/crates/firewheel-macros/src/patch.rs
@@ -92,7 +92,7 @@ pub fn derive_patch(input: TokenStream) -> syn::Result<TokenStream2> {
             type Patch = #patch;
 
             fn patch(
-                data: &#firewheel_path::event::ParamData,
+                data: #firewheel_path::event::ParamData,
                 path: &[u32]
             ) -> #FQResult<Self::Patch, #diff_path::PatchError> {
                 #patch_body

--- a/crates/firewheel-nodes/Cargo.toml
+++ b/crates/firewheel-nodes/Cargo.toml
@@ -58,4 +58,5 @@ bevy_platform.workspace = true
 crossbeam-utils = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 fixed-resample = { version = "0.9.1", features = ["fft-resampler", "channel"], optional = true }
+itertools.workspace = true
 bevy_ecs = { version = "0.16", optional = true }

--- a/crates/firewheel-nodes/Cargo.toml
+++ b/crates/firewheel-nodes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewheel-nodes"
-version = "0.5.0-beta.0"
+version = "0.6.0-beta.0"
 description = "Official factory nodes for the Firewheel audio engine"
 homepage = "https://github.com/BillyDM/firewheel/blob/main/crates/firewheel-nodes"
 repository.workspace = true
@@ -53,7 +53,7 @@ stream = ["dep:fixed-resample"]
 bevy = ["dep:bevy_ecs"]
 
 [dependencies]
-firewheel-core = { path = "../firewheel-core", version = "0.5.0-beta.0" }
+firewheel-core = { path = "../firewheel-core", version = "0.6.0-beta.0" }
 bevy_platform.workspace = true
 crossbeam-utils = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -87,14 +87,14 @@ impl AudioNodeProcessor for Processor {
             return ProcessStatus::ClearAllOutputs;
         };
 
-        events.for_each_patch::<BeepTestNode>(|patch| match patch {
-            BeepTestNodePatch::FreqHz(f) => {
+        events.for_each_patch::<BeepTestNode>(|patch| match &patch.event {
+            &BeepTestNodePatch::FreqHz(f) => {
                 self.phasor_inc = f.clamp(20.0, 20_000.0) * proc_info.sample_rate_recip as f32;
             }
-            BeepTestNodePatch::Volume(v) => {
+            &BeepTestNodePatch::Volume(v) => {
                 self.gain = v.amp_clamped(DEFAULT_AMP_EPSILON);
             }
-            BeepTestNodePatch::Enabled(e) => self.enabled = e,
+            &BeepTestNodePatch::Enabled(e) => self.enabled = e,
         });
 
         if !self.enabled {

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -51,7 +51,6 @@ impl AudioNode for BeepTestNode {
                 num_inputs: ChannelCount::ZERO,
                 num_outputs: ChannelCount::MONO,
             })
-            .uses_events(true)
     }
 
     fn construct_processor(
@@ -81,21 +80,23 @@ impl AudioNodeProcessor for Processor {
         &mut self,
         buffers: ProcBuffers,
         proc_info: &ProcInfo,
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
         let Some(out) = buffers.outputs.first_mut() else {
             return ProcessStatus::ClearAllOutputs;
         };
 
-        events.for_each_patch::<BeepTestNode>(|patch| match &patch.event {
-            &BeepTestNodePatch::FreqHz(f) => {
-                self.phasor_inc = f.clamp(20.0, 20_000.0) * proc_info.sample_rate_recip as f32;
+        for patch in events.drain_patches::<BeepTestNode>() {
+            match patch {
+                BeepTestNodePatch::FreqHz(f) => {
+                    self.phasor_inc = f.clamp(20.0, 20_000.0) * proc_info.sample_rate_recip as f32;
+                }
+                BeepTestNodePatch::Volume(v) => {
+                    self.gain = v.amp_clamped(DEFAULT_AMP_EPSILON);
+                }
+                BeepTestNodePatch::Enabled(e) => self.enabled = e,
             }
-            &BeepTestNodePatch::Volume(v) => {
-                self.gain = v.amp_clamped(DEFAULT_AMP_EPSILON);
-            }
-            &BeepTestNodePatch::Enabled(e) => self.enabled = e,
-        });
+        }
 
         if !self.enabled {
             return ProcessStatus::ClearAllOutputs;

--- a/crates/firewheel-nodes/src/lib.rs
+++ b/crates/firewheel-nodes/src/lib.rs
@@ -17,6 +17,7 @@ pub mod stream;
 pub mod noise_generator;
 
 mod stereo_to_mono;
+
 pub use stereo_to_mono::StereoToMonoNode;
 
 pub mod volume_pan;

--- a/crates/firewheel-nodes/src/noise_generator/pink.rs
+++ b/crates/firewheel-nodes/src/noise_generator/pink.rs
@@ -118,11 +118,11 @@ impl AudioNodeProcessor for Processor {
         mut events: NodeEventList,
     ) -> ProcessStatus {
         events.for_each_patch::<PinkNoiseGenNode>(|patch| {
-            if let PinkNoiseGenNodePatch::Volume(vol) = &patch {
+            if let PinkNoiseGenNodePatch::Volume(vol) = &patch.event {
                 self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
             }
 
-            self.params.apply(patch);
+            self.params.apply(patch.event);
         });
 
         if !self.params.enabled || (self.gain.target_value() == 0.0 && !self.gain.is_smoothing()) {

--- a/crates/firewheel-nodes/src/noise_generator/pink.rs
+++ b/crates/firewheel-nodes/src/noise_generator/pink.rs
@@ -69,7 +69,6 @@ impl AudioNode for PinkNoiseGenNode {
                 num_inputs: ChannelCount::ZERO,
                 num_outputs: ChannelCount::MONO,
             })
-            .uses_events(true)
     }
 
     fn construct_processor(
@@ -115,15 +114,15 @@ impl AudioNodeProcessor for Processor {
         &mut self,
         buffers: ProcBuffers,
         _proc_info: &ProcInfo,
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
-        events.for_each_patch::<PinkNoiseGenNode>(|patch| {
-            if let PinkNoiseGenNodePatch::Volume(vol) = &patch.event {
+        for patch in events.drain_patches::<PinkNoiseGenNode>() {
+            if let PinkNoiseGenNodePatch::Volume(vol) = patch {
                 self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
             }
 
-            self.params.apply(patch.event);
-        });
+            self.params.apply(patch);
+        }
 
         if !self.params.enabled || (self.gain.target_value() == 0.0 && !self.gain.is_smoothing()) {
             self.gain.reset();

--- a/crates/firewheel-nodes/src/noise_generator/white.rs
+++ b/crates/firewheel-nodes/src/noise_generator/white.rs
@@ -105,11 +105,11 @@ impl AudioNodeProcessor for Processor {
         mut events: NodeEventList,
     ) -> ProcessStatus {
         events.for_each_patch::<WhiteNoiseGenNode>(|patch| {
-            if let WhiteNoiseGenNodePatch::Volume(vol) = &patch {
+            if let WhiteNoiseGenNodePatch::Volume(vol) = &patch.event {
                 self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
             }
 
-            self.params.apply(patch);
+            self.params.apply(patch.event);
         });
 
         if !self.params.enabled || (self.gain.target_value() == 0.0 && !self.gain.is_smoothing()) {

--- a/crates/firewheel-nodes/src/noise_generator/white.rs
+++ b/crates/firewheel-nodes/src/noise_generator/white.rs
@@ -64,7 +64,6 @@ impl AudioNode for WhiteNoiseGenNode {
                 num_inputs: ChannelCount::ZERO,
                 num_outputs: ChannelCount::MONO,
             })
-            .uses_events(true)
     }
 
     fn construct_processor(
@@ -102,15 +101,15 @@ impl AudioNodeProcessor for Processor {
         &mut self,
         buffers: ProcBuffers,
         _proc_info: &ProcInfo,
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
-        events.for_each_patch::<WhiteNoiseGenNode>(|patch| {
-            if let WhiteNoiseGenNodePatch::Volume(vol) = &patch.event {
+        for patch in events.drain_patches::<WhiteNoiseGenNode>() {
+            if let WhiteNoiseGenNodePatch::Volume(vol) = patch {
                 self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
             }
 
-            self.params.apply(patch.event);
-        });
+            self.params.apply(patch);
+        }
 
         if !self.params.enabled || (self.gain.target_value() == 0.0 && !self.gain.is_smoothing()) {
             self.gain.reset();

--- a/crates/firewheel-nodes/src/peak_meter.rs
+++ b/crates/firewheel-nodes/src/peak_meter.rs
@@ -202,7 +202,6 @@ impl<const NUM_CHANNELS: usize> AudioNode for PeakMeterNode<NUM_CHANNELS> {
                 num_inputs: ChannelCount::new(NUM_CHANNELS as u32).unwrap(),
                 num_outputs: ChannelCount::new(NUM_CHANNELS as u32).unwrap(),
             })
-            .uses_events(true)
             .custom_state(PeakMeterState::<NUM_CHANNELS>::new())
     }
 
@@ -236,11 +235,13 @@ impl<const NUM_CHANNELS: usize> AudioNodeProcessor for Processor<NUM_CHANNELS> {
         &mut self,
         buffers: ProcBuffers,
         proc_info: &ProcInfo,
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
         let was_enabled = self.params.enabled;
 
-        events.for_each_patch::<PeakMeterNode<NUM_CHANNELS>>(|p| self.params.apply(p.event));
+        for patch in events.drain_patches::<PeakMeterNode<NUM_CHANNELS>>() {
+            self.params.apply(patch);
+        }
 
         if was_enabled && !self.params.enabled {
             for ch in self.shared_state.peak_gains.iter() {

--- a/crates/firewheel-nodes/src/peak_meter.rs
+++ b/crates/firewheel-nodes/src/peak_meter.rs
@@ -240,7 +240,7 @@ impl<const NUM_CHANNELS: usize> AudioNodeProcessor for Processor<NUM_CHANNELS> {
     ) -> ProcessStatus {
         let was_enabled = self.params.enabled;
 
-        events.for_each_patch::<PeakMeterNode<NUM_CHANNELS>>(|p| self.params.apply(p));
+        events.for_each_patch::<PeakMeterNode<NUM_CHANNELS>>(|p| self.params.apply(p.event));
 
         if was_enabled && !self.params.enabled {
             for ch in self.shared_state.peak_gains.iter() {

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -7,6 +7,7 @@ use core::{
     num::{NonZeroU32, NonZeroUsize},
     ops::Range,
 };
+use firewheel_core::diff::RealtimeClone;
 use smallvec::SmallVec;
 
 use firewheel_core::{
@@ -91,14 +92,23 @@ pub enum PlaybackSpeedQuality {
 #[derive(Clone, Diff, Patch)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 pub struct SamplerNode {
-    /// The current sequence loaded into the sampler.
-    pub sequence: Notify<Option<SequenceType>>,
+    /// The sample resource to use.
+    pub sample: Option<ArcGc<dyn SampleResource>>,
+
+    /// The volume to play the sample at.
+    ///
+    /// Note, this gain parameter is *NOT* smoothed! If you need the gain to be
+    /// smoothed, please use a [`VolumeNode`] or a [`VolumePanNode`].
+    pub volume: Volume,
 
     /// The current playback state.
     pub playback: Notify<PlaybackState>,
 
     /// The playhead state.
     pub playhead: Notify<Playhead>,
+
+    /// How many times a sample should be repeated.
+    pub repeat_mode: RepeatMode,
 
     /// The speed at which to play the sample at. `1.0` means to play the sound at
     /// its original speed, `< 1.0` means to play the sound slower (which will make
@@ -110,9 +120,11 @@ pub struct SamplerNode {
 impl Default for SamplerNode {
     fn default() -> Self {
         Self {
-            sequence: Notify::default(),
+            sample: None,
+            volume: Volume::default(),
             playback: Default::default(),
             playhead: Default::default(),
+            repeat_mode: RepeatMode::default(),
             speed: 1.0,
         }
     }
@@ -120,31 +132,23 @@ impl Default for SamplerNode {
 
 impl SamplerNode {
     /// Set the parameters to a play a single sample.
-    ///
-    /// * `sample` - The sample resource to use.
-    /// * `volume` - The volume to play the sample at. Note that this node does not
-    /// support changing the volume while playing. Instead, use a node like the volume
-    /// node for that.
-    /// * `repeat_mode` - How many times a sample/sequence should be repeated for each
-    /// `StartOrRestart` command.
-    pub fn set_sample(
-        &mut self,
-        sample: ArcGc<dyn SampleResource>,
-        volume: Volume,
-        repeat_mode: RepeatMode,
-    ) {
-        *self.sequence = Some(SequenceType::SingleSample {
-            sample,
-            volume,
-            repeat_mode,
-        });
+    pub fn set_sample(&mut self, sample: ArcGc<dyn SampleResource>) {
+        self.sample = Some(sample);
     }
 
-    /// Returns an event type to sync the `sequence` parameter.
-    pub fn sync_sequence_event(&self) -> NodeEventType {
+    /// Returns an event type to sync the `sample` parameter.
+    pub fn sync_sample_event(&self) -> NodeEventType {
         NodeEventType::Param {
-            data: ParamData::any(self.sequence.clone()),
+            data: ParamData::any(self.sample.clone()),
             path: ParamPath::Single(0),
+        }
+    }
+
+    /// Returns an event type to sync the `volume` parameter.
+    pub fn sync_volume_event(&self) -> NodeEventType {
+        NodeEventType::Param {
+            data: ParamData::Volume(self.volume),
+            path: ParamPath::Single(1),
         }
     }
 
@@ -152,7 +156,7 @@ impl SamplerNode {
     pub fn sync_playback_event(&self) -> NodeEventType {
         NodeEventType::Param {
             data: ParamData::any(self.playback.clone()),
-            path: ParamPath::Single(1),
+            path: ParamPath::Single(2),
         }
     }
 
@@ -160,40 +164,56 @@ impl SamplerNode {
     pub fn sync_playhead_event(&self) -> NodeEventType {
         NodeEventType::Param {
             data: ParamData::any(self.playhead.clone()),
-            path: ParamPath::Single(2),
+            path: ParamPath::Single(3),
         }
     }
 
-    /// Play the sequence in this node.
+    /// Returns an event type to sync the `playhead` parameter.
+    pub fn sync_repeat_mode_event(&self) -> NodeEventType {
+        NodeEventType::Param {
+            data: ParamData::any(self.repeat_mode),
+            path: ParamPath::Single(4),
+        }
+    }
+
+    /// Returns an event type to sync the `speed` parameter.
+    pub fn sync_speed_event(&self) -> NodeEventType {
+        NodeEventType::Param {
+            data: ParamData::F64(self.speed),
+            path: ParamPath::Single(5),
+        }
+    }
+
+    /// Play the sample in this node.
     ///
-    /// If a sequence is already playing, then it will restart from the beginning.
+    /// If a sample is already playing, then it will restart from the beginning.
     ///
-    /// * `instant` - The exact time at which the sequence should begin playing from the
+    /// * `instant` - The exact time at which the sample should begin playing from the
     /// beginning.
-    ///     * If this is `None`, then the sequence will restart from the beginning as soon
+    ///     * If this is `None`, then the sample will restart from the beginning as soon
     /// as this event is received.
-    ///     * If this is `Some`, then the sequence will begin playing from the
+    ///     * If this is `Some`, then the sample will begin playing from the
     /// beginning when the instant occurs. If this instant is in the past when
-    /// the node receives this event, then the sequence will skip ahead as if
+    /// the node receives this event, then the sample will skip ahead as if
     /// it started playing from that instant in the past.
     pub fn start_or_restart(&mut self, instant: Option<EventInstant>) {
         *self.playhead = Playhead::default();
         *self.playback = PlaybackState::Play { instant };
     }
 
-    /// Pause sequence playback.
+    /// Pause sample playback.
     pub fn pause(&mut self) {
         *self.playback = PlaybackState::Pause;
     }
 
-    /// Resume sequence playback.
+    /// Resume sample playback.
     pub fn resume(&mut self) {
         *self.playback = PlaybackState::Play { instant: None };
     }
 
-    /// Stop sequence playback.
+    /// Stop sample playback.
     ///
-    /// Calling [`SamplerNode::resume`] after this will restart the sequence from
+    /// Calling [`SamplerNode::resume`] after this will restart the sample from
     /// the beginning.
     pub fn stop(&mut self) {
         *self.playback = PlaybackState::Stop;
@@ -217,11 +237,11 @@ impl SamplerState {
     /// a single channel of audio).
     pub fn playhead_frames(&self) -> u64 {
         self.shared_state
-            .sequence_playhead_frames
+            .sample_playhead_frames
             .load(Ordering::Relaxed)
     }
 
-    /// Get the current position of the sequence playhead in seconds.
+    /// Get the current position of the sample playhead in seconds.
     ///
     /// * `sample_rate` - The sample rate of the current audio stream.
     pub fn playhead_seconds(&self, sample_rate: NonZeroU32) -> f64 {
@@ -269,7 +289,7 @@ impl SamplerState {
             / sample_rate.get() as f64
     }
 
-    /// Returns `true` if the sequence has either not started playing yet or has finished
+    /// Returns `true` if the sample has either not started playing yet or has finished
     /// playing.
     pub fn stopped(&self) -> bool {
         self.shared_state.stopped.load(Ordering::Relaxed)
@@ -294,7 +314,7 @@ impl SamplerState {
     /// A score of how suitable this node is to start new work (Play a new sample). The
     /// higher the score, the better the candidate.
     pub fn worker_score(&self, params: &SamplerNode) -> u64 {
-        if params.sequence.is_some() {
+        if params.sample.is_some() {
             let stopped = self.stopped();
 
             match *params.playback {
@@ -330,30 +350,30 @@ impl SamplerState {
     }
 }
 
-/// A parameter representing the current playback state of a sequence.
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
+/// A parameter representing the current playback state of a sample.
+#[derive(Default, Debug, Clone, Copy, PartialEq, RealtimeClone)]
 pub enum PlaybackState {
-    /// Stop the sequence.
+    /// Stop the sample.
     ///
-    /// When the sequence is started again, it will restart from the beginning.
+    /// When the sample is started again, it will restart from the beginning.
     #[default]
     Stop,
-    /// Pause the sequence.
+    /// Pause the sample.
     ///
-    /// When the sequence is started again, it will continue from where it last
+    /// When the sample is started again, it will continue from where it last
     /// left off.
     Pause,
-    /// Play the sequence.
+    /// Play the sample.
     Play {
-        /// The exact time at which the sequence should begin playing from the
+        /// The exact time at which the sample should begin playing from the
         /// beginning.
         ///
-        /// If this is `None`, then the sequence will start/resume as soon as this
+        /// If this is `None`, then the sample will start/resume as soon as this
         /// event is received.
         ///
-        /// If this is `Some`, then the sequence will begin playing from the
+        /// If this is `Some`, then the sample will begin playing from the
         /// beginning when the instant occurs. If this instant is in the past when
-        /// this node receives this event, then the sequence will skip ahead as if
+        /// this node receives this event, then the sample will skip ahead as if
         /// it started playing from that instant in the past.
         instant: Option<EventInstant>,
     },
@@ -369,8 +389,8 @@ impl PlaybackState {
     }
 }
 
-/// The playhead of a sequence.
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// The playhead of a sample.
+#[derive(Debug, Clone, Copy, PartialEq, RealtimeClone)]
 pub enum Playhead {
     /// The playhead in units of seconds.
     Seconds(f64),
@@ -400,78 +420,15 @@ impl Default for Playhead {
     }
 }
 
-/// The current sequence loaded into the sampler.
-#[derive(Clone, PartialEq)]
-pub enum SequenceType {
-    SingleSample {
-        /// The sample resource to use.
-        sample: ArcGc<dyn SampleResource>,
-        /// The volume to play the sample at.
-        ///
-        /// Note that this node does not support changing the volume while
-        /// playing. Instead, use a node like the volume node for that.
-        volume: Volume,
-        /// How many times a sample/sequence should be repeated.
-        repeat_mode: RepeatMode,
-    },
-    /// A sequence with multiple events (NOT IMPLEMENTED YET, WILL PANIC IF USED)
-    Sequence {
-        sequence: ArcGc<Vec<SequenceEvent>>,
-        timing: SequenceTiming,
-    },
-}
-
-/// The method of timing to use for a sequence.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SequenceTiming {
-    /// Use time in units of seconds.
-    Seconds,
-    /// Use time in units of samples (of a single channel of audio).
-    Samples,
-}
-
-#[derive(Clone, PartialEq)]
-pub struct SequenceEvent {
-    pub event: SequenceEventType,
-    /// The amount of time from the start of the sequence that this event should occur.
-    ///
-    /// If the timing is set to [`SequenceTiming::Seconds`], then this is in units of seconds. If
-    /// the timing is set to [`SequenceTiming::Samples`], then this is in units of samples (of a
-    /// single channel of audio).
-    pub offset_from_start: f64,
-}
-
-#[derive(Clone, PartialEq)]
-pub enum SequenceEventType {
-    PlaySample {
-        /// The sample resource to use.
-        sample: ArcGc<dyn SampleResource>,
-        /// The volume to play the sample at, where `0.0` is silence and `1.0`
-        /// is unity gain.
-        ///
-        /// Note that this node does not support changing the volume while
-        /// playing. Instead, use a node like the volume node for that.
-        normalized_volume: f32,
-        // TODO: Pitch
-    },
-    /// Stop the currently playing sample.
-    Stop,
-    /// Set the position of the playhead in seconds.
-    SetPlayheadSeconds(f64),
-    /// Set the position of the playhead in units of samples (of a single channel
-    /// of audio).
-    SetPlayheadSamples(u64),
-}
-
-/// How many times a sample/sequence should be repeated for each `StartOrRestart` command.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+/// How many times a sample should be repeated.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Diff, Patch)]
 pub enum RepeatMode {
-    /// Play the sample/sequence once and then stop.
+    /// Play the sample once and then stop.
     #[default]
     PlayOnce,
-    /// Repeat the sample/sequence the given number of times.
+    /// Repeat the sample the given number of times.
     RepeatMultiple { num_times_to_repeat: u32 },
-    /// Repeat the sample/sequence endlessly.
+    /// Repeat the sample endlessly.
     RepeatEndlessly,
 }
 
@@ -497,7 +454,6 @@ impl AudioNode for SamplerNode {
                 num_inputs: ChannelCount::ZERO,
                 num_outputs: config.channels.get(),
             })
-            .uses_events(true)
             .custom_state(SamplerState::new())
     }
 
@@ -709,7 +665,7 @@ impl SamplerProcessor {
     }
 
     fn currently_processing_sample(&self) -> bool {
-        if self.params.sequence.is_none() || self.play_from_instant.is_some() {
+        if self.params.sample.is_none() || self.play_from_instant.is_some() {
             false
         } else {
             self.playback_state.is_playing()
@@ -791,14 +747,8 @@ impl SamplerProcessor {
         }
     }
 
-    fn load_sample(
-        &mut self,
-        sample: ArcGc<dyn SampleResource>,
-        volume: Volume,
-        repeat_mode: RepeatMode,
-        num_out_channels: usize,
-    ) {
-        let mut gain = volume.amp_clamped(self.amp_epsilon);
+    fn load_sample(&mut self, sample: ArcGc<dyn SampleResource>, num_out_channels: usize) {
+        let mut gain = self.params.volume.amp_clamped(self.amp_epsilon);
         if gain > 0.99999 && gain < 1.00001 {
             gain = 1.0;
         }
@@ -816,7 +766,6 @@ impl SamplerProcessor {
             sample_mono_to_stereo,
             gain,
             playhead: 0,
-            repeat_mode,
             num_times_looped_back: 0,
         });
     }
@@ -827,23 +776,30 @@ impl AudioNodeProcessor for SamplerProcessor {
         &mut self,
         buffers: ProcBuffers,
         proc_info: &ProcInfo,
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
-        let mut sequence_changed = false;
+        let mut sample_changed = false;
         let mut playhead_changed = false;
         let mut playback_changed = false;
+        let mut repeat_mode_changed = false;
         let mut speed_changed = false;
+        let mut volume_changed = false;
 
-        events.for_each_patch::<SamplerNode>(|patch| {
-            match &patch.event {
-                SamplerNodePatch::Sequence(_) => sequence_changed = true,
+        for mut patch in events.drain_patches::<SamplerNode>() {
+            match &mut patch {
+                SamplerNodePatch::Sample(_) => sample_changed = true,
+                SamplerNodePatch::Volume(_) => volume_changed = true,
                 SamplerNodePatch::Playhead(_) => playhead_changed = true,
-                SamplerNodePatch::Playback(_) => playback_changed = true,
+                SamplerNodePatch::Playback(_) => {
+                    playback_changed = true;
+                    println!("got playback")
+                }
+                SamplerNodePatch::RepeatMode(_) => repeat_mode_changed = true,
                 SamplerNodePatch::Speed(_) => speed_changed = true,
             }
 
-            self.params.apply(patch.event);
-        });
+            self.params.apply(patch);
+        }
 
         if speed_changed {
             self.speed = self.params.speed.max(MIN_PLAYBACK_SPEED);
@@ -853,7 +809,22 @@ impl AudioNodeProcessor for SamplerProcessor {
             }
         }
 
-        if sequence_changed || self.is_first_process {
+        if volume_changed {
+            if let Some(loaded_sample) = &mut self.loaded_sample_state {
+                loaded_sample.gain = self.params.volume.amp_clamped(self.amp_epsilon);
+                if loaded_sample.gain > 0.99999 && loaded_sample.gain < 1.00001 {
+                    loaded_sample.gain = 1.0;
+                }
+            }
+        }
+
+        if repeat_mode_changed {
+            if let Some(loaded_sample) = &mut self.loaded_sample_state {
+                loaded_sample.num_times_looped_back = 0;
+            }
+        }
+
+        if sample_changed || self.is_first_process {
             self.stop(
                 proc_info.declick_values,
                 buffers.outputs.len(),
@@ -862,31 +833,18 @@ impl AudioNodeProcessor for SamplerProcessor {
 
             self.loaded_sample_state = None;
 
-            match self.params.sequence.as_ref() {
-                None => {
-                    self.playback_state = PlaybackState::Stop;
-                    self.shared_state.stopped.store(true, Ordering::Relaxed);
-                }
-                Some(SequenceType::SingleSample {
-                    sample,
-                    volume,
-                    repeat_mode,
-                }) => {
-                    self.load_sample(
-                        ArcGc::clone(sample),
-                        *volume,
-                        *repeat_mode,
-                        buffers.outputs.len(),
-                    );
-                }
-                _ => todo!(),
+            if let Some(sample) = &self.params.sample {
+                self.load_sample(ArcGc::clone(sample), buffers.outputs.len());
+            } else {
+                self.playback_state = PlaybackState::Stop;
+                self.shared_state.stopped.store(true, Ordering::Relaxed);
             }
         }
 
         if playhead_changed || self.is_first_process {
             let playhead_frames = self.params.playhead.as_frames(proc_info.sample_rate);
 
-            if let Some(SequenceType::SingleSample { .. }) = self.params.sequence.as_ref() {
+            if self.params.sample.is_some() {
                 let state = self.loaded_sample_state.as_ref().unwrap();
 
                 let playhead_frames = playhead_frames.min(state.sample_len_frames);
@@ -906,7 +864,7 @@ impl AudioNodeProcessor for SamplerProcessor {
                     self.playback_state = playback_state;
 
                     self.shared_state
-                        .sequence_playhead_frames
+                        .sample_playhead_frames
                         .store(playhead_frames, Ordering::Relaxed);
 
                     if playhead_frames > 0 {
@@ -920,7 +878,7 @@ impl AudioNodeProcessor for SamplerProcessor {
                 }
             }
 
-            // If the sequence previously finished, restart it.
+            // If the sample previously finished, restart it.
             playback_changed = true;
         }
 
@@ -941,8 +899,8 @@ impl AudioNodeProcessor for SamplerProcessor {
 
                         self.declicker.fade_to_0(proc_info.declick_values);
 
-                        self.playback_pause_time_seconds = proc_info.clock_seconds.start;
-                        self.playback_pause_time_frames = proc_info.clock_samples.start;
+                        self.playback_pause_time_seconds = proc_info.clock_seconds();
+                        self.playback_pause_time_frames = proc_info.clock_samples;
                     }
                 }
                 PlaybackState::Play {
@@ -975,20 +933,22 @@ impl AudioNodeProcessor for SamplerProcessor {
             Ordering::Relaxed,
         );
 
-        let start_on_frame = if let Some(play_from_instant) = self.play_from_instant {
+        let start_on_frame = self.play_from_instant.and_then(|play_from_instant| {
             play_from_instant
                 .to_samples(proc_info)
                 .and_then(|instant_clock_samples| {
-                    if instant_clock_samples >= proc_info.clock_samples.end {
+                    let clock_samples_range = proc_info.clock_samples_range();
+
+                    if instant_clock_samples >= clock_samples_range.end {
                         None
-                    } else if instant_clock_samples < proc_info.clock_samples.start {
+                    } else if instant_clock_samples < clock_samples_range.start {
                         self.play_from_instant = None;
 
                         if let Some(state) = &mut self.loaded_sample_state {
-                            state.playhead =
-                                ((proc_info.clock_samples.start - instant_clock_samples).0 as u64
-                                    + self.params.playhead.as_frames(proc_info.sample_rate))
-                                .min(state.sample_len_frames);
+                            state.playhead = ((clock_samples_range.start - instant_clock_samples).0
+                                as u64
+                                + self.params.playhead.as_frames(proc_info.sample_rate))
+                            .min(state.sample_len_frames);
                             state.num_times_looped_back = 0;
                         }
 
@@ -1009,12 +969,10 @@ impl AudioNodeProcessor for SamplerProcessor {
                             state.num_times_looped_back = 0;
                         }
 
-                        Some((instant_clock_samples - proc_info.clock_samples.start).0 as usize)
+                        Some((instant_clock_samples - clock_samples_range.start).0 as usize)
                     }
                 })
-        } else {
-            None
-        };
+        });
 
         let currently_processing_sample = self.currently_processing_sample();
 
@@ -1024,45 +982,36 @@ impl AudioNodeProcessor for SamplerProcessor {
 
         let mut num_filled_channels = 0;
 
-        if currently_processing_sample {
-            match self.params.sequence.as_ref() {
-                None => {}
-                Some(SequenceType::SingleSample { .. }) => {
-                    let sample_state = self.loaded_sample_state.as_ref().unwrap();
-                    let looping = sample_state
-                        .repeat_mode
-                        .do_loop(sample_state.num_times_looped_back);
+        if currently_processing_sample && self.params.sample.is_some() {
+            let sample_state = self.loaded_sample_state.as_ref().unwrap();
 
-                    let (finished, n_channels) = self.process_internal(
-                        buffers.outputs,
-                        proc_info.frames,
-                        looping,
-                        proc_info.declick_values,
-                        start_on_frame,
-                        buffers.scratch_buffers,
-                    );
+            let looping = self
+                .params
+                .repeat_mode
+                .do_loop(sample_state.num_times_looped_back);
 
-                    num_filled_channels = n_channels;
+            let (finished, n_channels) = self.process_internal(
+                buffers.outputs,
+                proc_info.frames,
+                looping,
+                proc_info.declick_values,
+                start_on_frame,
+                buffers.scratch_buffers,
+            );
 
-                    self.shared_state.sequence_playhead_frames.store(
-                        self.loaded_sample_state.as_ref().unwrap().playhead,
-                        Ordering::Relaxed,
-                    );
+            num_filled_channels = n_channels;
 
-                    if finished {
-                        self.playback_state = PlaybackState::Stop;
-                        self.shared_state.stopped.store(true, Ordering::Relaxed);
-                        self.shared_state
-                            .finished
-                            .store(self.params.sequence.id(), Ordering::Relaxed);
-                    }
-                }
-                Some(SequenceType::Sequence {
-                    sequence: _,
-                    timing: _,
-                }) => {
-                    todo!()
-                }
+            self.shared_state.sample_playhead_frames.store(
+                self.loaded_sample_state.as_ref().unwrap().playhead,
+                Ordering::Relaxed,
+            );
+
+            if finished {
+                self.playback_state = PlaybackState::Stop;
+                self.shared_state.stopped.store(true, Ordering::Relaxed);
+                self.shared_state
+                    .finished
+                    .store(self.params.playback.id(), Ordering::Relaxed);
             }
         }
 
@@ -1138,7 +1087,7 @@ impl AudioNodeProcessor for SamplerProcessor {
 
             // The sample rate has changed, meaning that the sample resources now have
             // the incorrect sample rate and the user must reload them.
-            *self.params.sequence.as_mut_unsync() = None;
+            self.params.sample = None;
             self.loaded_sample_state = None;
             self.playback_state = PlaybackState::Stop;
             self.shared_state.playing.store(false, Ordering::Relaxed);
@@ -1149,7 +1098,7 @@ impl AudioNodeProcessor for SamplerProcessor {
 }
 
 struct SharedState {
-    sequence_playhead_frames: AtomicU64,
+    sample_playhead_frames: AtomicU64,
     playing: AtomicBool,
     stopped: AtomicBool,
     finished: AtomicU64,
@@ -1158,7 +1107,7 @@ struct SharedState {
 impl Default for SharedState {
     fn default() -> Self {
         Self {
-            sequence_playhead_frames: AtomicU64::new(0),
+            sample_playhead_frames: AtomicU64::new(0),
             playing: AtomicBool::new(false),
             stopped: AtomicBool::new(true),
             finished: AtomicU64::new(0),
@@ -1173,7 +1122,6 @@ struct LoadedSampleState {
     sample_mono_to_stereo: bool,
     gain: f32,
     playhead: u64,
-    repeat_mode: RepeatMode,
     num_times_looped_back: u64,
 }
 

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -835,14 +835,14 @@ impl AudioNodeProcessor for SamplerProcessor {
         let mut speed_changed = false;
 
         events.for_each_patch::<SamplerNode>(|patch| {
-            match &patch {
+            match &patch.event {
                 SamplerNodePatch::Sequence(_) => sequence_changed = true,
                 SamplerNodePatch::Playhead(_) => playhead_changed = true,
                 SamplerNodePatch::Playback(_) => playback_changed = true,
                 SamplerNodePatch::Speed(_) => speed_changed = true,
             }
 
-            self.params.apply(patch);
+            self.params.apply(patch.event);
         });
 
         if speed_changed {

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -271,7 +271,7 @@ impl AudioNodeProcessor for Processor {
     ) -> ProcessStatus {
         let mut updated = false;
         events.for_each_patch::<SpatialBasicNode>(|mut patch| {
-            match &mut patch {
+            match &mut patch.event {
                 SpatialBasicNodePatch::Offset(offset) => {
                     if !offset.is_finite() {
                         *offset = Vec3::default();
@@ -286,7 +286,7 @@ impl AudioNodeProcessor for Processor {
                 _ => {}
             }
 
-            self.params.apply(patch);
+            self.params.apply(patch.event);
             updated = true;
         });
 

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -10,10 +10,10 @@ use firewheel_core::{
         pan_law::PanLaw,
         volume::{Volume, DEFAULT_AMP_EPSILON},
     },
-    event::Vec3,
+    event::{NodeEventList, Vec3},
     node::{
-        AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, GetChannels,
-        ProcInfo, ProcessStatus, SimpleAudioProcessor,
+        AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
+        ProcInfo, ProcessStatus,
     },
     param::smoother::{SmoothedParam, SmootherConfig},
     SilenceMask,
@@ -200,7 +200,6 @@ impl AudioNode for SpatialBasicNode {
                 num_inputs: ChannelCount::STEREO,
                 num_outputs: ChannelCount::STEREO,
             })
-            .uses_events(true)
     }
 
     fn construct_processor(
@@ -243,7 +242,6 @@ impl AudioNode for SpatialBasicNode {
             params: *self,
             prev_block_was_silent: true,
             amp_epsilon: config.amp_epsilon,
-            updated: false,
         }
     }
 }
@@ -261,62 +259,37 @@ struct Processor {
 
     prev_block_was_silent: bool,
     amp_epsilon: f32,
-    updated: bool,
 }
 
-impl SimpleAudioProcessor for Processor {
-    type Params = SpatialBasicNode;
-
-    fn apply_patch(&mut self, mut patch: SpatialBasicNodePatch) {
-        match &mut patch {
-            SpatialBasicNodePatch::Offset(offset) => {
-                if !offset.is_finite() {
-                    *offset = Vec3::default();
+impl AudioNodeProcessor for Processor {
+    fn process(
+        &mut self,
+        buffers: ProcBuffers,
+        proc_info: &ProcInfo,
+        events: &mut NodeEventList,
+    ) -> ProcessStatus {
+        let mut updated = false;
+        for mut patch in events.drain_patches::<SpatialBasicNode>() {
+            match &mut patch {
+                SpatialBasicNodePatch::Offset(offset) => {
+                    if !offset.is_finite() {
+                        *offset = Vec3::default();
+                    }
                 }
+                SpatialBasicNodePatch::MuffleCutoffHz(cutoff) => {
+                    *cutoff = cutoff.clamp(DAMPING_CUTOFF_HZ_MIN, DAMPING_CUTOFF_HZ_MAX);
+                }
+                SpatialBasicNodePatch::PanningThreshold(threshold) => {
+                    *threshold = threshold.clamp(0.0, 1.0);
+                }
+                _ => {}
             }
-            SpatialBasicNodePatch::MuffleCutoffHz(cutoff) => {
-                *cutoff = cutoff.clamp(DAMPING_CUTOFF_HZ_MIN, DAMPING_CUTOFF_HZ_MAX);
-            }
-            SpatialBasicNodePatch::PanningThreshold(threshold) => {
-                *threshold = threshold.clamp(0.0, 1.0);
-            }
-            _ => {}
+
+            self.params.apply(patch);
+            updated = true;
         }
 
-        self.params.apply(patch);
-        self.updated = true;
-    }
-
-    fn can_skip_patch(&self, patch: &SpatialBasicNodePatch) -> bool {
-        match patch {
-            &SpatialBasicNodePatch::Offset(mut offset) => {
-                if !offset.is_finite() {
-                    offset = Vec3::default();
-                }
-
-                (offset - self.params.offset).length_squared() < f32::EPSILON
-            }
-            SpatialBasicNodePatch::MuffleCutoffHz(cutoff) => {
-                let cutoff = cutoff.clamp(DAMPING_CUTOFF_HZ_MIN, DAMPING_CUTOFF_HZ_MAX);
-
-                (cutoff - self.params.muffle_cutoff_hz).abs() < f32::EPSILON
-            }
-            SpatialBasicNodePatch::PanningThreshold(threshold) => {
-                let threshold = threshold.clamp(0.0, 1.0);
-
-                (threshold - self.params.panning_threshold).abs() < f32::EPSILON
-            }
-            SpatialBasicNodePatch::Volume(vol) => {
-                (vol.amp() - self.params.volume.amp()).abs() < f32::EPSILON
-            }
-            SpatialBasicNodePatch::DampingDistance(dist) => {
-                (*dist - self.params.damping_distance).abs() < f32::EPSILON
-            }
-        }
-    }
-
-    fn process<B: GetChannels>(&mut self, mut buffers: B, proc_info: &ProcInfo) -> ProcessStatus {
-        if self.updated {
+        if updated {
             let computed_values = self.params.compute_values(self.amp_epsilon);
 
             self.gain_l.set_value(computed_values.gain_l);
@@ -340,8 +313,6 @@ impl SimpleAudioProcessor for Processor {
             }
         }
 
-        self.updated = false;
-
         self.prev_block_was_silent = false;
 
         if proc_info.in_silence_mask.all_channels_silent(2) {
@@ -356,12 +327,11 @@ impl SimpleAudioProcessor for Processor {
             return ProcessStatus::ClearAllOutputs;
         }
 
-        let mut buffers = buffers.channels();
-
-        let in1 = buffers.inputs.next().unwrap();
-        let in2 = buffers.inputs.next().unwrap();
-        let out1 = buffers.outputs.next().unwrap();
-        let out2 = buffers.outputs.next().unwrap();
+        let in1 = &buffers.inputs[0][..proc_info.frames];
+        let in2 = &buffers.inputs[1][..proc_info.frames];
+        let (out1, out2) = buffers.outputs.split_first_mut().unwrap();
+        let out1 = &mut out1[..proc_info.frames];
+        let out2 = &mut out2[0][..proc_info.frames];
 
         if !self.gain_l.is_smoothing()
             && !self.gain_r.is_smoothing()

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -265,7 +265,7 @@ struct Processor {
 }
 
 impl SimpleAudioProcessor for Processor {
-    type Node = SpatialBasicNode;
+    type Params = SpatialBasicNode;
 
     fn apply_patch(&mut self, mut patch: SpatialBasicNodePatch) {
         match &mut patch {

--- a/crates/firewheel-nodes/src/stereo_to_mono.rs
+++ b/crates/firewheel-nodes/src/stereo_to_mono.rs
@@ -21,7 +21,6 @@ impl AudioNode for StereoToMonoNode {
                 num_inputs: ChannelCount::STEREO,
                 num_outputs: ChannelCount::MONO,
             })
-            .uses_events(false)
     }
 
     fn construct_processor(
@@ -40,7 +39,7 @@ impl AudioNodeProcessor for StereoToMonoProcessor {
         &mut self,
         buffers: ProcBuffers,
         proc_info: &ProcInfo,
-        _events: NodeEventList,
+        _events: &mut NodeEventList,
     ) -> ProcessStatus {
         if proc_info.in_silence_mask.all_channels_silent(2)
             || buffers.inputs.len() < 2

--- a/crates/firewheel-nodes/src/stream/reader.rs
+++ b/crates/firewheel-nodes/src/stream/reader.rs
@@ -378,7 +378,7 @@ impl AudioNodeProcessor for Processor {
         mut events: NodeEventList,
     ) -> ProcessStatus {
         events.for_each(|event| {
-            if let NodeEventType::Custom(event) = event {
+            if let NodeEventType::Custom(event) = event.event {
                 if let Some(out_stream_event) = event
                     .downcast_mut::<SyncWrapper<NewOutputStreamEvent>>()
                     .and_then(SyncWrapper::get_mut)

--- a/crates/firewheel-nodes/src/stream/reader.rs
+++ b/crates/firewheel-nodes/src/stream/reader.rs
@@ -15,7 +15,6 @@ use firewheel_core::{
         AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
         ProcInfo, ProcessStatus,
     },
-    sync_wrapper::SyncWrapper,
 };
 use fixed_resample::{PushStatus, ReadStatus, ResamplingChannelConfig};
 
@@ -313,7 +312,6 @@ impl AudioNode for StreamReaderNode {
                 num_inputs: config.channels.get(),
                 num_outputs: ChannelCount::ZERO,
             })
-            .uses_events(true)
             .custom_state(StreamReaderState::new(config.channels))
     }
 
@@ -375,20 +373,15 @@ impl AudioNodeProcessor for Processor {
         &mut self,
         buffers: ProcBuffers,
         proc_info: &ProcInfo,
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
-        events.for_each(|event| {
-            if let NodeEventType::Custom(event) = event.event {
-                if let Some(out_stream_event) = event
-                    .downcast_mut::<SyncWrapper<NewOutputStreamEvent>>()
-                    .and_then(SyncWrapper::get_mut)
-                {
-                    // Swap the memory so that the old channel will be properly
-                    // dropped outside of the audio thread.
-                    core::mem::swap(&mut self.prod, &mut out_stream_event.prod);
-                }
+        for mut event in events.drain() {
+            if let Some(out_stream_event) = event.downcast_mut::<NewOutputStreamEvent>() {
+                // Swap the values so that the old producer gets dropped on
+                // the main thread.
+                core::mem::swap(&mut self.prod, &mut out_stream_event.prod);
             }
-        });
+        }
 
         if !self.shared_state.stream_active.load(Ordering::Relaxed)
             || self.shared_state.paused.load(Ordering::Relaxed)
@@ -443,6 +436,6 @@ pub struct NewOutputStreamEvent {
 
 impl From<NewOutputStreamEvent> for NodeEventType {
     fn from(value: NewOutputStreamEvent) -> Self {
-        NodeEventType::Custom(Box::new(SyncWrapper::new(value)))
+        NodeEventType::custom(value)
     }
 }

--- a/crates/firewheel-nodes/src/stream/writer.rs
+++ b/crates/firewheel-nodes/src/stream/writer.rs
@@ -367,7 +367,7 @@ impl AudioNodeProcessor for Processor {
         mut events: NodeEventList,
     ) -> ProcessStatus {
         events.for_each(|event| {
-            if let NodeEventType::Custom(event) = event {
+            if let NodeEventType::Custom(event) = event.event {
                 if let Some(in_stream_event) = event
                     .downcast_mut::<SyncWrapper<NewInputStreamEvent>>()
                     .and_then(SyncWrapper::get_mut)

--- a/crates/firewheel-nodes/src/stream/writer.rs
+++ b/crates/firewheel-nodes/src/stream/writer.rs
@@ -16,7 +16,6 @@ use firewheel_core::{
         AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
         ProcInfo, ProcessStatus,
     },
-    sync_wrapper::SyncWrapper,
     SilenceMask,
 };
 use fixed_resample::{ReadStatus, ResamplingChannelConfig};
@@ -298,7 +297,6 @@ impl AudioNode for StreamWriterNode {
                 num_inputs: ChannelCount::ZERO,
                 num_outputs: config.channels.get(),
             })
-            .uses_events(true)
             .custom_state(StreamWriterState::new(config.channels))
     }
 
@@ -364,20 +362,15 @@ impl AudioNodeProcessor for Processor {
         &mut self,
         buffers: ProcBuffers,
         proc_info: &ProcInfo,
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
-        events.for_each(|event| {
-            if let NodeEventType::Custom(event) = event.event {
-                if let Some(in_stream_event) = event
-                    .downcast_mut::<SyncWrapper<NewInputStreamEvent>>()
-                    .and_then(SyncWrapper::get_mut)
-                {
-                    // Swap the memory so that the old channel will be properly
-                    // dropped outside of the audio thread.
-                    core::mem::swap(&mut self.cons, &mut in_stream_event.cons);
-                }
+        for mut event in events.drain() {
+            if let Some(in_stream_event) = event.downcast_mut::<NewInputStreamEvent>() {
+                // Swap the values so that the old consumer gets dropped on
+                // the main thread.
+                core::mem::swap(&mut self.cons, &mut in_stream_event.cons);
             }
-        });
+        }
 
         let enabled = self.shared_state.stream_active.load(Ordering::Relaxed)
             && !self.shared_state.paused.load(Ordering::Relaxed);
@@ -470,6 +463,6 @@ pub struct NewInputStreamEvent {
 
 impl From<NewInputStreamEvent> for NodeEventType {
     fn from(value: NewInputStreamEvent) -> Self {
-        NodeEventType::Custom(Box::new(SyncWrapper::new(value)))
+        NodeEventType::custom(value)
     }
 }

--- a/crates/firewheel-nodes/src/volume.rs
+++ b/crates/firewheel-nodes/src/volume.rs
@@ -168,10 +168,7 @@ impl SimpleAudioProcessor for VolumeProcessor {
             let out0 = buffers.outputs.next().unwrap();
             let out1 = buffers.outputs.next().unwrap();
 
-            for ((os0, ins0), (os1, ins1)) in out0
-                .iter_mut()
-                .zip(in0)
-                .zip(out1.iter_mut().zip(in1))
+            for ((os0, ins0), (os1, ins1)) in out0.iter_mut().zip(in0).zip(out1.iter_mut().zip(in1))
             {
                 let g = self.gain.next_smoothed();
                 *os0 = *ins0 * g;
@@ -182,9 +179,7 @@ impl SimpleAudioProcessor for VolumeProcessor {
             self.gain
                 .process_into_buffer(&mut scratch[..buffers.frames]);
 
-            for (ch_i, (out_ch, in_ch)) in
-                buffers.outputs.zip(buffers.inputs).enumerate()
-            {
+            for (ch_i, (out_ch, in_ch)) in buffers.outputs.zip(buffers.inputs).enumerate() {
                 if proc_info.in_silence_mask.is_channel_silent(ch_i) {
                     if !proc_info.out_silence_mask.is_channel_silent(ch_i) {
                         out_ch.fill(0.0);

--- a/crates/firewheel-nodes/src/volume.rs
+++ b/crates/firewheel-nodes/src/volume.rs
@@ -84,7 +84,7 @@ struct VolumeProcessor {
 }
 
 impl SimpleAudioProcessor for VolumeProcessor {
-    type Node = VolumeNode;
+    type Params = VolumeNode;
 
     fn can_skip_patch(&self, VolumeNodePatch::Volume(v): &VolumeNodePatch) -> bool {
         let gain = v.amp_clamped(self.amp_epsilon);

--- a/crates/firewheel-nodes/src/volume.rs
+++ b/crates/firewheel-nodes/src/volume.rs
@@ -2,11 +2,13 @@ use firewheel_core::{
     channel_config::{ChannelConfig, NonZeroChannelCount},
     diff::{Diff, Patch},
     dsp::volume::{Volume, DEFAULT_AMP_EPSILON},
+    event::NodeEventList,
     node::{
-        AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, GetChannels,
-        ProcInfo, ProcessStatus, SimpleAudioProcessor,
+        AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
+        ProcInfo, ProcessStatus,
     },
     param::smoother::{SmoothedParam, SmootherConfig},
+    SilenceMask,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -51,7 +53,6 @@ impl AudioNode for VolumeNode {
                 num_inputs: config.channels.get(),
                 num_outputs: config.channels.get(),
             })
-            .uses_events(true)
     }
 
     fn construct_processor(
@@ -83,35 +84,29 @@ struct VolumeProcessor {
     amp_epsilon: f32,
 }
 
-impl SimpleAudioProcessor for VolumeProcessor {
-    type Params = VolumeNode;
+impl AudioNodeProcessor for VolumeProcessor {
+    fn process(
+        &mut self,
+        buffers: ProcBuffers,
+        proc_info: &ProcInfo,
+        events: &mut NodeEventList,
+    ) -> ProcessStatus {
+        for patch in events.drain_patches::<VolumeNode>() {
+            let VolumeNodePatch::Volume(v) = patch;
 
-    fn can_skip_patch(&self, VolumeNodePatch::Volume(v): &VolumeNodePatch) -> bool {
-        let gain = v.amp_clamped(self.amp_epsilon);
+            let mut gain = v.amp_clamped(self.amp_epsilon);
+            if gain > 0.99999 && gain < 1.00001 {
+                gain = 1.0;
+            }
+            self.gain.set_value(gain);
 
-        // If the gain has not meaningfully changed, ignore.
-        (gain - self.gain.target_value()).abs() < DEFAULT_AMP_EPSILON
-    }
-
-    fn apply_patch(&mut self, VolumeNodePatch::Volume(v): VolumeNodePatch) {
-        let mut gain = v.amp_clamped(self.amp_epsilon);
-
-        if (1. - DEFAULT_AMP_EPSILON..1. + DEFAULT_AMP_EPSILON).contains(&gain) {
-            gain = 1.0;
+            if self.prev_block_was_silent {
+                // Previous block was silent, so no need to smooth.
+                self.gain.reset();
+            }
         }
 
-        self.gain.set_value(gain);
-
-        if self.prev_block_was_silent {
-            // Previous block was silent, so no need to smooth.
-            self.gain.reset();
-        }
-    }
-
-    fn process<B: GetChannels>(&mut self, mut buffers: B, proc_info: &ProcInfo) -> ProcessStatus {
         self.prev_block_was_silent = false;
-
-        let mut buffers = buffers.channels();
 
         if proc_info
             .in_silence_mask
@@ -134,7 +129,12 @@ impl SimpleAudioProcessor for VolumeProcessor {
                 // Unity gain, there is no need to process.
                 return ProcessStatus::Bypass;
             } else {
-                for (ch_i, (out_ch, in_ch)) in buffers.outputs.zip(buffers.inputs).enumerate() {
+                for (ch_i, (out_ch, in_ch)) in buffers
+                    .outputs
+                    .iter_mut()
+                    .zip(buffers.inputs.iter())
+                    .enumerate()
+                {
                     if proc_info.in_silence_mask.is_channel_silent(ch_i) {
                         if !proc_info.out_silence_mask.is_channel_silent(ch_i) {
                             out_ch.fill(0.0);
@@ -153,33 +153,35 @@ impl SimpleAudioProcessor for VolumeProcessor {
         }
 
         if buffers.inputs.len() == 1 {
-            for (os, is) in buffers
-                .outputs
-                .next()
-                .unwrap()
-                .iter_mut()
-                .zip(buffers.inputs.next().unwrap().iter())
-            {
+            // Provide an optimized loop for mono.
+            for (os, &is) in buffers.outputs[0].iter_mut().zip(buffers.inputs[0].iter()) {
                 *os = is * self.gain.next_smoothed();
             }
         } else if buffers.inputs.len() == 2 {
-            let in0 = buffers.inputs.next().unwrap();
-            let in1 = buffers.inputs.next().unwrap();
-            let out0 = buffers.outputs.next().unwrap();
-            let out1 = buffers.outputs.next().unwrap();
+            // Provide an optimized loop for stereo.
 
-            for ((os0, ins0), (os1, ins1)) in out0.iter_mut().zip(in0).zip(out1.iter_mut().zip(in1))
-            {
-                let g = self.gain.next_smoothed();
-                *os0 = *ins0 * g;
-                *os1 = *ins1 * g;
+            let in0 = &buffers.inputs[0][..proc_info.frames];
+            let in1 = &buffers.inputs[1][..proc_info.frames];
+            let (out0, out1) = buffers.outputs.split_first_mut().unwrap();
+            let out0 = &mut out0[..proc_info.frames];
+            let out1 = &mut out1[0][..proc_info.frames];
+
+            for i in 0..proc_info.frames {
+                let gain = self.gain.next_smoothed();
+
+                out0[i] = in0[i] * gain;
+                out1[i] = in1[i] * gain;
             }
         } else {
-            let scratch = buffers.scratch_buffers.next().unwrap();
             self.gain
-                .process_into_buffer(&mut scratch[..buffers.frames]);
+                .process_into_buffer(&mut buffers.scratch_buffers[0][..proc_info.frames]);
 
-            for (ch_i, (out_ch, in_ch)) in buffers.outputs.zip(buffers.inputs).enumerate() {
+            for (ch_i, (out_ch, in_ch)) in buffers
+                .outputs
+                .iter_mut()
+                .zip(buffers.inputs.iter())
+                .enumerate()
+            {
                 if proc_info.in_silence_mask.is_channel_silent(ch_i) {
                     if !proc_info.out_silence_mask.is_channel_silent(ch_i) {
                         out_ch.fill(0.0);
@@ -187,7 +189,11 @@ impl SimpleAudioProcessor for VolumeProcessor {
                     continue;
                 }
 
-                for ((os, &is), &g) in out_ch.iter_mut().zip(in_ch.iter()).zip(&*scratch) {
+                for ((os, &is), &g) in out_ch
+                    .iter_mut()
+                    .zip(in_ch.iter())
+                    .zip(buffers.scratch_buffers[0][..proc_info.frames].iter())
+                {
                     *os = is * g;
                 }
             }
@@ -195,9 +201,7 @@ impl SimpleAudioProcessor for VolumeProcessor {
 
         self.gain.settle();
 
-        ProcessStatus::OutputsModified {
-            out_silence_mask: proc_info.in_silence_mask,
-        }
+        ProcessStatus::outputs_modified(SilenceMask::NONE_SILENT)
     }
 
     fn new_stream(&mut self, stream_info: &firewheel_core::StreamInfo) {

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -2,9 +2,10 @@ use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     diff::{Diff, Patch},
     dsp::{pan_law::PanLaw, volume::Volume},
+    event::NodeEventList,
     node::{
-        AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, GetChannels,
-        ProcInfo, ProcessStatus, SimpleAudioProcessor,
+        AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
+        ProcInfo, ProcessStatus,
     },
     param::smoother::{SmoothedParam, SmootherConfig},
     SilenceMask,
@@ -75,7 +76,6 @@ impl AudioNode for VolumePanNode {
                 num_inputs: ChannelCount::STEREO,
                 num_outputs: ChannelCount::STEREO,
             })
-            .uses_events(true)
     }
 
     fn construct_processor(
@@ -105,7 +105,6 @@ impl AudioNode for VolumePanNode {
             params: *self,
             prev_block_was_silent: true,
             amp_epsilon: config.amp_epsilon,
-            updated: false,
         }
     }
 }
@@ -118,43 +117,28 @@ struct Processor {
 
     prev_block_was_silent: bool,
     amp_epsilon: f32,
-    updated: bool,
 }
 
-impl SimpleAudioProcessor for Processor {
-    type Params = VolumePanNode;
+impl AudioNodeProcessor for Processor {
+    fn process(
+        &mut self,
+        buffers: ProcBuffers,
+        proc_info: &ProcInfo,
+        events: &mut NodeEventList,
+    ) -> ProcessStatus {
+        let mut updated = false;
+        for mut patch in events.drain_patches::<VolumePanNode>() {
+            // here we selectively clamp the panning, leaving
+            // other patches untouched
+            if let VolumePanNodePatch::Pan(p) = &mut patch {
+                *p = p.clamp(-1.0, 1.0);
+            }
 
-    fn apply_patch(&mut self, mut patch: VolumePanNodePatch) {
-        // here we selectively clamp the panning, leaving
-        // other patches untouched
-        if let VolumePanNodePatch::Pan(p) = &mut patch {
-            *p = p.clamp(-1.0, 1.0);
+            self.params.apply(patch);
+            updated = true;
         }
 
-        self.params.apply(patch);
-        self.updated = true;
-    }
-
-    fn can_skip_patch(&self, patch: &VolumePanNodePatch) -> bool {
-        // here we selectively clamp the panning, leaving
-        // other patches untouched
-        match &patch {
-            VolumePanNodePatch::Pan(p) => {
-                let p = p.clamp(-1.0, 1.0);
-
-                (self.params.pan - p).abs() < f32::EPSILON
-            }
-            VolumePanNodePatch::Volume(v) => {
-                (self.params.volume.amp() - v.amp()).abs() < self.amp_epsilon
-            }
-            _ => false,
-        }
-    }
-
-    fn process<B: GetChannels>(&mut self, mut buffers: B, proc_info: &ProcInfo) -> ProcessStatus {
-        let mut buffers = buffers.channels();
-
-        if self.updated {
+        if updated {
             let (gain_l, gain_r) = self.params.compute_gains(self.amp_epsilon);
             self.gain_l.set_value(gain_l);
             self.gain_r.set_value(gain_r);
@@ -166,8 +150,6 @@ impl SimpleAudioProcessor for Processor {
             }
         }
 
-        self.updated = false;
-
         self.prev_block_was_silent = false;
 
         if proc_info.in_silence_mask.all_channels_silent(2) {
@@ -178,10 +160,11 @@ impl SimpleAudioProcessor for Processor {
             return ProcessStatus::ClearAllOutputs;
         }
 
-        let in1 = &buffers.inputs.next().unwrap();
-        let in2 = &buffers.inputs.next().unwrap();
-        let out1 = &mut buffers.outputs.next().unwrap();
-        let out2 = &mut buffers.outputs.next().unwrap();
+        let in1 = &buffers.inputs[0][..proc_info.frames];
+        let in2 = &buffers.inputs[1][..proc_info.frames];
+        let (out1, out2) = buffers.outputs.split_first_mut().unwrap();
+        let out1 = &mut out1[..proc_info.frames];
+        let out2 = &mut out2[0][..proc_info.frames];
 
         if !self.gain_l.is_smoothing() && !self.gain_r.is_smoothing() {
             if self.gain_l.target_value() == 0.0 && self.gain_r.target_value() == 0.0 {

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -131,11 +131,11 @@ impl AudioNodeProcessor for Processor {
         events.for_each_patch::<VolumePanNode>(|mut patch| {
             // here we selectively clamp the panning, leaving
             // other patches untouched
-            if let VolumePanNodePatch::Pan(p) = &mut patch {
+            if let VolumePanNodePatch::Pan(p) = &mut patch.event {
                 *p = p.clamp(-1.0, 1.0);
             }
 
-            self.params.apply(patch);
+            self.params.apply(patch.event);
             updated = true;
         });
 

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -122,7 +122,7 @@ struct Processor {
 }
 
 impl SimpleAudioProcessor for Processor {
-    type Node = VolumePanNode;
+    type Params = VolumePanNode;
 
     fn apply_patch(&mut self, mut patch: VolumePanNodePatch) {
         // here we selectively clamp the panning, leaving

--- a/examples/custom_nodes/src/nodes/filter.rs
+++ b/examples/custom_nodes/src/nodes/filter.rs
@@ -136,7 +136,7 @@ impl AudioNodeProcessor for Processor {
         //
         // We don't need to keep around a `FilterNode` instance,
         // so we can just match on each event directly.
-        events.for_each_patch::<FilterNode>(|patch| match patch {
+        events.for_each_patch::<FilterNode>(|patch| match patch.event {
             FilterNodePatch::CutoffHz(cutoff) => {
                 self.cutoff_hz.set_value(cutoff.clamp(20.0, 20_000.0));
             }

--- a/examples/custom_nodes/src/nodes/filter.rs
+++ b/examples/custom_nodes/src/nodes/filter.rs
@@ -70,10 +70,6 @@ impl AudioNode for FilterNode {
                 num_inputs: ChannelCount::STEREO,
                 num_outputs: ChannelCount::STEREO,
             })
-            // Wether or not our node uses events. If it does not, then setting
-            // this to `false` will save a bit of memory by not allocating an
-            // event buffer for this node.
-            .uses_events(true)
     }
 
     // Construct the realtime processor counterpart using the given information
@@ -130,25 +126,27 @@ impl AudioNodeProcessor for Processor {
         // Additional information about the process.
         proc_info: &ProcInfo,
         // The list of events for our node to process.
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
         // Process the events.
         //
         // We don't need to keep around a `FilterNode` instance,
         // so we can just match on each event directly.
-        events.for_each_patch::<FilterNode>(|patch| match patch.event {
-            FilterNodePatch::CutoffHz(cutoff) => {
-                self.cutoff_hz.set_value(cutoff.clamp(20.0, 20_000.0));
+        for patch in events.drain_patches::<FilterNode>() {
+            match patch {
+                FilterNodePatch::CutoffHz(cutoff) => {
+                    self.cutoff_hz.set_value(cutoff.clamp(20.0, 20_000.0));
+                }
+                FilterNodePatch::Volume(volume) => {
+                    self.gain.set_value(volume.amp_clamped(DEFAULT_AMP_EPSILON));
+                }
+                FilterNodePatch::Enabled(enabled) => {
+                    // Tell the declicker to crossfade.
+                    self.enable_declicker
+                        .fade_to_enabled(enabled, proc_info.declick_values);
+                }
             }
-            FilterNodePatch::Volume(volume) => {
-                self.gain.set_value(volume.amp_clamped(DEFAULT_AMP_EPSILON));
-            }
-            FilterNodePatch::Enabled(enabled) => {
-                // Tell the declicker to crossfade.
-                self.enable_declicker
-                    .fade_to_enabled(enabled, proc_info.declick_values);
-            }
-        });
+        }
 
         if self.enable_declicker.disabled() {
             // Disabled. Bypass this node.

--- a/examples/custom_nodes/src/nodes/noise_gen.rs
+++ b/examples/custom_nodes/src/nodes/noise_gen.rs
@@ -123,11 +123,11 @@ impl AudioNodeProcessor for Processor {
         events.for_each_patch::<NoiseGenNode>(|patch| {
             // Since we want to clamp the volume event, we can
             // grab it here and perform the processing only when required.
-            if let NoiseGenNodePatch::Volume(vol) = &patch {
+            if let NoiseGenNodePatch::Volume(vol) = &patch.event {
                 self.gain = vol.amp_clamped(DEFAULT_AMP_EPSILON);
             }
 
-            self.params.apply(patch);
+            self.params.apply(patch.event);
         });
 
         if !self.params.enabled {

--- a/examples/custom_nodes/src/nodes/noise_gen.rs
+++ b/examples/custom_nodes/src/nodes/noise_gen.rs
@@ -74,10 +74,6 @@ impl AudioNode for NoiseGenNode {
                 num_inputs: ChannelCount::ZERO,
                 num_outputs: ChannelCount::MONO,
             })
-            // Wether or not our node uses events. If it does not, then setting
-            // this to `false` will save a bit of memory by not allocating an
-            // event buffer for this node.
-            .uses_events(true)
     }
 
     // Construct the realtime processor counterpart using the given information
@@ -117,20 +113,20 @@ impl AudioNodeProcessor for Processor {
         // Additional information about the process.
         _proc_info: &ProcInfo,
         // The list of events for our node to process.
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
         // Process the events.
-        events.for_each_patch::<NoiseGenNode>(|patch| {
+        for patch in events.drain_patches::<NoiseGenNode>() {
             // Since we want to clamp the volume event, we can
             // grab it here and perform the processing only when required.
-            if let NoiseGenNodePatch::Volume(vol) = &patch.event {
+            if let NoiseGenNodePatch::Volume(vol) = &patch {
                 self.gain = vol.amp_clamped(DEFAULT_AMP_EPSILON);
             }
 
-            self.params.apply(patch.event);
-        });
+            self.params.apply(patch);
+        }
 
-        if !self.params.enabled {
+        if !self.params.enabled || self.gain == 0.0 {
             // Tell the engine to automatically and efficiently clear the output buffers
             // for us. This is equivalent to doing:
             // ```

--- a/examples/custom_nodes/src/nodes/rms.rs
+++ b/examples/custom_nodes/src/nodes/rms.rs
@@ -101,10 +101,6 @@ impl AudioNode for RmsNode {
                 num_inputs: ChannelCount::MONO,
                 num_outputs: ChannelCount::ZERO,
             })
-            // Wether or not our node uses events. If it does not, then setting
-            // this to `false` will save a bit of memory by not allocating an
-            // event buffer for this node.
-            .uses_events(true)
             // Custom !Send state that can be stored in the Firewheel context and
             // accessed by the user.
             //
@@ -159,9 +155,11 @@ impl AudioNodeProcessor for Processor {
         // Additional information about the process.
         proc_info: &ProcInfo,
         // The list of events for our node to process.
-        mut events: NodeEventList,
+        events: &mut NodeEventList,
     ) -> ProcessStatus {
-        events.for_each_patch::<RmsNode>(|p| self.params.apply(p.event));
+        for patch in events.drain_patches::<RmsNode>() {
+            self.params.apply(patch);
+        }
 
         if !self.params.enabled {
             self.shared_state.rms_value.store(0.0, Ordering::Relaxed);

--- a/examples/custom_nodes/src/nodes/rms.rs
+++ b/examples/custom_nodes/src/nodes/rms.rs
@@ -161,7 +161,7 @@ impl AudioNodeProcessor for Processor {
         // The list of events for our node to process.
         mut events: NodeEventList,
     ) -> ProcessStatus {
-        events.for_each_patch::<RmsNode>(|p| self.params.apply(p));
+        events.for_each_patch::<RmsNode>(|p| self.params.apply(p.event));
 
         if !self.params.enabled {
             self.shared_state.rms_value.store(0.0, Ordering::Relaxed);

--- a/examples/play_sample/src/main.rs
+++ b/examples/play_sample/src/main.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use clap::Parser;
 use firewheel::{
     error::UpdateError,
-    nodes::sampler::{RepeatMode, SamplerNode, SamplerState},
-    FirewheelContext, Volume,
+    nodes::sampler::{SamplerNode, SamplerState},
+    FirewheelContext,
 };
 use symphonium::SymphoniumLoader;
 
@@ -46,8 +46,8 @@ fn main() {
             .unwrap()
             .into_dyn_resource();
 
-    sampler_node.set_sample(sample, Volume::UNITY_GAIN, RepeatMode::PlayOnce);
-    cx.queue_event_for(sampler_id, sampler_node.sync_sequence_event());
+    sampler_node.set_sample(sample);
+    cx.queue_event_for(sampler_id, sampler_node.sync_sample_event());
 
     sampler_node.start_or_restart(None);
     cx.queue_event_for(sampler_id, sampler_node.sync_playback_event());

--- a/examples/sampler_pool/src/system.rs
+++ b/examples/sampler_pool/src/system.rs
@@ -3,12 +3,12 @@ use firewheel::{
     diff::Memo,
     error::UpdateError,
     nodes::{
-        sampler::{RepeatMode, SamplerNode},
+        sampler::SamplerNode,
         volume::{VolumeNode, VolumeNodeConfig},
         StereoToMonoNode,
     },
     sampler_pool::{FxChain, SamplerPool, VolumePanChain},
-    FirewheelContext, Volume,
+    FirewheelContext,
 };
 use symphonium::SymphoniumLoader;
 
@@ -64,7 +64,7 @@ impl AudioSystem {
         .into_dyn_resource();
 
         let mut sampler_node = SamplerNode::default();
-        sampler_node.set_sample(sample, Volume::UNITY_GAIN, RepeatMode::PlayOnce);
+        sampler_node.set_sample(sample);
 
         Self {
             cx,

--- a/examples/sampler_test/src/ui.rs
+++ b/examples/sampler_test/src/ui.rs
@@ -65,15 +65,7 @@ impl App for DemoApp {
                     ui.label(sampler_state.text);
 
                     if ui.button("Start or Restart").clicked() {
-                        self.audio_system.start_or_restart(
-                            i,
-                            sampler_state.percent_volume / 100.0,
-                            if sampler_state.repeat {
-                                RepeatMode::RepeatEndlessly
-                            } else {
-                                RepeatMode::PlayOnce
-                            },
-                        );
+                        self.audio_system.start_or_restart(i);
                     }
 
                     match self.audio_system.playback_state(i) {
@@ -94,18 +86,30 @@ impl App for DemoApp {
                         self.audio_system.stop(i);
                     }
 
-                    ui.checkbox(&mut sampler_state.repeat, "repeat");
+                    if ui.checkbox(&mut sampler_state.repeat, "repeat").changed() {
+                        let repeat_mode = if sampler_state.repeat {
+                            RepeatMode::RepeatEndlessly
+                        } else {
+                            RepeatMode::PlayOnce
+                        };
 
-                    ui.add(
-                        egui::Slider::new(&mut sampler_state.percent_volume, 0.0..=100.0)
-                            .text("volume"),
-                    );
+                        self.audio_system.set_repeat_mode(i, repeat_mode);
+                    }
+
+                    if ui
+                        .add(
+                            egui::Slider::new(&mut sampler_state.percent_volume, 0.0..=100.0)
+                                .text("volume"),
+                        )
+                        .changed()
+                    {
+                        self.audio_system
+                            .set_volume(i, sampler_state.percent_volume);
+                    }
                 });
 
                 ui.separator();
             }
-
-            ui.label("Note, \"repeat\" and \"volume\" are only applied when started/restarted.");
 
             ui.separator();
 

--- a/examples/spatial_basic/src/system.rs
+++ b/examples/spatial_basic/src/system.rs
@@ -6,7 +6,7 @@ use firewheel::{
         sampler::{RepeatMode, SamplerNode},
         spatial_basic::SpatialBasicNode,
     },
-    FirewheelContext, Volume,
+    FirewheelContext,
 };
 use symphonium::SymphoniumLoader;
 
@@ -40,7 +40,8 @@ impl AudioSystem {
         let graph_out_node_id = cx.graph_out_node_id();
 
         let mut sampler_node = SamplerNode::default();
-        sampler_node.set_sample(sample, Volume::UNITY_GAIN, RepeatMode::RepeatEndlessly);
+        sampler_node.set_sample(sample);
+        sampler_node.repeat_mode = RepeatMode::RepeatEndlessly;
         sampler_node.start_or_restart(None);
 
         let sampler_node_id = cx.add_node(sampler_node.clone(), None);

--- a/examples/visual_node_graph/src/system.rs
+++ b/examples/visual_node_graph/src/system.rs
@@ -153,10 +153,10 @@ impl AudioSystem {
 
     #[expect(dead_code)]
     pub fn queue_event(&mut self, node_id: NodeID, event: NodeEventType) {
-        self.cx.queue_event(NodeEvent { node_id, event });
+        self.cx.queue_event(NodeEvent { node_id, time: None, event });
     }
 
-    pub fn event_queue(&mut self, node_id: NodeID) -> ContextQueue<CpalBackend> {
+    pub fn event_queue(&mut self, node_id: NodeID) -> ContextQueue<'_, CpalBackend> {
         self.cx.event_queue(node_id)
     }
 }

--- a/examples/visual_node_graph/src/system.rs
+++ b/examples/visual_node_graph/src/system.rs
@@ -153,7 +153,11 @@ impl AudioSystem {
 
     #[expect(dead_code)]
     pub fn queue_event(&mut self, node_id: NodeID, event: NodeEventType) {
-        self.cx.queue_event(NodeEvent { node_id, time: None, event });
+        self.cx.queue_event(NodeEvent {
+            node_id,
+            time: None,
+            event,
+        });
     }
 
     pub fn event_queue(&mut self, node_id: NodeID) -> ContextQueue<'_, CpalBackend> {


### PR DESCRIPTION
This PR implements a lightweight way of optionally scheduling multiple patch updates per frame, with timing information. The user (e.g. `bevy_seedling`) can choose to ignore this and never provide timing information, in which case every `time` field will be `None`, and an `AudioProcessor` can choose to ignore timing information or ignore events that don't apply to the whole buffer. However, if `bevy_seedling` knows that a parameter is animated, it can use the information from the animation curve to generate multiple samples along that curve per buffer period. This isn't as flexible as full parameter automation support, as while it technically can support changing the parameter every sample it's quite an inefficient way to do it, but in my opinion it's the best middle-ground that supports both animation and decoupling the buffer rate from the framerate without needing Firewheel to understand Bevy curves.

I've added an example of using the new timing data to the `Volume` node.

In general the insertion could be smarter: converting events scheduled before (or at the start of) the next buffer period to `time: None`, coalescing events with the same `time` field, doing the sort on insert rather than before processing, but considering the small number of events per buffer period this implementation should be more than good enough. This simpler implementation might even be faster than implementing those changes.

### Motivation

As part of discussion with Corvus regarding the approach taken by FMOD, I found some examples of people complaining about choppiness when modulating parameters quickly. FMOD only supports buffer-rate parameter modulation by a game using it with a default rate of 50Hz, although it supports sample-rate modulation of many parameters when using the automation tools in FMOD Studio.

https://qa.fmod.com/t/correct-way-of-sending-parameters-to-fmod-choppy-sound/20905
https://qa.fmod.com/t/suggestion-seek-speed-on-everything/16947
https://qa.fmod.com/t/parameters-arent-performing-smoothly/16509
https://qa.fmod.com/t/fmod-parameters-and-quantization/22816

The idea for this approach is that it's a good-enough, opt-in solution that means that users of `bevy_seedling` can animate parameters without it audible aliasing, even if it's not the true audio-rate modulation you'd want in, say, a DAW.

### Note on vectorisation

One issue with true sample-rate modulation is that it can interfere with vectorisation. Since this API is only intended to increase the rate of param updates rather than true sample accuracy, the nodes can still batch-process in an autovectorisable way between parameter updates. I checked the disassembly of my `VolumeNode` implementation that uses timed events, and it is still being fully autovectorised, so it should have very little performance penalty compared to processing the entire buffer at once. I have not yet written benchmarks to prove the performance penalty, but I can at least confirm that the disassembly looks to be of equal quality to the previous version that only allows buffer-rate updates. As this approach is not intended to support full sample accuracy, just updating params at a higher rate than buffer-rate, it might be worth quantising event timing to some multiple of the maximum vector size of the platform or limiting the number of updates per buffer period. The necessity of this would have to be proven with benchmarks though, and I think that this kind of performance tuning is probably better done by e.g. `bevy_seedling` as a performance tuning option rather than being done implicitly inside Firewheel itself.