### PR TITLE
improve spatial basic node

### DIFF
--- a/crates/firewheel-core/src/dsp/distance_attenuator.rs
+++ b/crates/firewheel-core/src/dsp/distance_attenuator.rs
@@ -1,0 +1,283 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
+use core::num::NonZeroU32;
+
+use firewheel_macros::{Diff, Patch};
+
+use crate::{
+    dsp::filter::single_pole_iir::{OnePoleIirLPF, OnePoleIirLPFCoeff},
+    param::smoother::{SmoothedParam, SmootherConfig},
+};
+
+pub const MUFFLE_CUTOFF_HZ_MIN: f32 = 20.0;
+pub const MUFFLE_CUTOFF_HZ_MAX: f32 = 20_480.0;
+const MUFFLE_CUTOFF_HZ_RANGE_RECIP: f32 = 1.0 / (MUFFLE_CUTOFF_HZ_MAX - MUFFLE_CUTOFF_HZ_MIN);
+const CALC_FILTER_COEFF_INTERVAL: usize = 8;
+
+/// The method in which to calculate the volume of a sound based on the distance from
+/// the listener.
+///
+/// Based on <https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel>
+///
+/// Interactive graph of the different models: <https://www.desmos.com/calculator/g1pbsc5m9y>
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Diff, Patch)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
+#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+pub enum DistanceModel {
+    #[default]
+    /// A linear distance model calculates the gain by:
+    ///
+    /// `reference_distance / (reference_distance + rolloff_factor * (max(distance, reference_distance) - reference_distance))`
+    ///
+    /// This mostly closely matches how sound is attenuated in the real world, and is the default model.
+    Inverse,
+    /// A linear distance model calculates the gain by:
+    ///
+    /// `(1.0 - rolloff_factor * (distance - reference_distance) / (max_distance - reference_distance)).clamp(0.0, 1.0)`
+    Linear,
+    /// An exponential distance model calculates the gain by:
+    ///
+    /// `pow((max(distance, reference_distance) / reference_distance, -rolloff_factor)`
+    ///
+    /// This is equivalent to [`DistanceModel::Inverse`] when `rolloff_factor = 1.0`.
+    Exponential,
+}
+
+impl DistanceModel {
+    fn calculate_gain(
+        &self,
+        distance: f32,
+        distance_gain_factor: f32,
+        reference_distance: f32,
+        maximum_distance: f32,
+    ) -> f32 {
+        if distance <= reference_distance || distance_gain_factor <= 0.00001 {
+            return 1.0;
+        }
+
+        match self {
+            DistanceModel::Inverse => {
+                reference_distance
+                    / (reference_distance
+                        + (distance_gain_factor * (distance - reference_distance)))
+            }
+            DistanceModel::Linear => {
+                if maximum_distance <= reference_distance {
+                    1.0
+                } else {
+                    (1.0 - (distance_gain_factor * (distance - reference_distance)
+                        / (maximum_distance - reference_distance)))
+                        .clamp(0.0, 1.0)
+                }
+            }
+            DistanceModel::Exponential => {
+                (distance / reference_distance).powf(-distance_gain_factor)
+            }
+        }
+    }
+}
+
+pub struct DistanceAttenuatorStereoDsp {
+    pub gain: SmoothedParam,
+    pub muffle_cutoff_hz: SmoothedParam,
+    pub damping_disabled: bool,
+
+    pub filter_l: OnePoleIirLPF,
+    pub filter_r: OnePoleIirLPF,
+}
+
+impl DistanceAttenuatorStereoDsp {
+    pub fn new(smoother_config: SmootherConfig, sample_rate: NonZeroU32) -> Self {
+        Self {
+            gain: SmoothedParam::new(1.0, smoother_config, sample_rate),
+            muffle_cutoff_hz: SmoothedParam::new(
+                MUFFLE_CUTOFF_HZ_MAX,
+                smoother_config,
+                sample_rate,
+            ),
+            damping_disabled: true,
+            filter_l: OnePoleIirLPF::default(),
+            filter_r: OnePoleIirLPF::default(),
+        }
+    }
+
+    pub fn is_silent(&self) -> bool {
+        self.gain.target_value() == 0.0 && !self.gain.is_smoothing()
+    }
+
+    pub fn compute_values(
+        &mut self,
+        distance: f32,
+        distance_model: DistanceModel,
+        distance_gain_factor: f32,
+        reference_distance: f32,
+        max_distance: f32,
+        distance_muffle_factor: f32,
+        max_muffle_distance: f32,
+        max_distance_muffle_cutoff_hz: f32,
+        muffle_cutoff_hz: f32,
+        min_gain: f32,
+    ) {
+        let reference_distance = reference_distance.max(0.00001);
+        let max_distance = max_distance.max(0.0);
+        let max_distance_muffle_cutoff_hz = max_distance_muffle_cutoff_hz.max(MUFFLE_CUTOFF_HZ_MIN);
+
+        let distance_gain = distance_model.calculate_gain(
+            distance,
+            distance_gain_factor,
+            reference_distance,
+            max_distance,
+        );
+
+        let gain = if distance_gain <= min_gain {
+            0.0
+        } else {
+            distance_gain
+        };
+
+        let distance_cutoff_norm = if distance_muffle_factor <= 0.00001
+            || distance <= reference_distance
+            || max_muffle_distance <= reference_distance
+            || max_distance_muffle_cutoff_hz >= MUFFLE_CUTOFF_HZ_MAX
+        {
+            1.0
+        } else {
+            let num = distance - reference_distance;
+            let den = max_muffle_distance - reference_distance;
+
+            let norm = 1.0 - (num / den).powf(distance_muffle_factor.recip());
+
+            let min_norm = (max_distance_muffle_cutoff_hz - MUFFLE_CUTOFF_HZ_MIN)
+                * MUFFLE_CUTOFF_HZ_RANGE_RECIP;
+
+            norm.max(min_norm)
+        };
+
+        let muffle_cutoff_hz = if (muffle_cutoff_hz < MUFFLE_CUTOFF_HZ_MAX - 0.01)
+            || distance_cutoff_norm < 1.0
+        {
+            let hz = if distance_cutoff_norm < 1.0 {
+                let muffle_cutoff_norm =
+                    (muffle_cutoff_hz - MUFFLE_CUTOFF_HZ_MIN) * MUFFLE_CUTOFF_HZ_RANGE_RECIP;
+                let final_norm = muffle_cutoff_norm * distance_cutoff_norm;
+
+                (final_norm * (MUFFLE_CUTOFF_HZ_MAX - MUFFLE_CUTOFF_HZ_MIN)) + MUFFLE_CUTOFF_HZ_MIN
+            } else {
+                muffle_cutoff_hz
+            };
+
+            Some(hz.clamp(MUFFLE_CUTOFF_HZ_MIN, MUFFLE_CUTOFF_HZ_MAX))
+        } else {
+            None
+        };
+
+        self.gain.set_value(gain);
+
+        if let Some(cutoff_hz) = muffle_cutoff_hz {
+            self.muffle_cutoff_hz.set_value(cutoff_hz);
+            self.damping_disabled = false;
+        } else {
+            self.muffle_cutoff_hz.set_value(MUFFLE_CUTOFF_HZ_MAX);
+            self.damping_disabled = true;
+        }
+    }
+
+    /// Returns `true` if the output buffers should be cleared with silence, `false`
+    /// otherwise.
+    pub fn process(
+        &mut self,
+        frames: usize,
+        out1: &mut [f32],
+        out2: &mut [f32],
+        sample_rate_recip: f64,
+    ) -> bool {
+        // Make doubly sure that the compiler optimizes away the bounds checking
+        // in the loop.
+        let out1 = &mut out1[..frames];
+        let out2 = &mut out2[..frames];
+
+        if !self.gain.is_smoothing() && !self.muffle_cutoff_hz.is_smoothing() {
+            if !self.gain.is_smoothing() && self.gain.target_value() == 0.0 {
+                self.gain.reset();
+                self.muffle_cutoff_hz.reset();
+                self.filter_l.reset();
+                self.filter_r.reset();
+
+                return true;
+            } else if self.damping_disabled {
+                for i in 0..frames {
+                    out1[i] = out1[i] * self.gain.target_value();
+                    out2[i] = out2[i] * self.gain.target_value();
+                }
+            } else {
+                // The cutoff parameter is not currently smoothing, so we can optimize by
+                // only updating the filter coefficients once.
+                let coeff = OnePoleIirLPFCoeff::new(
+                    self.muffle_cutoff_hz.target_value(),
+                    sample_rate_recip as f32,
+                );
+
+                for i in 0..frames {
+                    let l = out1[i] * self.gain.target_value();
+                    let r = out2[i] * self.gain.target_value();
+
+                    out1[i] = self.filter_l.process(l, coeff);
+                    out2[i] = self.filter_r.process(r, coeff);
+                }
+            }
+        } else {
+            if self.damping_disabled && !self.muffle_cutoff_hz.is_smoothing() {
+                for i in 0..frames {
+                    let gain = self.gain.next_smoothed();
+
+                    out1[i] = out1[i] * gain;
+                    out2[i] = out2[i] * gain;
+                }
+            } else {
+                let mut coeff = OnePoleIirLPFCoeff::default();
+
+                for i in 0..frames {
+                    let cutoff_hz = self.muffle_cutoff_hz.next_smoothed();
+                    let gain = self.gain.next_smoothed();
+
+                    let l = out1[i] * gain;
+                    let r = out2[i] * gain;
+
+                    // Because recalculating filter coefficients is expensive, a trick like
+                    // this can be use to only recalculate them every CALC_FILTER_COEFF_INTERVAL
+                    // frames.
+                    if i & (CALC_FILTER_COEFF_INTERVAL - 1) == 0 {
+                        coeff = OnePoleIirLPFCoeff::new(cutoff_hz, sample_rate_recip as f32);
+                    }
+
+                    out1[i] = self.filter_l.process(l, coeff);
+                    out2[i] = self.filter_r.process(r, coeff);
+                }
+            }
+
+            self.gain.settle();
+            self.muffle_cutoff_hz.settle();
+        }
+
+        false
+    }
+
+    pub fn reset(&mut self) {
+        self.gain.reset();
+        self.muffle_cutoff_hz.reset();
+        self.filter_l.reset();
+        self.filter_r.reset();
+    }
+
+    pub fn set_smooth_seconds(&mut self, seconds: f32, sample_rate: NonZeroU32) {
+        self.gain.set_smooth_seconds(seconds, sample_rate);
+        self.muffle_cutoff_hz
+            .set_smooth_seconds(seconds, sample_rate);
+    }
+
+    pub fn update_sample_rate(&mut self, sample_rate: NonZeroU32) {
+        self.gain.update_sample_rate(sample_rate);
+        self.muffle_cutoff_hz.update_sample_rate(sample_rate);
+    }
+}

--- a/crates/firewheel-core/src/dsp/filter/smoothing_filter.rs
+++ b/crates/firewheel-core/src/dsp/filter/smoothing_filter.rs
@@ -17,7 +17,7 @@ pub struct SmoothingFilterCoeff {
 
 impl SmoothingFilterCoeff {
     pub fn new(sample_rate: NonZeroU32, smooth_secs: f32) -> Self {
-        assert!(smooth_secs > 0.0);
+        let smooth_secs = smooth_secs.max(0.00001);
 
         let b1 = (-1.0f32 / (smooth_secs * sample_rate.get() as f32)).exp();
         let a0 = 1.0f32 - b1;

--- a/crates/firewheel-core/src/dsp/filter/smoothing_filter.rs
+++ b/crates/firewheel-core/src/dsp/filter/smoothing_filter.rs
@@ -3,7 +3,7 @@ use num_traits::Float;
 
 use core::num::NonZeroU32;
 
-pub const DEFAULT_SMOOTH_SECONDS: f32 = 10.0 / 1_000.0;
+pub const DEFAULT_SMOOTH_SECONDS: f32 = 15.0 / 1_000.0;
 pub const DEFAULT_SETTLE_EPSILON: f32 = 0.00001f32;
 
 /// The coefficients for a simple smoothing/declicking filter where:

--- a/crates/firewheel-core/src/dsp/mod.rs
+++ b/crates/firewheel-core/src/dsp/mod.rs
@@ -1,7 +1,7 @@
 pub mod algo;
 pub mod buffer;
 pub mod declick;
-pub mod distance_attenuator;
+pub mod distance_attenuation;
 pub mod filter;
 pub mod interleave;
 pub mod pan_law;

--- a/crates/firewheel-core/src/dsp/mod.rs
+++ b/crates/firewheel-core/src/dsp/mod.rs
@@ -1,6 +1,7 @@
 pub mod algo;
 pub mod buffer;
 pub mod declick;
+pub mod distance_attenuator;
 pub mod filter;
 pub mod interleave;
 pub mod pan_law;

--- a/crates/firewheel-nodes/src/noise_generator/pink.rs
+++ b/crates/firewheel-nodes/src/noise_generator/pink.rs
@@ -34,7 +34,7 @@ pub struct PinkNoiseGenNode {
     pub enabled: bool,
     /// The time in seconds of the internal smoothing filter.
     ///
-    /// By default this is set to `0.01` (10ms).
+    /// By default this is set to `0.015` (15ms).
     pub smooth_seconds: f32,
 }
 

--- a/crates/firewheel-nodes/src/noise_generator/pink.rs
+++ b/crates/firewheel-nodes/src/noise_generator/pink.rs
@@ -5,7 +5,10 @@
 use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     diff::{Diff, Patch},
-    dsp::volume::{Volume, DEFAULT_AMP_EPSILON},
+    dsp::{
+        filter::smoothing_filter::DEFAULT_SMOOTH_SECONDS,
+        volume::{Volume, DEFAULT_AMP_EPSILON},
+    },
     event::ProcEvents,
     node::{
         AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
@@ -29,6 +32,10 @@ pub struct PinkNoiseGenNode {
     pub volume: Volume,
     /// Whether or not this node is enabled.
     pub enabled: bool,
+    /// The time in seconds of the internal smoothing filter.
+    ///
+    /// By default this is set to `0.01` (10ms).
+    pub smooth_seconds: f32,
 }
 
 impl Default for PinkNoiseGenNode {
@@ -36,6 +43,7 @@ impl Default for PinkNoiseGenNode {
         Self {
             volume: Volume::Linear(0.4),
             enabled: true,
+            smooth_seconds: DEFAULT_SMOOTH_SECONDS,
         }
     }
 }
@@ -46,18 +54,11 @@ impl Default for PinkNoiseGenNode {
 pub struct PinkNoiseGenConfig {
     /// The starting seed. This cannot be zero.
     pub seed: i32,
-    /// The time in seconds of the internal smoothing filter.
-    ///
-    /// By default this is set to `0.01` (10ms).
-    pub smooth_secs: f32,
 }
 
 impl Default for PinkNoiseGenConfig {
     fn default() -> Self {
-        Self {
-            seed: 17,
-            smooth_secs: 10.0 / 1_000.0,
-        }
+        Self { seed: 17 }
     }
 }
 
@@ -85,7 +86,7 @@ impl AudioNode for PinkNoiseGenNode {
             gain: SmoothedParam::new(
                 self.volume.amp_clamped(DEFAULT_AMP_EPSILON),
                 SmootherConfig {
-                    smooth_secs: config.smooth_secs,
+                    smooth_seconds: self.smooth_seconds,
                     ..Default::default()
                 },
                 cx.stream_info.sample_rate,
@@ -114,14 +115,20 @@ struct Processor {
 impl AudioNodeProcessor for Processor {
     fn process(
         &mut self,
-        _info: &ProcInfo,
+        info: &ProcInfo,
         buffers: ProcBuffers,
         events: &mut ProcEvents,
         _extra: &mut ProcExtra,
     ) -> ProcessStatus {
         for patch in events.drain_patches::<PinkNoiseGenNode>() {
-            if let PinkNoiseGenNodePatch::Volume(vol) = patch {
-                self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
+            match patch {
+                PinkNoiseGenNodePatch::Volume(vol) => {
+                    self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
+                }
+                PinkNoiseGenNodePatch::SmoothSeconds(seconds) => {
+                    self.gain.set_smooth_seconds(seconds, info.sample_rate);
+                }
+                _ => {}
             }
 
             self.params.apply(patch);

--- a/crates/firewheel-nodes/src/noise_generator/white.rs
+++ b/crates/firewheel-nodes/src/noise_generator/white.rs
@@ -29,7 +29,7 @@ pub struct WhiteNoiseGenNode {
     pub enabled: bool,
     /// The time in seconds of the internal smoothing filter.
     ///
-    /// By default this is set to `0.01` (10ms).
+    /// By default this is set to `0.015` (15ms).
     pub smooth_seconds: f32,
 }
 

--- a/crates/firewheel-nodes/src/noise_generator/white.rs
+++ b/crates/firewheel-nodes/src/noise_generator/white.rs
@@ -3,7 +3,10 @@
 use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     diff::{Diff, Patch},
-    dsp::volume::{Volume, DEFAULT_AMP_EPSILON},
+    dsp::{
+        filter::smoothing_filter::DEFAULT_SMOOTH_SECONDS,
+        volume::{Volume, DEFAULT_AMP_EPSILON},
+    },
     event::ProcEvents,
     node::{
         AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
@@ -24,6 +27,10 @@ pub struct WhiteNoiseGenNode {
     pub volume: Volume,
     /// Whether or not this node is enabled.
     pub enabled: bool,
+    /// The time in seconds of the internal smoothing filter.
+    ///
+    /// By default this is set to `0.01` (10ms).
+    pub smooth_seconds: f32,
 }
 
 impl Default for WhiteNoiseGenNode {
@@ -31,6 +38,7 @@ impl Default for WhiteNoiseGenNode {
         Self {
             volume: Volume::Linear(0.4),
             enabled: true,
+            smooth_seconds: DEFAULT_SMOOTH_SECONDS,
         }
     }
 }
@@ -41,18 +49,11 @@ impl Default for WhiteNoiseGenNode {
 pub struct WhiteNoiseGenConfig {
     /// The starting seed. This cannot be zero.
     pub seed: i32,
-    /// The time in seconds of the internal smoothing filter.
-    ///
-    /// By default this is set to `0.01` (10ms).
-    pub smooth_secs: f32,
 }
 
 impl Default for WhiteNoiseGenConfig {
     fn default() -> Self {
-        Self {
-            seed: 17,
-            smooth_secs: 10.0 / 1_000.0,
-        }
+        Self { seed: 17 }
     }
 }
 
@@ -81,7 +82,7 @@ impl AudioNode for WhiteNoiseGenNode {
             gain: SmoothedParam::new(
                 self.volume.amp_clamped(DEFAULT_AMP_EPSILON),
                 SmootherConfig {
-                    smooth_secs: config.smooth_secs,
+                    smooth_seconds: self.smooth_seconds,
                     ..Default::default()
                 },
                 cx.stream_info.sample_rate,
@@ -101,14 +102,20 @@ struct Processor {
 impl AudioNodeProcessor for Processor {
     fn process(
         &mut self,
-        _info: &ProcInfo,
+        info: &ProcInfo,
         buffers: ProcBuffers,
         events: &mut ProcEvents,
         _extra: &mut ProcExtra,
     ) -> ProcessStatus {
         for patch in events.drain_patches::<WhiteNoiseGenNode>() {
-            if let WhiteNoiseGenNodePatch::Volume(vol) = patch {
-                self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
+            match patch {
+                WhiteNoiseGenNodePatch::Volume(vol) => {
+                    self.gain.set_value(vol.amp_clamped(DEFAULT_AMP_EPSILON));
+                }
+                WhiteNoiseGenNodePatch::SmoothSeconds(seconds) => {
+                    self.gain.set_smooth_seconds(seconds, info.sample_rate);
+                }
+                _ => {}
             }
 
             self.params.apply(patch);

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -9,10 +9,8 @@ use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     diff::{Diff, Patch},
     dsp::{
-        filter::{
-            single_pole_iir::{OnePoleIirLPF, OnePoleIirLPFCoeff},
-            smoothing_filter::DEFAULT_SMOOTH_SECONDS,
-        },
+        distance_attenuator::{DistanceAttenuatorStereoDsp, DistanceModel, MUFFLE_CUTOFF_HZ_MAX},
+        filter::smoothing_filter::DEFAULT_SMOOTH_SECONDS,
         pan_law::PanLaw,
         volume::Volume,
     },
@@ -25,71 +23,6 @@ use firewheel_core::{
     vector::Vec3,
     ConnectedMask, SilenceMask,
 };
-
-const MUFFLE_CUTOFF_HZ_MIN: f32 = 20.0;
-const MUFFLE_CUTOFF_HZ_MAX: f32 = 20_480.0;
-const MUFFLE_CUTOFF_HZ_RANGE_RECIP: f32 = 1.0 / (MUFFLE_CUTOFF_HZ_MAX - MUFFLE_CUTOFF_HZ_MIN);
-const CALC_FILTER_COEFF_INTERVAL: usize = 8;
-
-/// The method in which to calculate the volume of a sound based on the distance from
-/// the listener.
-///
-/// Based on <https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel>
-///
-/// Interactive graph of the different models: <https://www.desmos.com/calculator/g1pbsc5m9y>
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Diff, Patch)]
-#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
-#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
-pub enum DistanceModel {
-    #[default]
-    /// A linear distance model calculates the gain by:
-    ///
-    /// `reference_distance / (reference_distance + rolloff_factor * (max(distance, reference_distance) - reference_distance))`
-    ///
-    /// This mostly closely matches how sound is attenuated in the real world, and is the default model.
-    Inverse,
-    /// A linear distance model calculates the gain by:
-    ///
-    /// `(1.0 - rolloff_factor * (distance - reference_distance) / (max_distance - reference_distance)).clamp(0.0, 1.0)`
-    Linear,
-    /// An exponential distance model calculates the gain by:
-    ///
-    /// `pow((max(distance, reference_distance) / reference_distance, -rolloff_factor)`
-    ///
-    /// This is equivalent to [`DistanceModel::Inverse`] when `rolloff_factor = 1.0`.
-    Exponential,
-}
-
-impl DistanceModel {
-    fn calculate_gain(
-        &self,
-        distance: f32,
-        rolloff_factor: f32,
-        reference_distance: f32,
-        maximum_distance: f32,
-    ) -> f32 {
-        if distance <= reference_distance || rolloff_factor <= 0.00001 {
-            return 1.0;
-        }
-
-        match self {
-            DistanceModel::Inverse => {
-                reference_distance
-                    / (reference_distance + (rolloff_factor * (distance - reference_distance)))
-            }
-            DistanceModel::Linear => {
-                if maximum_distance <= reference_distance {
-                    1.0
-                } else {
-                    (1.0 - (rolloff_factor * (distance - reference_distance)
-                        / (maximum_distance - reference_distance)))
-                        .clamp(0.0, 1.0)
-                }
-            }
-            DistanceModel::Exponential => (distance / reference_distance).powf(-rolloff_factor),
-        }
-    }
-}
 
 /// The parameters for a 3D spatial positioning node using a basic (and naive) algorithm.
 /// It does not make use of any fancy binaural algorithms, rather it just applies basic
@@ -112,6 +45,25 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `(0.0, 0.0, 0.0)`
     pub offset: Vec3,
+
+    /// The threshold for the maximum amount of panning that can occur, in the range
+    /// `[0.0, 1.0]`, where `0.0` is no panning and `1.0` is full panning (where one
+    /// of the channels is fully silent when panned hard left or right).
+    ///
+    /// Setting this to a value less than `1.0` can help remove some of the
+    /// jarringness of having a sound playing in only one ear.
+    ///
+    /// By default this is set to `0.6`.
+    pub panning_threshold: f32,
+
+    /// If `true`, then any stereo input signals will be downmixed to mono before
+    /// going throught the spatialization algorithm. If `false` then the left and
+    /// right channels will be processed independently.
+    ///
+    /// This has no effect if only one input channel is connected.
+    ///
+    /// By default this is set to `true`.
+    pub downmix: bool,
 
     /// The method in which to calculate the volume of a sound based on the distance from
     /// the listener.
@@ -159,16 +111,6 @@ pub struct SpatialBasicNode {
     /// See <https://www.desmos.com/calculator/g1pbsc5m9y> for an interactive graph of
     /// how these parameters affect the final volume of a sound for each distance model.
     pub max_distance: f32,
-
-    /// The threshold for the maximum amount of panning that can occur, in the range
-    /// `[0.0, 1.0]`, where `0.0` is no panning and `1.0` is full panning (where one
-    /// of the channels is fully silent when panned hard left or right).
-    ///
-    /// Setting this to a value less than `1.0` can help remove some of the
-    /// jarringness of having a sound playing in only one ear.
-    ///
-    /// By default this is set to `0.6`.
-    pub panning_threshold: f32,
 
     /// The factor which determines the curve of the high frequency damping (lowpass)
     /// in relation to distance.
@@ -221,15 +163,6 @@ pub struct SpatialBasicNode {
     /// how these parameters affect the final lowpass cuttoff frequency.
     pub muffle_cutoff_hz: f32,
 
-    /// If `true`, then any stereo input signals will be downmixed to mono before
-    /// going throught the spatialization algorithm. If `false` then the left and
-    /// right channels will be processed independently.
-    ///
-    /// This has no effect if only one input channel is connected.
-    ///
-    /// By default this is set to `true`.
-    pub downmix: bool,
-
     /// The time in seconds of the internal smoothing filter.
     ///
     /// By default this is set to `0.015` (15ms).
@@ -246,16 +179,16 @@ impl Default for SpatialBasicNode {
         Self {
             volume: Volume::default(),
             offset: Vec3::new(0.0, 0.0, 0.0),
+            panning_threshold: 0.6,
+            downmix: true,
             distance_model: DistanceModel::Inverse,
             distance_gain_factor: 1.0,
             reference_distance: 5.0,
             max_distance: 200.0,
-            panning_threshold: 0.6,
             distance_muffle_factor: 1.9,
             max_muffle_distance: 200.0,
             max_distance_muffle_cutoff_hz: 20.0,
             muffle_cutoff_hz: MUFFLE_CUTOFF_HZ_MAX,
-            downmix: true,
             smooth_seconds: DEFAULT_SMOOTH_SECONDS,
             min_gain: 0.0001,
         }
@@ -263,17 +196,10 @@ impl Default for SpatialBasicNode {
 }
 
 impl SpatialBasicNode {
-    pub fn compute_values(&self) -> ComputedValues {
+    fn compute_values(&self) -> ComputedValues {
         let x2_z2 = (self.offset.x * self.offset.x) + (self.offset.z * self.offset.z);
-        let xyz_distance = (x2_z2 + (self.offset.y * self.offset.y)).sqrt();
         let xz_distance = x2_z2.sqrt();
-
-        let distance_gain = self.distance_model.calculate_gain(
-            xyz_distance,
-            self.distance_gain_factor,
-            self.reference_distance,
-            self.max_distance,
-        );
+        let distance = (x2_z2 + (self.offset.y * self.offset.y)).sqrt();
 
         let pan = if xz_distance > 0.0 {
             (self.offset.x / xz_distance) * self.panning_threshold.clamp(0.0, 1.0)
@@ -286,48 +212,9 @@ impl SpatialBasicNode {
         if volume_gain > 0.99999 && volume_gain < 1.00001 {
             volume_gain = 1.0;
         }
-        if volume_gain <= self.min_gain {
-            volume_gain = 0.0;
-        }
 
-        let distance_cutoff_norm = if self.distance_muffle_factor <= 0.00001
-            || xyz_distance <= self.reference_distance
-            || self.max_muffle_distance <= self.reference_distance
-            || self.max_distance_muffle_cutoff_hz >= MUFFLE_CUTOFF_HZ_MAX
-        {
-            1.0
-        } else {
-            let num = xyz_distance - self.reference_distance;
-            let den = self.max_muffle_distance - self.reference_distance;
-
-            let norm = 1.0 - (num / den).powf(self.distance_muffle_factor.recip());
-
-            let min_norm = (self.max_distance_muffle_cutoff_hz - MUFFLE_CUTOFF_HZ_MIN)
-                * MUFFLE_CUTOFF_HZ_RANGE_RECIP;
-
-            norm.max(min_norm)
-        };
-
-        let damping_cutoff_hz = if (self.muffle_cutoff_hz < MUFFLE_CUTOFF_HZ_MAX - 0.01)
-            || distance_cutoff_norm < 1.0
-        {
-            let hz = if distance_cutoff_norm < 1.0 {
-                let muffle_cutoff_norm =
-                    (self.muffle_cutoff_hz - MUFFLE_CUTOFF_HZ_MIN) * MUFFLE_CUTOFF_HZ_RANGE_RECIP;
-                let final_norm = muffle_cutoff_norm * distance_cutoff_norm;
-
-                (final_norm * (MUFFLE_CUTOFF_HZ_MAX - MUFFLE_CUTOFF_HZ_MIN)) + MUFFLE_CUTOFF_HZ_MIN
-            } else {
-                self.muffle_cutoff_hz
-            };
-
-            Some(hz.clamp(MUFFLE_CUTOFF_HZ_MIN, MUFFLE_CUTOFF_HZ_MAX))
-        } else {
-            None
-        };
-
-        let mut gain_l = pan_gain_l * distance_gain * volume_gain;
-        let mut gain_r = pan_gain_r * distance_gain * volume_gain;
+        let mut gain_l = pan_gain_l * volume_gain;
+        let mut gain_r = pan_gain_r * volume_gain;
 
         if gain_l <= self.min_gain {
             gain_l = 0.0;
@@ -337,17 +224,16 @@ impl SpatialBasicNode {
         }
 
         ComputedValues {
+            distance,
             gain_l,
             gain_r,
-            damping_cutoff_hz,
         }
     }
 }
-
-pub struct ComputedValues {
-    pub gain_l: f32,
-    pub gain_r: f32,
-    pub damping_cutoff_hz: Option<f32>,
+struct ComputedValues {
+    distance: f32,
+    gain_l: f32,
+    gain_r: f32,
 }
 
 impl AudioNode for SpatialBasicNode {
@@ -386,19 +272,13 @@ impl AudioNode for SpatialBasicNode {
                 },
                 cx.stream_info.sample_rate,
             ),
-            damping_cutoff_hz: SmoothedParam::new(
-                computed_values
-                    .damping_cutoff_hz
-                    .unwrap_or(MUFFLE_CUTOFF_HZ_MAX),
+            distance_attenuator: DistanceAttenuatorStereoDsp::new(
                 SmootherConfig {
                     smooth_seconds: self.smooth_seconds,
                     ..Default::default()
                 },
                 cx.stream_info.sample_rate,
             ),
-            damping_disabled: computed_values.damping_cutoff_hz.is_none(),
-            filter_l: OnePoleIirLPF::default(),
-            filter_r: OnePoleIirLPF::default(),
             params: *self,
             prev_block_was_silent: true,
         }
@@ -408,11 +288,8 @@ impl AudioNode for SpatialBasicNode {
 struct Processor {
     gain_l: SmoothedParam,
     gain_r: SmoothedParam,
-    damping_cutoff_hz: SmoothedParam,
-    damping_disabled: bool,
 
-    filter_l: OnePoleIirLPF,
-    filter_r: OnePoleIirLPF,
+    distance_attenuator: DistanceAttenuatorStereoDsp,
 
     params: SpatialBasicNode,
 
@@ -435,31 +312,13 @@ impl AudioNodeProcessor for Processor {
                         *offset = Vec3::default();
                     }
                 }
-                SpatialBasicNodePatch::DistanceGainFactor(f) => {
-                    *f = f.max(0.0);
-                }
-                SpatialBasicNodePatch::ReferenceDistance(d) => {
-                    *d = d.max(0.00001);
-                }
-                SpatialBasicNodePatch::MaxDistance(d) => {
-                    *d = d.max(0.0);
-                }
-                SpatialBasicNodePatch::DistanceMuffleFactor(f) => {
-                    *f = f.max(0.0);
-                }
-                SpatialBasicNodePatch::MaxDistanceMuffleCutoffHz(cutoff) => {
-                    *cutoff = cutoff.clamp(MUFFLE_CUTOFF_HZ_MIN, MUFFLE_CUTOFF_HZ_MAX);
-                }
-                SpatialBasicNodePatch::MuffleCutoffHz(cutoff) => {
-                    *cutoff = cutoff.clamp(MUFFLE_CUTOFF_HZ_MIN, MUFFLE_CUTOFF_HZ_MAX);
-                }
                 SpatialBasicNodePatch::PanningThreshold(threshold) => {
                     *threshold = threshold.clamp(0.0, 1.0);
                 }
                 SpatialBasicNodePatch::SmoothSeconds(seconds) => {
                     self.gain_l.set_smooth_seconds(*seconds, info.sample_rate);
                     self.gain_r.set_smooth_seconds(*seconds, info.sample_rate);
-                    self.damping_cutoff_hz
+                    self.distance_attenuator
                         .set_smooth_seconds(*seconds, info.sample_rate);
                 }
                 SpatialBasicNodePatch::MinGain(g) => {
@@ -478,21 +337,24 @@ impl AudioNodeProcessor for Processor {
             self.gain_l.set_value(computed_values.gain_l);
             self.gain_r.set_value(computed_values.gain_r);
 
-            if let Some(cutoff_hz) = computed_values.damping_cutoff_hz {
-                self.damping_cutoff_hz.set_value(cutoff_hz);
-                self.damping_disabled = false;
-            } else {
-                self.damping_cutoff_hz.set_value(MUFFLE_CUTOFF_HZ_MAX);
-                self.damping_disabled = true;
-            }
+            self.distance_attenuator.compute_values(
+                computed_values.distance,
+                self.params.distance_model,
+                self.params.distance_gain_factor,
+                self.params.reference_distance,
+                self.params.max_distance,
+                self.params.distance_muffle_factor,
+                self.params.max_muffle_distance,
+                self.params.max_distance_muffle_cutoff_hz,
+                self.params.muffle_cutoff_hz,
+                self.params.min_gain,
+            );
 
             if self.prev_block_was_silent {
                 // Previous block was silent, so no need to smooth.
                 self.gain_l.reset();
                 self.gain_r.reset();
-                self.damping_cutoff_hz.reset();
-                self.filter_l.reset();
-                self.filter_r.reset();
+                self.distance_attenuator.reset();
             }
         }
 
@@ -501,9 +363,7 @@ impl AudioNodeProcessor for Processor {
         if info.in_silence_mask.all_channels_silent(2) {
             self.gain_l.reset();
             self.gain_r.reset();
-            self.damping_cutoff_hz.reset();
-            self.filter_l.reset();
-            self.filter_r.reset();
+            self.distance_attenuator.reset();
 
             self.prev_block_was_silent = true;
 
@@ -515,12 +375,12 @@ impl AudioNodeProcessor for Processor {
         let (in1, in2) = if info.in_connected_mask == ConnectedMask::STEREO_CONNECTED {
             if self.params.downmix {
                 // Downmix the stereo signal to mono.
-                for (out_s, (&in1, &in2)) in scratch_buffer[..info.frames].iter_mut().zip(
+                for (scratch_s, (&in1, &in2)) in scratch_buffer[..info.frames].iter_mut().zip(
                     buffers.inputs[0][..info.frames]
                         .iter()
                         .zip(buffers.inputs[1][..info.frames].iter()),
                 ) {
-                    *out_s = (in1 + in2) * 0.5;
+                    *scratch_s = (in1 + in2) * 0.5;
                 }
 
                 (
@@ -551,87 +411,58 @@ impl AudioNodeProcessor for Processor {
         let out1 = &mut out1[..info.frames];
         let out2 = &mut out2[0][..info.frames];
 
-        if !self.gain_l.is_smoothing()
-            && !self.gain_r.is_smoothing()
-            && !self.damping_cutoff_hz.is_smoothing()
-        {
-            if self.gain_l.target_value() == 0.0 && self.gain_r.target_value() == 0.0 {
+        if !self.gain_l.is_smoothing() && !self.gain_r.is_smoothing() {
+            if self.gain_l.target_value() == 0.0
+                && self.gain_r.target_value() == 0.0
+                && self.distance_attenuator.is_silent()
+            {
                 self.gain_l.reset();
                 self.gain_r.reset();
-                self.damping_cutoff_hz.reset();
-                self.filter_l.reset();
-                self.filter_r.reset();
+                self.distance_attenuator.reset();
 
                 self.prev_block_was_silent = true;
 
                 return ProcessStatus::ClearAllOutputs;
-            } else if self.damping_disabled {
-                for i in 0..info.frames {
-                    out1[i] = in1[i] * self.gain_l.target_value();
-                    out2[i] = in2[i] * self.gain_r.target_value();
-                }
             } else {
-                // The cutoff parameter is not currently smoothing, so we can optimize by
-                // only updating the filter coefficients once.
-                let coeff = OnePoleIirLPFCoeff::new(
-                    self.damping_cutoff_hz.target_value(),
-                    info.sample_rate_recip as f32,
-                );
-
                 for i in 0..info.frames {
                     out1[i] = in1[i] * self.gain_l.target_value();
                     out2[i] = in2[i] * self.gain_r.target_value();
-
-                    out1[i] = self.filter_l.process(out1[i], coeff);
-                    out2[i] = self.filter_r.process(out2[i], coeff);
                 }
             }
-
-            ProcessStatus::outputs_modified(info.in_silence_mask);
         } else {
-            if self.damping_disabled && !self.damping_cutoff_hz.is_smoothing() {
-                for i in 0..info.frames {
-                    let gain_l = self.gain_l.next_smoothed();
-                    let gain_r = self.gain_r.next_smoothed();
+            for i in 0..info.frames {
+                let gain_l = self.gain_l.next_smoothed();
+                let gain_r = self.gain_r.next_smoothed();
 
-                    out1[i] = in1[i] * gain_l;
-                    out2[i] = in2[i] * gain_r;
-                }
-            } else {
-                let mut coeff = OnePoleIirLPFCoeff::default();
-
-                for i in 0..info.frames {
-                    let cutoff_hz = self.damping_cutoff_hz.next_smoothed();
-                    let gain_l = self.gain_l.next_smoothed();
-                    let gain_r = self.gain_r.next_smoothed();
-
-                    out1[i] = in1[i] * gain_l;
-                    out2[i] = in2[i] * gain_r;
-
-                    // Because recalculating filter coefficients is expensive, a trick like
-                    // this can be use to only recalculate them every CALC_FILTER_COEFF_INTERVAL
-                    // frames.
-                    if i & (CALC_FILTER_COEFF_INTERVAL - 1) == 0 {
-                        coeff = OnePoleIirLPFCoeff::new(cutoff_hz, info.sample_rate_recip as f32);
-                    }
-
-                    out1[i] = self.filter_l.process(out1[i], coeff);
-                    out2[i] = self.filter_r.process(out2[i], coeff);
-                }
+                out1[i] = in1[i] * gain_l;
+                out2[i] = in2[i] * gain_r;
             }
 
             self.gain_l.settle();
             self.gain_r.settle();
-            self.damping_cutoff_hz.settle();
         }
 
-        ProcessStatus::outputs_modified(SilenceMask::NONE_SILENT)
+        let clear_outputs =
+            self.distance_attenuator
+                .process(info.frames, out1, out2, info.sample_rate_recip);
+
+        if clear_outputs {
+            self.gain_l.reset();
+            self.gain_r.reset();
+            self.distance_attenuator.reset();
+
+            self.prev_block_was_silent = true;
+
+            return ProcessStatus::ClearAllOutputs;
+        } else {
+            ProcessStatus::outputs_modified(SilenceMask::NONE_SILENT)
+        }
     }
 
     fn new_stream(&mut self, stream_info: &firewheel_core::StreamInfo) {
         self.gain_l.update_sample_rate(stream_info.sample_rate);
         self.gain_r.update_sample_rate(stream_info.sample_rate);
-        self.damping_cutoff_hz
+        self.distance_attenuator
             .update_sample_rate(stream_info.sample_rate);
     }
 }

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -67,10 +67,6 @@ pub struct SpatialBasicNode {
     /// By default this is set to `true`.
     pub downmix: bool,
 
-    /// The parameters which describe how to attenuate a sound based on its distance from
-    /// the listener.
-    pub distance_attenuation: DistanceAttenuation,
-
     /// The amount of muffling (lowpass) in the range `[20.0, 20_480.0]`,
     /// where `20_480.0` is no muffling and `20.0` is maximum muffling.
     ///
@@ -82,6 +78,10 @@ pub struct SpatialBasicNode {
     /// See <https://www.desmos.com/calculator/jxp8t9ero4> for an interactive graph of
     /// how these parameters affect the final lowpass cuttoff frequency.
     pub muffle_cutoff_hz: f32,
+
+    /// The parameters which describe how to attenuate a sound based on its distance from
+    /// the listener.
+    pub distance_attenuation: DistanceAttenuation,
 
     /// The time in seconds of the internal smoothing filter.
     ///

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -232,7 +232,7 @@ pub struct SpatialBasicNode {
 
     /// The time in seconds of the internal smoothing filter.
     ///
-    /// By default this is set to `0.01` (10ms).
+    /// By default this is set to `0.015` (15ms).
     pub smooth_seconds: f32,
     /// If the resutling gain (in raw amplitude, not decibels) is less than or equal
     /// to this value, the the gain will be clamped to `0` (silence).

--- a/crates/firewheel-nodes/src/spatial_basic.rs
+++ b/crates/firewheel-nodes/src/spatial_basic.rs
@@ -56,9 +56,9 @@ impl Default for SpatialBasicConfig {
 /// The method in which to calculate the volume of a sound based on the distance from
 /// the listener.
 ///
-/// Based on https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel
+/// Based on <https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel>
 ///
-/// Interactive graph of the different models: https://www.desmos.com/calculator/g1pbsc5m9y
+/// Interactive graph of the different models: <https://www.desmos.com/calculator/g1pbsc5m9y>
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Diff, Patch)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
@@ -140,9 +140,9 @@ pub struct SpatialBasicNode {
     ///
     /// by default this is set to [`DistanceModel::Inverse`].
     ///
-    /// Based on https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel
+    /// Based on <https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel>
     ///
-    /// Interactive graph of the different models: https://www.desmos.com/calculator/g1pbsc5m9y
+    /// Interactive graph of the different models: <https://www.desmos.com/calculator/g1pbsc5m9y>
     pub distance_model: DistanceModel,
 
     /// The factor by which the sound gets quieter the farther away it is from the
@@ -155,7 +155,7 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `1.0`.
     ///
-    /// See https://www.desmos.com/calculator/g1pbsc5m9y for an interactive graph of
+    /// See <https://www.desmos.com/calculator/g1pbsc5m9y> for an interactive graph of
     /// how these parameters affect the final volume of a sound for each distance model.
     pub distance_gain_factor: f32,
 
@@ -166,11 +166,11 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `5.0`.
     ///
-    /// See https://www.desmos.com/calculator/g1pbsc5m9y for an interactive graph of
+    /// See <https://www.desmos.com/calculator/g1pbsc5m9y> for an interactive graph of
     /// how these parameters affect the final volume of a sound for each distance model.
     pub reference_distance: f32,
 
-    /// When using [`DistanceAlgorithm::Linear`], the maximum reference distance (at a
+    /// When using [`DistanceModel::Linear`], the maximum reference distance (at a
     /// rolloff factor of `1.0`) of a sound before it is considered to be "silent".
     /// (Distances greater than this value will be clamped to silence).
     ///
@@ -178,7 +178,7 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `200.0`.
     ///
-    /// See https://www.desmos.com/calculator/g1pbsc5m9y for an interactive graph of
+    /// See <https://www.desmos.com/calculator/g1pbsc5m9y> for an interactive graph of
     /// how these parameters affect the final volume of a sound for each distance model.
     pub max_distance: f32,
 
@@ -202,7 +202,7 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `1.9`.
     ///
-    /// See https://www.desmos.com/calculator/jxp8t9ero4 for an interactive graph of
+    /// See <https://www.desmos.com/calculator/jxp8t9ero4> for an interactive graph of
     /// how these parameters affect the final lowpass cuttoff frequency.
     pub distance_muffle_factor: f32,
 
@@ -215,7 +215,7 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `200.0`.
     ///
-    /// See https://www.desmos.com/calculator/jxp8t9ero4 for an interactive graph of
+    /// See <https://www.desmos.com/calculator/jxp8t9ero4> for an interactive graph of
     /// how these parameters affect the final lowpass cuttoff frequency.
     pub max_muffle_distance: f32,
 
@@ -227,7 +227,7 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `20.0`.
     ///
-    /// See https://www.desmos.com/calculator/jxp8t9ero4 for an interactive graph of
+    /// See <https://www.desmos.com/calculator/jxp8t9ero4> for an interactive graph of
     /// how these parameters affect the final lowpass cuttoff frequency.
     pub max_distance_muffle_cutoff_hz: f32,
 
@@ -239,7 +239,7 @@ pub struct SpatialBasicNode {
     ///
     /// By default this is set to `20_480.0`.
     ///
-    /// See https://www.desmos.com/calculator/jxp8t9ero4 for an interactive graph of
+    /// See <https://www.desmos.com/calculator/jxp8t9ero4> for an interactive graph of
     /// how these parameters affect the final lowpass cuttoff frequency.
     pub muffle_cutoff_hz: f32,
 

--- a/crates/firewheel-nodes/src/volume.rs
+++ b/crates/firewheel-nodes/src/volume.rs
@@ -38,7 +38,7 @@ pub struct VolumeNode {
 
     /// The time in seconds of the internal smoothing filter.
     ///
-    /// By default this is set to `0.01` (10ms).
+    /// By default this is set to `0.015` (15ms).
     pub smooth_seconds: f32,
     /// If the resutling gain (in raw amplitude, not decibels) is less
     /// than or equal to this value, then the gain will be clamped to

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -34,7 +34,7 @@ pub struct VolumePanNode {
 
     /// The time in seconds of the internal smoothing filter.
     ///
-    /// By default this is set to `0.01` (10ms).
+    /// By default this is set to `0.015` (15ms).
     pub smooth_seconds: f32,
     /// If the resutling gain (in raw amplitude, not decibels) is less
     /// than or equal to this value, then the gain will be clamped to

--- a/crates/firewheel-nodes/src/volume_pan.rs
+++ b/crates/firewheel-nodes/src/volume_pan.rs
@@ -1,7 +1,11 @@
 use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount},
     diff::{Diff, Patch},
-    dsp::{pan_law::PanLaw, volume::Volume},
+    dsp::{
+        filter::smoothing_filter::DEFAULT_SMOOTH_SECONDS,
+        pan_law::PanLaw,
+        volume::{Volume, DEFAULT_AMP_EPSILON},
+    },
     event::ProcEvents,
     node::{
         AudioNode, AudioNodeInfo, AudioNodeProcessor, ConstructProcessorContext, ProcBuffers,
@@ -27,15 +31,17 @@ pub struct VolumePanNode {
     /// The algorithm to use to map a normalized panning value in the range `[-1.0, 1.0]`
     /// to the corresponding gain values for the left and right channels.
     pub pan_law: PanLaw,
-}
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
-pub struct VolumePanNodeConfig {
     /// The time in seconds of the internal smoothing filter.
     ///
     /// By default this is set to `0.01` (10ms).
-    pub smooth_secs: f32,
+    pub smooth_seconds: f32,
+    /// If the resutling gain (in raw amplitude, not decibels) is less
+    /// than or equal to this value, then the gain will be clamped to
+    /// `0.0` (silence).
+    ///
+    /// By default this is set to `0.00001` (-100 decibels).
+    pub min_gain: f32,
 }
 
 impl VolumePanNode {
@@ -64,6 +70,8 @@ impl Default for VolumePanNode {
             volume: Volume::default(),
             pan: 0.0,
             pan_law: PanLaw::default(),
+            smooth_seconds: DEFAULT_SMOOTH_SECONDS,
+            min_gain: DEFAULT_AMP_EPSILON,
         }
     }
 }
@@ -82,16 +90,18 @@ impl AudioNode for VolumePanNode {
 
     fn construct_processor(
         &self,
-        config: &Self::Configuration,
+        _config: &Self::Configuration,
         cx: ConstructProcessorContext,
     ) -> impl AudioNodeProcessor {
-        let (gain_l, gain_r) = self.compute_gains(config.amp_epsilon);
+        let min_gain = self.min_gain.max(0.0);
+
+        let (gain_l, gain_r) = self.compute_gains(self.min_gain);
 
         Processor {
             gain_l: SmoothedParam::new(
                 gain_l,
                 SmootherConfig {
-                    smooth_secs: config.smooth_secs,
+                    smooth_seconds: self.smooth_seconds,
                     ..Default::default()
                 },
                 cx.stream_info.sample_rate,
@@ -99,14 +109,14 @@ impl AudioNode for VolumePanNode {
             gain_r: SmoothedParam::new(
                 gain_r,
                 SmootherConfig {
-                    smooth_secs: config.smooth_secs,
+                    smooth_seconds: self.smooth_seconds,
                     ..Default::default()
                 },
                 cx.stream_info.sample_rate,
             ),
             params: *self,
             prev_block_was_silent: true,
-            amp_epsilon: config.amp_epsilon,
+            min_gain,
         }
     }
 }
@@ -118,7 +128,7 @@ struct Processor {
     params: VolumePanNode,
 
     prev_block_was_silent: bool,
-    amp_epsilon: f32,
+    min_gain: f32,
 }
 
 impl AudioNodeProcessor for Processor {
@@ -131,10 +141,18 @@ impl AudioNodeProcessor for Processor {
     ) -> ProcessStatus {
         let mut updated = false;
         for mut patch in events.drain_patches::<VolumePanNode>() {
-            // here we selectively clamp the panning, leaving
-            // other patches untouched
-            if let VolumePanNodePatch::Pan(p) = &mut patch {
-                *p = p.clamp(-1.0, 1.0);
+            match &mut patch {
+                VolumePanNodePatch::Pan(p) => {
+                    *p = p.clamp(-1.0, 1.0);
+                }
+                VolumePanNodePatch::SmoothSeconds(seconds) => {
+                    self.gain_l.set_smooth_seconds(*seconds, info.sample_rate);
+                    self.gain_r.set_smooth_seconds(*seconds, info.sample_rate);
+                }
+                VolumePanNodePatch::MinGain(min_gain) => {
+                    self.min_gain = min_gain.max(0.0);
+                }
+                _ => {}
             }
 
             self.params.apply(patch);
@@ -142,7 +160,7 @@ impl AudioNodeProcessor for Processor {
         }
 
         if updated {
-            let (gain_l, gain_r) = self.params.compute_gains(self.amp_epsilon);
+            let (gain_l, gain_r) = self.params.compute_gains(self.min_gain);
             self.gain_l.set_value(gain_l);
             self.gain_r.set_value(gain_r);
 

--- a/crates/firewheel-pool/src/spatial_basic.rs
+++ b/crates/firewheel-pool/src/spatial_basic.rs
@@ -12,7 +12,6 @@ use crate::FxChain;
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
 pub struct SpatialBasicChain {
     pub spatial_basic: firewheel_nodes::spatial_basic::SpatialBasicNode,
-    pub config: firewheel_nodes::spatial_basic::SpatialBasicConfig,
 }
 
 impl SpatialBasicChain {
@@ -55,7 +54,7 @@ impl FxChain for SpatialBasicChain {
     ) -> Vec<NodeID> {
         let spatial_basic_params = firewheel_nodes::spatial_basic::SpatialBasicNode::default();
 
-        let spatial_basic_node_id = cx.add_node(spatial_basic_params, Some(self.config));
+        let spatial_basic_node_id = cx.add_node(spatial_basic_params, None);
 
         cx.connect(
             first_node_id,

--- a/examples/spatial_basic/src/main.rs
+++ b/examples/spatial_basic/src/main.rs
@@ -11,8 +11,8 @@ fn main() -> eframe::Result<()> {
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([575.0, 535.0])
-            .with_min_inner_size([575.0, 535.0]),
+            .with_inner_size([575.0, 555.0])
+            .with_min_inner_size([575.0, 555.0]),
         vsync: true,
         ..Default::default()
     };

--- a/examples/spatial_basic/src/main.rs
+++ b/examples/spatial_basic/src/main.rs
@@ -11,8 +11,8 @@ fn main() -> eframe::Result<()> {
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([575.0, 555.0])
-            .with_min_inner_size([575.0, 555.0]),
+            .with_inner_size([575.0, 575.0])
+            .with_min_inner_size([575.0, 575.0]),
         vsync: true,
         ..Default::default()
     };

--- a/examples/spatial_basic/src/main.rs
+++ b/examples/spatial_basic/src/main.rs
@@ -11,8 +11,8 @@ fn main() -> eframe::Result<()> {
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
-            .with_inner_size([575.0, 405.0])
-            .with_min_inner_size([575.0, 405.0]),
+            .with_inner_size([575.0, 535.0])
+            .with_min_inner_size([575.0, 535.0]),
         vsync: true,
         ..Default::default()
     };

--- a/examples/spatial_basic/src/ui.rs
+++ b/examples/spatial_basic/src/ui.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use eframe::App;
 use egui::{epaint::CircleShape, Color32, Pos2, Sense, Stroke, StrokeKind};
-use firewheel::{dsp::distance_attenuator::DistanceModel, Volume};
+use firewheel::{dsp::distance_attenuation::DistanceModel, Volume};
 
 use crate::system::AudioSystem;
 
@@ -114,32 +114,61 @@ impl App for DemoApp {
                 ))
                 .changed();
 
-            let before = self.audio_system.spatial_basic_node.distance_model;
+            let before = self
+                .audio_system
+                .spatial_basic_node
+                .distance_attenuation
+                .distance_model;
             egui::ComboBox::from_label("distance model")
-                .selected_text(match self.audio_system.spatial_basic_node.distance_model {
-                    DistanceModel::Inverse => "Inverse",
-                    DistanceModel::Linear => "Linear",
-                    DistanceModel::Exponential => "Exponential",
-                })
+                .selected_text(
+                    match self
+                        .audio_system
+                        .spatial_basic_node
+                        .distance_attenuation
+                        .distance_model
+                    {
+                        DistanceModel::Inverse => "Inverse",
+                        DistanceModel::Linear => "Linear",
+                        DistanceModel::Exponential => "Exponential",
+                    },
+                )
                 .show_ui(ui, |ui| {
                     ui.selectable_value(
-                        &mut self.audio_system.spatial_basic_node.distance_model,
+                        &mut self
+                            .audio_system
+                            .spatial_basic_node
+                            .distance_attenuation
+                            .distance_model,
                         DistanceModel::Inverse,
                         "Inverse",
                     );
                     ui.selectable_value(
-                        &mut self.audio_system.spatial_basic_node.distance_model,
+                        &mut self
+                            .audio_system
+                            .spatial_basic_node
+                            .distance_attenuation
+                            .distance_model,
                         DistanceModel::Linear,
                         "Linear",
                     );
                     ui.selectable_value(
-                        &mut self.audio_system.spatial_basic_node.distance_model,
+                        &mut self
+                            .audio_system
+                            .spatial_basic_node
+                            .distance_attenuation
+                            .distance_model,
                         DistanceModel::Exponential,
                         "Exponential",
                     );
                 });
 
-            if self.audio_system.spatial_basic_node.distance_model != before {
+            if self
+                .audio_system
+                .spatial_basic_node
+                .distance_attenuation
+                .distance_model
+                != before
+            {
                 updated = true;
             }
 
@@ -147,7 +176,11 @@ impl App for DemoApp {
                 updated |= ui
                     .add(
                         egui::Slider::new(
-                            &mut self.audio_system.spatial_basic_node.distance_gain_factor,
+                            &mut self
+                                .audio_system
+                                .spatial_basic_node
+                                .distance_attenuation
+                                .distance_gain_factor,
                             0.0001..=10.0,
                         )
                         .step_by(0.0)
@@ -162,7 +195,11 @@ impl App for DemoApp {
                 updated |= ui
                     .add(
                         egui::Slider::new(
-                            &mut self.audio_system.spatial_basic_node.reference_distance,
+                            &mut self
+                                .audio_system
+                                .spatial_basic_node
+                                .distance_attenuation
+                                .reference_distance,
                             0.0001..=50.0,
                         )
                         .step_by(0.0)
@@ -175,7 +212,11 @@ impl App for DemoApp {
                 updated |= ui
                     .add(
                         egui::Slider::new(
-                            &mut self.audio_system.spatial_basic_node.max_distance,
+                            &mut self
+                                .audio_system
+                                .spatial_basic_node
+                                .distance_attenuation
+                                .max_distance,
                             1.0..=500.0,
                         )
                         .step_by(0.0)
@@ -190,7 +231,11 @@ impl App for DemoApp {
                 updated |= ui
                     .add(
                         egui::Slider::new(
-                            &mut self.audio_system.spatial_basic_node.distance_muffle_factor,
+                            &mut self
+                                .audio_system
+                                .spatial_basic_node
+                                .distance_attenuation
+                                .distance_muffle_factor,
                             0.0..=10.0,
                         )
                         .step_by(0.0)
@@ -204,7 +249,11 @@ impl App for DemoApp {
             updated |= ui
                 .add(
                     egui::Slider::new(
-                        &mut self.audio_system.spatial_basic_node.max_muffle_distance,
+                        &mut self
+                            .audio_system
+                            .spatial_basic_node
+                            .distance_attenuation
+                            .max_muffle_distance,
                         1.0..=500.0,
                     )
                     .step_by(0.0)
@@ -218,6 +267,7 @@ impl App for DemoApp {
                         &mut self
                             .audio_system
                             .spatial_basic_node
+                            .distance_attenuation
                             .max_distance_muffle_cutoff_hz,
                         20.0..=20_480.0,
                     )

--- a/examples/spatial_basic/src/ui.rs
+++ b/examples/spatial_basic/src/ui.rs
@@ -171,18 +171,6 @@ impl App for DemoApp {
             updated |= ui
                 .add(
                     egui::Slider::new(
-                        &mut self.audio_system.spatial_basic_node.min_gain,
-                        0.0..=1.0,
-                    )
-                    .logarithmic(true)
-                    .step_by(0.0)
-                    .text("minimum gain (raw amplitude, not decibels)"),
-                )
-                .changed();
-
-            updated |= ui
-                .add(
-                    egui::Slider::new(
                         &mut self.audio_system.spatial_basic_node.panning_threshold,
                         0.0..=1.0,
                     )
@@ -249,6 +237,29 @@ impl App for DemoApp {
                     &mut self.audio_system.spatial_basic_node.downmix,
                     "downmix stereo to mono",
                 ))
+                .changed();
+
+            updated |= ui
+                .add(
+                    egui::Slider::new(
+                        &mut self.audio_system.spatial_basic_node.min_gain,
+                        0.0..=1.0,
+                    )
+                    .logarithmic(true)
+                    .step_by(0.0)
+                    .text("minimum gain (raw amplitude, not decibels)"),
+                )
+                .changed();
+
+            updated |= ui
+                .add(
+                    egui::Slider::new(
+                        &mut self.audio_system.spatial_basic_node.smooth_seconds,
+                        0.0..=0.15,
+                    )
+                    .step_by(0.0)
+                    .text("smoothing filter seconds"),
+                )
                 .changed();
 
             let offset = &mut self.audio_system.spatial_basic_node.offset;

--- a/examples/spatial_basic/src/ui.rs
+++ b/examples/spatial_basic/src/ui.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use eframe::App;
 use egui::{epaint::CircleShape, Color32, Pos2, Sense, Stroke, StrokeKind};
-use firewheel::{nodes::spatial_basic::DistanceModel, Volume};
+use firewheel::{dsp::distance_attenuator::DistanceModel, Volume};
 
 use crate::system::AudioSystem;
 
@@ -96,6 +96,24 @@ impl App for DemoApp {
                 )
                 .changed();
 
+            updated |= ui
+                .add(
+                    egui::Slider::new(
+                        &mut self.audio_system.spatial_basic_node.panning_threshold,
+                        0.0..=1.0,
+                    )
+                    .step_by(0.0)
+                    .text("panning threshold"),
+                )
+                .changed();
+
+            updated |= ui
+                .add(egui::Checkbox::new(
+                    &mut self.audio_system.spatial_basic_node.downmix,
+                    "downmix stereo to mono",
+                ))
+                .changed();
+
             let before = self.audio_system.spatial_basic_node.distance_model;
             egui::ComboBox::from_label("distance model")
                 .selected_text(match self.audio_system.spatial_basic_node.distance_model {
@@ -168,17 +186,6 @@ impl App for DemoApp {
                 ui.label("(only has effect with linear distance model)");
             });
 
-            updated |= ui
-                .add(
-                    egui::Slider::new(
-                        &mut self.audio_system.spatial_basic_node.panning_threshold,
-                        0.0..=1.0,
-                    )
-                    .step_by(0.0)
-                    .text("panning threshold"),
-                )
-                .changed();
-
             ui.horizontal(|ui| {
                 updated |= ui
                     .add(
@@ -230,13 +237,6 @@ impl App for DemoApp {
                     .logarithmic(true)
                     .text("muffle cutoff hz"),
                 )
-                .changed();
-
-            updated |= ui
-                .add(egui::Checkbox::new(
-                    &mut self.audio_system.spatial_basic_node.downmix,
-                    "downmix stereo to mono",
-                ))
                 .changed();
 
             updated |= ui

--- a/examples/spatial_basic/src/ui.rs
+++ b/examples/spatial_basic/src/ui.rs
@@ -171,6 +171,18 @@ impl App for DemoApp {
             updated |= ui
                 .add(
                     egui::Slider::new(
+                        &mut self.audio_system.spatial_basic_node.min_gain,
+                        0.0..=1.0,
+                    )
+                    .logarithmic(true)
+                    .step_by(0.0)
+                    .text("minimum gain (raw amplitude, not decibels)"),
+                )
+                .changed();
+
+            updated |= ui
+                .add(
+                    egui::Slider::new(
                         &mut self.audio_system.spatial_basic_node.panning_threshold,
                         0.0..=1.0,
                     )

--- a/examples/spatial_basic/src/ui.rs
+++ b/examples/spatial_basic/src/ui.rs
@@ -130,7 +130,7 @@ impl App for DemoApp {
                     .add(
                         egui::Slider::new(
                             &mut self.audio_system.spatial_basic_node.distance_gain_factor,
-                            0.0001..=3.0,
+                            0.0001..=10.0,
                         )
                         .step_by(0.0)
                         .text("distance gain factor"),
@@ -145,7 +145,7 @@ impl App for DemoApp {
                     .add(
                         egui::Slider::new(
                             &mut self.audio_system.spatial_basic_node.reference_distance,
-                            0.0001..=10.0,
+                            0.0001..=50.0,
                         )
                         .step_by(0.0)
                         .text("reference distance"),
@@ -184,7 +184,7 @@ impl App for DemoApp {
                     .add(
                         egui::Slider::new(
                             &mut self.audio_system.spatial_basic_node.distance_muffle_factor,
-                            0.0..=3.0,
+                            0.0..=10.0,
                         )
                         .step_by(0.0)
                         .text("distance muffle factor"),


### PR DESCRIPTION
The spatial basic node has been reworked to follow the distance models from https://developer.mozilla.org/en-US/docs/Web/API/PannerNode/distanceModel.

I have also improved the "muffling" model to be more flexible.

Right now the default values are just a rough guess of what I thought sounded good. I would love some feedback on better default values to use. Especially from someone using it in the context of an actual 3D game.