### PR TITLE
Pin `glam` to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,8 @@ bevy = ["firewheel-nodes/bevy", "firewheel-core/bevy"]
 bevy_reflect = ["firewheel-nodes/bevy_reflect", "firewheel-core/bevy_reflect"]
 # Enables the wasm-bindgen feature for the CPAL backend
 wasm-bindgen = ["firewheel-cpal/wasm-bindgen"]
-# Enables `glam::Vec2` and `glam::Vec3` parameter derives.
-glam = ["firewheel-core/glam"]
+# Enables `glam::Vec2` and `glam::Vec3` parameter derives for glam 0.29.
+glam-29 = ["firewheel-core/glam-29"]
 # Enables the `MIDI` event type, using the `wmidi` crate.
 midi_events = ["firewheel-core/midi_events"]
 

--- a/crates/firewheel-core/Cargo.toml
+++ b/crates/firewheel-core/Cargo.toml
@@ -87,8 +87,8 @@ symphonium_stretch = [
 bevy = ["dep:bevy_ecs"]
 # Enables `Reflect` derives for core types.
 bevy_reflect = ["dep:bevy_reflect"]
-# Enables `glam::Vec2` and `glam::Vec3` parameter derives.
-glam = ["dep:glam"]
+# Enables `glam::Vec2` and `glam::Vec3` parameter derives for glam 0.29.
+glam-29 = ["dep:glam"]
 # Enables the `MIDI` event type, using the `wmidi` crate.
 midi_events = ["dep:wmidi"]
 
@@ -110,7 +110,7 @@ log.workspace = true
 num-traits.workspace = true
 bevy_ecs = { workspace = true, optional = true }
 bevy_reflect = { workspace = true, optional = true }
-glam = { version = "0.*", default-features = false, optional = true }
+glam = { version = "0.29", default-features = false, optional = true }
 # TODO: Remove this once `bevy_platform` exposes the atomic float types from `portable-atomic`.
 portable-atomic = { version = "1", default-features = false, features = [
     "fallback",

--- a/crates/firewheel-core/src/diff/leaf.rs
+++ b/crates/firewheel-core/src/diff/leaf.rs
@@ -182,9 +182,9 @@ primitive_diff!(DurationMusical, DurationMusical);
 primitive_diff!(Vec2, Vector2D);
 primitive_diff!(Vec3, Vector3D);
 
-#[cfg(feature = "glam")]
+#[cfg(feature = "glam-29")]
 primitive_diff!(glam::Vec2, Vector2D);
-#[cfg(feature = "glam")]
+#[cfg(feature = "glam-29")]
 primitive_diff!(glam::Vec3, Vector3D);
 
 impl<A: ?Sized + Send + Sync + 'static> Diff for ArcGc<A> {

--- a/crates/firewheel-core/src/event.rs
+++ b/crates/firewheel-core/src/event.rs
@@ -255,9 +255,9 @@ param_data_from!(InstantMusical, InstantMusical);
 #[cfg(feature = "musical_transport")]
 param_data_from!(DurationMusical, DurationMusical);
 
-#[cfg(feature = "glam")]
+#[cfg(feature = "glam-29")]
 param_data_from!(glam::Vec2, Vector2D);
-#[cfg(feature = "glam")]
+#[cfg(feature = "glam-29")]
 param_data_from!(glam::Vec3, Vector3D);
 
 /// A list of events for an [`AudioNodeProcessor`][crate::node::AudioNodeProcessor].

--- a/crates/firewheel-core/src/vector.rs
+++ b/crates/firewheel-core/src/vector.rs
@@ -83,30 +83,30 @@ impl From<Vec3> for (f32, f32, f32) {
     }
 }
 
-#[cfg(feature = "glam")]
+#[cfg(feature = "glam-29")]
 impl From<glam::Vec2> for Vec2 {
     fn from(value: glam::Vec2) -> Self {
         Self::new(value.x, value.y)
     }
 }
 
-#[cfg(feature = "glam")]
+#[cfg(feature = "glam-29")]
 impl From<glam::Vec3> for Vec3 {
     fn from(value: glam::Vec3) -> Self {
         Self::new(value.x, value.y, value.z)
     }
 }
 
-#[cfg(feature = "glam")]
-impl Into<glam::Vec2> for Vec2 {
-    fn into(self) -> glam::Vec2 {
-        glam::Vec2::new(self.x, self.y)
+#[cfg(feature = "glam-29")]
+impl From<Vec2> for glam::Vec2 {
+    fn from(value: Vec2) -> Self {
+        Self::new(value.x, value.y)
     }
 }
 
-#[cfg(feature = "glam")]
-impl Into<glam::Vec3> for Vec3 {
-    fn into(self) -> glam::Vec3 {
-        glam::Vec3::new(self.x, self.y, self.z)
+#[cfg(feature = "glam-29")]
+impl From<Vec3> for glam::Vec3 {
+    fn from(value: Vec3) -> Self {
+        Self::new(value.x, value.y, value.z)
     }
 }


### PR DESCRIPTION
For a number of reasons, it's easier for Bevy-adjacent projects if Firewheel can pin glam to `0.29`. The feature has been given a specific version in case more versions need to be supported for different projects.