### PR TITLE
Add reflection for core types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ stream_nodes = ["firewheel-nodes/stream"]
 noise_gen_nodes = ["firewheel-nodes/noise_generators"]
 # Enables `Component` derive macros for node parameters
 bevy = ["firewheel-nodes/bevy", "firewheel-core/bevy"]
+# Enables `Reflect` derive macros for node parameters
+bevy_reflect = ["firewheel-nodes/bevy_reflect", "firewheel-core/bevy_reflect"]
 # Enables the wasm-bindgen feature for the CPAL backend
 wasm-bindgen = ["firewheel-cpal/wasm-bindgen"]
 

--- a/crates/firewheel-core/Cargo.toml
+++ b/crates/firewheel-core/Cargo.toml
@@ -20,8 +20,15 @@ symphonium = ["dep:symphonium"]
 resampler = ["dep:fixed-resample", "symphonium?/resampler"]
 # Enables the "arbitrary sinc" resampler in Symphonium for changing the
 # pitch/length of samples at load time.
-symphonium_stretch = ["symphonium", "resampler", "symphonium?/stretch-sinc-resampler"]
+symphonium_stretch = [
+    "symphonium",
+    "resampler",
+    "symphonium?/stretch-sinc-resampler",
+]
+# Enables `Component` derives for parameters.
 bevy = ["dep:bevy_ecs"]
+# Enables `Reflect` derives for core types.
+bevy_reflect = ["dep:bevy_reflect"]
 
 [dependencies]
 firewheel-macros.workspace = true
@@ -29,10 +36,17 @@ arrayvec.workspace = true
 bitflags.workspace = true
 thunderdome.workspace = true
 symphonium = { version = "0.6.1", default-features = false, optional = true }
-fixed-resample = { version = "0.9.1", default-features = false, features = ["resampler", "fft-resampler"], optional = true }
+fixed-resample = { version = "0.9.1", default-features = false, features = [
+    "resampler",
+    "fft-resampler",
+], optional = true }
 smallvec.workspace = true
 bevy_platform.workspace = true
 glam = "0.29"
 bevy_ecs = { version = "0.16", optional = true }
+bevy_reflect = { version = "0.16", optional = true }
 # TODO: Remove this once `bevy_platform` exposes the atomic float types from `portable-atomic`.
-portable-atomic = { version = "1", default-features = false, features = ["fallback", "float"] }
+portable-atomic = { version = "1", default-features = false, features = [
+    "fallback",
+    "float",
+] }

--- a/crates/firewheel-core/Cargo.toml
+++ b/crates/firewheel-core/Cargo.toml
@@ -43,8 +43,8 @@ fixed-resample = { version = "0.9.1", default-features = false, features = [
 smallvec.workspace = true
 bevy_platform.workspace = true
 glam = "0.29"
-bevy_ecs = { version = "0.16", optional = true }
-bevy_reflect = { version = "0.16", optional = true }
+bevy_ecs = { version = "0.16", default-features = false, optional = true }
+bevy_reflect = { version = "0.16", default-features = false, optional = true }
 # TODO: Remove this once `bevy_platform` exposes the atomic float types from `portable-atomic`.
 portable-atomic = { version = "1", default-features = false, features = [
     "fallback",

--- a/crates/firewheel-core/src/channel_config.rs
+++ b/crates/firewheel-core/src/channel_config.rs
@@ -7,6 +7,8 @@ pub const MAX_CHANNELS: usize = 64;
 /// This number cannot be greater than `64`.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(opaque))]
 pub struct ChannelCount(u32);
 
 impl ChannelCount {
@@ -65,6 +67,8 @@ impl Into<usize> for ChannelCount {
 /// This number cannot be `0` or greater than `64`.
 #[repr(transparent)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(opaque))]
 pub struct NonZeroChannelCount(NonZeroU32);
 
 impl NonZeroChannelCount {

--- a/crates/firewheel-core/src/clock.rs
+++ b/crates/firewheel-core/src/clock.rs
@@ -144,6 +144,7 @@ impl Patch for Option<EventInstant> {
 /// An absolute audio clock instant in units of seconds.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct InstantSeconds(pub f64);
 
 impl InstantSeconds {
@@ -189,6 +190,7 @@ impl InstantSeconds {
 /// An audio clock duration in units of seconds.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct DurationSeconds(pub f64);
 
 impl DurationSeconds {
@@ -322,6 +324,7 @@ impl Into<f64> for DurationSeconds {
 /// An absolute audio clock instant in units of samples (in a single channel of audio).
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct InstantSamples(pub i64);
 
 impl InstantSamples {
@@ -379,6 +382,7 @@ impl InstantSamples {
 /// An audio clock duration in units of samples (in a single channel of audio).
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct DurationSamples(pub i64);
 
 impl DurationSamples {
@@ -548,6 +552,7 @@ impl Into<i64> for DurationSamples {
 
 /// An absolute audio clock instant in units of musical beats.
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct InstantMusical(pub f64);
 
 impl InstantMusical {
@@ -586,6 +591,7 @@ impl InstantMusical {
 /// An audio clock duration in units of musical beats.
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct DurationMusical(pub f64);
 
 impl DurationMusical {

--- a/crates/firewheel-core/src/diff/leaf.rs
+++ b/crates/firewheel-core/src/diff/leaf.rs
@@ -208,7 +208,7 @@ impl<A: ?Sized + Send + Sync + 'static> Patch for ArcGc<A> {
     }
 }
 
-impl<T: ?Sized + Send + Sync + RealtimeClone + PartialEq + 'static> Diff for Option<T> {
+impl<T: Send + Sync + RealtimeClone + PartialEq + 'static> Diff for Option<T> {
     fn diff<E: EventQueue>(&self, baseline: &Self, path: PathBuilder, event_queue: &mut E) {
         if self != baseline {
             event_queue.push_param(ParamData::opt_any(self.clone()), path);
@@ -216,7 +216,7 @@ impl<T: ?Sized + Send + Sync + RealtimeClone + PartialEq + 'static> Diff for Opt
     }
 }
 
-impl<T: ?Sized + Send + Sync + RealtimeClone + PartialEq + 'static> Patch for Option<T> {
+impl<T: Send + Sync + RealtimeClone + PartialEq + 'static> Patch for Option<T> {
     type Patch = Self;
 
     fn patch(data: &ParamData, _: &[u32]) -> Result<Self::Patch, PatchError> {

--- a/crates/firewheel-core/src/diff/notify.rs
+++ b/crates/firewheel-core/src/diff/notify.rs
@@ -157,7 +157,7 @@ mod test {
     #[test]
     fn test_identical_write() {
         let baseline = Notify::new(0.5f32);
-        let mut value = baseline.clone();
+        let mut value = baseline;
 
         let mut events = Vec::new();
         value.diff(&baseline, PathBuilder::default(), &mut events);
@@ -167,5 +167,360 @@ mod test {
 
         value.diff(&baseline, PathBuilder::default(), &mut events);
         assert_eq!(events.len(), 1);
+    }
+}
+
+#[cfg(feature = "bevy_reflect")]
+mod reflect {
+    use super::Notify;
+
+    impl<T> bevy_reflect::GetTypeRegistration for Notify<T>
+    where
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        T: Clone
+            + Default
+            + bevy_reflect::FromReflect
+            + bevy_reflect::TypePath
+            + bevy_reflect::MaybeTyped
+            + bevy_reflect::__macro_exports::RegisterForReflection,
+    {
+        fn get_type_registration() -> bevy_reflect::TypeRegistration {
+            let mut registration = bevy_reflect::TypeRegistration::of::<Self>();
+            registration.insert:: <bevy_reflect::ReflectFromPtr>(bevy_reflect::FromType:: <Self> ::from_type());
+            registration.insert::<bevy_reflect::ReflectFromReflect>(
+                bevy_reflect::FromType::<Self>::from_type(),
+            );
+            registration
+                .insert::<bevy_reflect::prelude::ReflectDefault>(
+                    bevy_reflect::FromType::<Self>::from_type(),
+                );
+            registration
+        }
+
+        #[inline(never)]
+        fn register_type_dependencies(registry: &mut bevy_reflect::TypeRegistry) {
+            <T as bevy_reflect::__macro_exports::RegisterForReflection>::__register(registry);
+            <u64 as bevy_reflect::__macro_exports::RegisterForReflection>::__register(registry);
+        }
+    }
+
+    impl<T> bevy_reflect::Typed for Notify<T>
+    where
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        T: Clone
+            + bevy_reflect::FromReflect
+            + bevy_reflect::TypePath
+            + bevy_reflect::MaybeTyped
+            + bevy_reflect::__macro_exports::RegisterForReflection,
+    {
+        #[inline]
+        fn type_info() -> &'static bevy_reflect::TypeInfo {
+            static CELL: bevy_reflect::utility::GenericTypeInfoCell =
+                bevy_reflect::utility::GenericTypeInfoCell::new();
+            CELL.get_or_insert::<Self, _>(|| {
+                bevy_reflect::TypeInfo::Struct(
+                    bevy_reflect::StructInfo::new::<Self>(&[
+                        bevy_reflect::NamedField::new::<T>("value").with_custom_attributes(
+                            bevy_reflect::attributes::CustomAttributes::default(),
+                        ),
+                    ])
+                    .with_custom_attributes(bevy_reflect::attributes::CustomAttributes::default())
+                    .with_generics(bevy_reflect::Generics::from_iter([
+                        bevy_reflect::GenericInfo::Type(bevy_reflect::TypeParamInfo::new::<T>(
+                            std::borrow::Cow::Borrowed("T"),
+                        )),
+                    ])),
+                )
+            })
+        }
+    }
+
+    extern crate alloc;
+    impl<T> bevy_reflect::TypePath for Notify<T>
+    where
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        T: bevy_reflect::TypePath,
+    {
+        fn type_path() -> &'static str {
+            static CELL: bevy_reflect::utility::GenericTypePathCell =
+                bevy_reflect::utility::GenericTypePathCell::new();
+            CELL.get_or_insert::<Self, _>(|| {
+                ::core::ops::Add::<&str>::add(
+                    ::core::ops::Add::<&str>::add(
+                        ToString::to_string(::core::concat!(
+                            ::core::concat!(
+                                ::core::concat!(::core::module_path!(), "::"),
+                                "Notify"
+                            ),
+                            "<"
+                        )),
+                        <T as bevy_reflect::TypePath>::type_path(),
+                    ),
+                    ">",
+                )
+            })
+        }
+        fn short_type_path() -> &'static str {
+            static CELL: bevy_reflect::utility::GenericTypePathCell =
+                bevy_reflect::utility::GenericTypePathCell::new();
+            CELL.get_or_insert::<Self, _>(|| {
+                ::core::ops::Add::<&str>::add(
+                    ::core::ops::Add::<&str>::add(
+                        ToString::to_string(::core::concat!("Notify", "<")),
+                        <T as bevy_reflect::TypePath>::short_type_path(),
+                    ),
+                    ">",
+                )
+            })
+        }
+        fn type_ident() -> Option<&'static str> {
+            Some("Notify")
+        }
+        fn crate_name() -> Option<&'static str> {
+            Some(::core::module_path!().split(':').next().unwrap())
+        }
+        fn module_path() -> Option<&'static str> {
+            Some(::core::module_path!())
+        }
+    }
+
+    impl<T> bevy_reflect::Reflect for Notify<T>
+    where
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        T: Clone
+            + bevy_reflect::FromReflect
+            + bevy_reflect::TypePath
+            + bevy_reflect::MaybeTyped
+            + bevy_reflect::__macro_exports::RegisterForReflection,
+    {
+        #[inline]
+        fn into_any(self: Box<Self>) -> Box<dyn ::core::any::Any> {
+            self
+        }
+        #[inline]
+        fn as_any(&self) -> &dyn ::core::any::Any {
+            self
+        }
+        #[inline]
+        fn as_any_mut(&mut self) -> &mut dyn ::core::any::Any {
+            self
+        }
+        #[inline]
+        fn into_reflect(self: Box<Self>) -> Box<dyn bevy_reflect::Reflect> {
+            self
+        }
+        #[inline]
+        fn as_reflect(&self) -> &dyn bevy_reflect::Reflect {
+            self
+        }
+        #[inline]
+        fn as_reflect_mut(&mut self) -> &mut dyn bevy_reflect::Reflect {
+            self
+        }
+        #[inline]
+        fn set(
+            &mut self,
+            value: Box<dyn bevy_reflect::Reflect>,
+        ) -> Result<(), Box<dyn bevy_reflect::Reflect>> {
+            *self = <dyn bevy_reflect::Reflect>::take(value)?;
+            Ok(())
+        }
+    }
+
+    impl<T> bevy_reflect::Struct for Notify<T>
+    where
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        T: Clone
+            + bevy_reflect::FromReflect
+            + bevy_reflect::TypePath
+            + bevy_reflect::MaybeTyped
+            + bevy_reflect::__macro_exports::RegisterForReflection,
+    {
+        fn field(&self, name: &str) -> Option<&dyn bevy_reflect::PartialReflect> {
+            match name {
+                "value" => Some(&self.value),
+                _ => None,
+            }
+        }
+
+        fn field_mut(&mut self, name: &str) -> Option<&mut dyn bevy_reflect::PartialReflect> {
+            match name {
+                "value" => Some(self.as_mut()),
+                _ => None,
+            }
+        }
+
+        fn field_at(&self, index: usize) -> Option<&dyn bevy_reflect::PartialReflect> {
+            match index {
+                0usize => Some(&self.value),
+                _ => None,
+            }
+        }
+
+        fn field_at_mut(&mut self, index: usize) -> Option<&mut dyn bevy_reflect::PartialReflect> {
+            match index {
+                0usize => Some(self.as_mut()),
+                _ => None,
+            }
+        }
+
+        fn name_at(&self, index: usize) -> Option<&str> {
+            match index {
+                0usize => Some("value"),
+                _ => None,
+            }
+        }
+
+        fn field_len(&self) -> usize {
+            1usize
+        }
+
+        fn iter_fields(&self) -> bevy_reflect::FieldIter {
+            bevy_reflect::FieldIter::new(self)
+        }
+
+        fn to_dynamic_struct(&self) -> bevy_reflect::DynamicStruct {
+            let mut dynamic: bevy_reflect::DynamicStruct = Default::default();
+            dynamic.set_represented_type(bevy_reflect::PartialReflect::get_represented_type_info(
+                self,
+            ));
+            dynamic.insert_boxed(
+                "value",
+                bevy_reflect::PartialReflect::to_dynamic(&self.value),
+            );
+            dynamic
+        }
+    }
+
+    impl<T> bevy_reflect::PartialReflect for Notify<T>
+    where
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        T: Clone
+            + bevy_reflect::FromReflect
+            + bevy_reflect::TypePath
+            + bevy_reflect::MaybeTyped
+            + bevy_reflect::__macro_exports::RegisterForReflection,
+    {
+        #[inline]
+        fn get_represented_type_info(&self) -> Option<&'static bevy_reflect::TypeInfo> {
+            Some(<Self as bevy_reflect::Typed>::type_info())
+        }
+
+        #[inline]
+        fn try_apply(
+            &mut self,
+            value: &dyn bevy_reflect::PartialReflect,
+        ) -> Result<(), bevy_reflect::ApplyError> {
+            if let bevy_reflect::ReflectRef::Struct(struct_value) =
+                bevy_reflect::PartialReflect::reflect_ref(value)
+            {
+                for (i, value) in ::core::iter::Iterator::enumerate(
+                    bevy_reflect::Struct::iter_fields(struct_value),
+                ) {
+                    let name = bevy_reflect::Struct::name_at(struct_value, i).unwrap();
+                    if let Some(v) = bevy_reflect::Struct::field_mut(self, name) {
+                        bevy_reflect::PartialReflect::try_apply(v, value)?;
+                    }
+                }
+            } else {
+                return Result::Err(bevy_reflect::ApplyError::MismatchedKinds {
+                    from_kind: bevy_reflect::PartialReflect::reflect_kind(value),
+                    to_kind: bevy_reflect::ReflectKind::Struct,
+                });
+            }
+            Ok(())
+        }
+
+        #[inline]
+        fn reflect_kind(&self) -> bevy_reflect::ReflectKind {
+            bevy_reflect::ReflectKind::Struct
+        }
+
+        #[inline]
+        fn reflect_ref(&self) -> bevy_reflect::ReflectRef {
+            bevy_reflect::ReflectRef::Struct(self)
+        }
+
+        #[inline]
+        fn reflect_mut(&mut self) -> bevy_reflect::ReflectMut {
+            bevy_reflect::ReflectMut::Struct(self)
+        }
+
+        #[inline]
+        fn reflect_owned(self: Box<Self>) -> bevy_reflect::ReflectOwned {
+            bevy_reflect::ReflectOwned::Struct(self)
+        }
+
+        #[inline]
+        fn try_into_reflect(
+            self: Box<Self>,
+        ) -> Result<Box<dyn bevy_reflect::Reflect>, Box<dyn bevy_reflect::PartialReflect>> {
+            Ok(self)
+        }
+
+        #[inline]
+        fn try_as_reflect(&self) -> Option<&dyn bevy_reflect::Reflect> {
+            Some(self)
+        }
+
+        #[inline]
+        fn try_as_reflect_mut(&mut self) -> Option<&mut dyn bevy_reflect::Reflect> {
+            Some(self)
+        }
+
+        #[inline]
+        fn into_partial_reflect(self: Box<Self>) -> Box<dyn bevy_reflect::PartialReflect> {
+            self
+        }
+
+        #[inline]
+        fn as_partial_reflect(&self) -> &dyn bevy_reflect::PartialReflect {
+            self
+        }
+
+        #[inline]
+        fn as_partial_reflect_mut(&mut self) -> &mut dyn bevy_reflect::PartialReflect {
+            self
+        }
+
+        fn reflect_partial_eq(&self, value: &dyn bevy_reflect::PartialReflect) -> Option<bool> {
+            (bevy_reflect::struct_partial_eq)(self, value)
+        }
+
+        #[inline]
+        fn reflect_clone(
+            &self,
+        ) -> Result<Box<dyn bevy_reflect::Reflect>, bevy_reflect::ReflectCloneError> {
+            Ok(Box::new(Clone::clone(self)))
+        }
+    }
+
+    impl<T> bevy_reflect::FromReflect for Notify<T>
+    where
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        T: Default
+            + Clone
+            + bevy_reflect::FromReflect
+            + bevy_reflect::TypePath
+            + bevy_reflect::MaybeTyped
+            + bevy_reflect::__macro_exports::RegisterForReflection,
+    {
+        fn from_reflect(reflect: &dyn bevy_reflect::PartialReflect) -> Option<Self> {
+            if let bevy_reflect::ReflectRef::Struct(ref_struct) =
+                bevy_reflect::PartialReflect::reflect_ref(reflect)
+            {
+                let mut this = <Self as ::core::default::Default>::default();
+                if let Some(field) = (|| {
+                    <T as bevy_reflect::FromReflect>::from_reflect(bevy_reflect::Struct::field(
+                        ref_struct, "value",
+                    )?)
+                })() {
+                    this.value = field;
+                }
+                Some(this)
+            } else {
+                None
+            }
+        }
     }
 }

--- a/crates/firewheel-core/src/dsp/pan_law.rs
+++ b/crates/firewheel-core/src/dsp/pan_law.rs
@@ -5,6 +5,7 @@ use crate::diff::{Diff, Patch};
 /// The algorithm to use to map a normalized panning value in the range `[-1.0, 1.0]`
 /// to the corresponding gain values for the left and right channels.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Diff, Patch)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 #[repr(u32)]
 pub enum PanLaw {
     /// This pan law makes the signal appear to play at a constant volume across

--- a/crates/firewheel-core/src/dsp/volume.rs
+++ b/crates/firewheel-core/src/dsp/volume.rs
@@ -3,6 +3,7 @@ pub const DEFAULT_DB_EPSILON: f32 = -100.0;
 
 /// A value representing a volume (gain) applied to an audio signal.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub enum Volume {
     /// Volume in a linear scale, where `0.0` is silence and `1.0` is unity gain.
     Linear(f32),

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -15,6 +15,8 @@ pub mod dummy;
 
 /// A globally unique identifier for a node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(feature = "bevy_reflect", reflect(opaque))]
 pub struct NodeID(pub thunderdome::Index);
 
 impl NodeID {
@@ -312,8 +314,9 @@ impl<'a> UpdateContext<'a> {
 /// This should be preferred over `()` because it implements
 /// Bevy's `Component` trait, making the
 /// [`AudioNode`] implementor trivially Bevy-compatible.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct EmptyConfig;
 
 /// A type-erased dyn-compatible [`AudioNode`].

--- a/crates/firewheel-core/src/param/smoother.rs
+++ b/crates/firewheel-core/src/param/smoother.rs
@@ -7,6 +7,7 @@ use crate::{
 
 /// The configuration for a [`SmoothedParam`]
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct SmootherConfig {
     /// The amount of smoothing in seconds
     ///

--- a/crates/firewheel-nodes/Cargo.toml
+++ b/crates/firewheel-nodes/Cargo.toml
@@ -23,7 +23,7 @@ default = [
     "spatial_basic",
     "stream",
     "fast_filters",
-    "noise_generators"
+    "noise_generators",
 ]
 all_nodes = [
     "beep_test",
@@ -32,7 +32,7 @@ all_nodes = [
     "spatial_basic",
     "stream",
     "fast_filters",
-    "noise_generators"
+    "noise_generators",
 ]
 # Enables the "beep test" node
 beep_test = []
@@ -51,11 +51,17 @@ noise_generators = []
 stream = ["dep:fixed-resample"]
 # Enables `Component` derive macros
 bevy = ["dep:bevy_ecs"]
+# Enables `Reflect` derive macros
+bevy_reflect = ["dep:bevy_reflect"]
 
 [dependencies]
 firewheel-core = { path = "../firewheel-core", version = "0.6.0-beta.0" }
 bevy_platform.workspace = true
 crossbeam-utils = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
-fixed-resample = { version = "0.9.1", features = ["fft-resampler", "channel"], optional = true }
+fixed-resample = { version = "0.9.1", features = [
+    "fft-resampler",
+    "channel",
+], optional = true }
 bevy_ecs = { version = "0.16", optional = true }
+bevy_reflect = { version = "0.16", optional = true }

--- a/crates/firewheel-nodes/Cargo.toml
+++ b/crates/firewheel-nodes/Cargo.toml
@@ -41,7 +41,7 @@ peak_meter = []
 # Enables the sampler node
 sampler = ["dep:smallvec", "dep:crossbeam-utils"]
 # Enables the basic 3D spatial positioning node
-spatial_basic = []
+spatial_basic = ["bevy_reflect?/glam"]
 # Enables FastLowpassNode, FastHighpassNode, and FastBandpassNode
 fast_filters = []
 # Enables WhiteNoiseGenNode and PinkNoiseGenNode
@@ -63,5 +63,5 @@ fixed-resample = { version = "0.9.1", features = [
     "fft-resampler",
     "channel",
 ], optional = true }
-bevy_ecs = { version = "0.16", optional = true }
-bevy_reflect = { version = "0.16", optional = true }
+bevy_ecs = { version = "0.16", optional = true, default-features = false }
+bevy_reflect = { version = "0.16", optional = true, default-features = false }

--- a/crates/firewheel-nodes/src/beep_test.rs
+++ b/crates/firewheel-nodes/src/beep_test.rs
@@ -15,6 +15,7 @@ use firewheel_core::{
 /// bother with parameter smoothing.
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct BeepTestNode {
     /// The frequency of the sine wave in the range `[20.0, 20_000.0]`. A good
     /// value for testing is `440` (middle C).

--- a/crates/firewheel-nodes/src/noise_generator/pink.rs
+++ b/crates/firewheel-nodes/src/noise_generator/pink.rs
@@ -20,6 +20,7 @@ const COEFF_SUM: [i16; 5] = [22347, 27917, 29523, 29942, 30007];
 
 /// A simple node that generates white noise. (Mono output only)
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct PinkNoiseGenNode {
     /// The overall volume.
     ///
@@ -41,6 +42,7 @@ impl Default for PinkNoiseGenNode {
 
 /// The configuration for a [`PinkNoiseGenNode`]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct PinkNoiseGenConfig {
     /// The starting seed. This cannot be zero.
     pub seed: i32,

--- a/crates/firewheel-nodes/src/noise_generator/white.rs
+++ b/crates/firewheel-nodes/src/noise_generator/white.rs
@@ -15,6 +15,7 @@ use firewheel_core::{
 
 /// A simple node that generates white noise. (Mono output only)
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct WhiteNoiseGenNode {
     /// The overall volume.
     ///
@@ -36,6 +37,7 @@ impl Default for WhiteNoiseGenNode {
 
 /// The configuration for a [`WhiteNoiseGenNode`]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct WhiteNoiseGenConfig {
     /// The starting seed. This cannot be zero.
     pub seed: i32,

--- a/crates/firewheel-nodes/src/peak_meter.rs
+++ b/crates/firewheel-nodes/src/peak_meter.rs
@@ -13,6 +13,7 @@ use firewheel_core::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct PeakMeterSmootherConfig {
     /// The rate of decay in seconds.
     ///
@@ -152,6 +153,7 @@ impl<const NUM_CHANNELS: usize> PeakMeterSmoother<NUM_CHANNELS> {
 }
 
 #[derive(Diff, Patch, Debug, Clone, Copy)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct PeakMeterNode<const NUM_CHANNELS: usize> {
     pub enabled: bool,
 }

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -35,6 +35,7 @@ pub const MIN_PLAYBACK_SPEED: f64 = 0.0000001;
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct SamplerConfig {
     /// The number of channels in this node.
     pub channels: NonZeroChannelCount,
@@ -79,6 +80,7 @@ impl Default for SamplerConfig {
 /// speed of a sampler node.
 #[non_exhaustive]
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub enum PlaybackSpeedQuality {
     #[default]
     /// Low quality, fast performance. Recommended for most use cases.
@@ -337,6 +339,7 @@ impl SamplerState {
 
 /// A parameter representing the current playback state of a sample.
 #[derive(Default, Debug, Clone, Copy, PartialEq, RealtimeClone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub enum PlaybackState {
     /// Stop the sample.
     ///
@@ -382,6 +385,7 @@ impl PlaybackState {
 
 /// The playhead of a sample.
 #[derive(Debug, Clone, Copy, PartialEq, RealtimeClone)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub enum Playhead {
     /// The playhead in units of seconds.
     Seconds(f64),
@@ -415,6 +419,7 @@ impl Default for Playhead {
 
 /// How many times a sample should be repeated.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Diff, Patch)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub enum RepeatMode {
     /// Play the sample once and then stop.
     #[default]

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -25,6 +25,7 @@ const CALC_FILTER_COEFF_INTERVAL: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct SpatialBasicConfig {
     /// The time in seconds of the internal smoothing filter.
     ///
@@ -50,6 +51,7 @@ impl Default for SpatialBasicConfig {
 /// panning and filtering.
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct SpatialBasicNode {
     /// The overall volume. This is applied before the spatialization algorithm.
     pub volume: Volume,

--- a/crates/firewheel-nodes/src/stereo_to_mono.rs
+++ b/crates/firewheel-nodes/src/stereo_to_mono.rs
@@ -9,6 +9,7 @@ use firewheel_core::{
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct StereoToMonoNode;
 
 impl AudioNode for StereoToMonoNode {

--- a/crates/firewheel-nodes/src/stream/reader.rs
+++ b/crates/firewheel-nodes/src/stream/reader.rs
@@ -22,6 +22,7 @@ pub const MAX_CHANNELS: usize = 16;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct StreamReaderConfig {
     /// The number of channels.
     pub channels: NonZeroChannelCount,
@@ -37,6 +38,7 @@ impl Default for StreamReaderConfig {
 
 #[derive(Default, Debug, Clone, Copy)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct StreamReaderNode;
 
 #[derive(Clone)]

--- a/crates/firewheel-nodes/src/stream/writer.rs
+++ b/crates/firewheel-nodes/src/stream/writer.rs
@@ -26,6 +26,7 @@ pub const MAX_CHANNELS: usize = 16;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct StreamWriterConfig {
     /// The number of channels.
     pub channels: NonZeroChannelCount,
@@ -49,6 +50,7 @@ impl Default for StreamWriterConfig {
 
 #[derive(Default, Debug, Clone, Copy)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct StreamWriterNode;
 
 #[derive(Clone)]

--- a/crates/firewheel-nodes/src/volume.rs
+++ b/crates/firewheel-nodes/src/volume.rs
@@ -13,6 +13,7 @@ use firewheel_core::{
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct VolumeNodeConfig {
     /// The time in seconds of the internal smoothing filter.
     ///
@@ -39,6 +40,7 @@ impl Default for VolumeNodeConfig {
 
 #[derive(Default, Diff, Patch, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct VolumeNode {
     pub volume: Volume,
 }

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -17,6 +17,7 @@ pub use super::volume::VolumeNodeConfig;
 
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct VolumePanNode {
     /// The overall volume.
     pub volume: Volume,
@@ -29,6 +30,7 @@ pub struct VolumePanNode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct VolumePanNodeConfig {
     /// The time in seconds of the internal smoothing filter.
     ///


### PR DESCRIPTION
This PR adds reflection to core Firewheel types. Reflect derives were added to node parameters and configs, and any of the types in their fields. For the most part, this is a very small change, but will help immensely for first-class integration with Bevy. Furthermore, `bevy_reflection` is posed as a general-purpose reflection library despite the name, so I don't consider this as "invasive" as it might otherwise seem.

I also added a `PartialEq` to `EmptyConfig`. This is because I've started to do some change detection on configurations in `bevy_seedling` for automatic node re-insertion. This is so convenient that I think it'll be a good convention going forward to derive `PartialEq` for configurations where possible.

The `Notify` reflection had to be implemented manually to preserve the change detection invariants. It's a little hefty, but it's mostly macro-generated, so it doesn't necessarily represent a huge maintenance burden. Let me know if you feel strongly against the inclusion of the manual implementation.

If you think it's acceptable, I may also add manual derives for `ChannelCount` and `NonZeroChannelCount`, since they also have some important invariants.