### PR TITLE
Event cloning

### DIFF
--- a/crates/firewheel-core/src/diff/mod.rs
+++ b/crates/firewheel-core/src/diff/mod.rs
@@ -372,7 +372,7 @@ pub trait Diff {
 }
 
 /// A path of indices that uniquely describes an arbitrarily nested field.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ParamPath {
     /// A path of one element.
     ///

--- a/crates/firewheel-core/src/event.rs
+++ b/crates/firewheel-core/src/event.rs
@@ -113,6 +113,7 @@ impl NodeEventType {
 }
 
 /// Data that can be used to patch an individual parameter.
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum ParamData {
     F32(f32),

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -869,6 +869,9 @@ impl AudioNodeProcessor for SamplerProcessor {
             match *self.params.playback {
                 PlaybackState::Stop => {
                     self.stop(buffers.outputs.len(), extra);
+                    self.shared_state
+                        .finished
+                        .store(self.params.playback.id(), Ordering::Relaxed);
 
                     self.playback_state = PlaybackState::Stop;
                 }
@@ -972,6 +975,9 @@ impl AudioNodeProcessor for SamplerProcessor {
                             == self.loaded_sample_state.as_ref().unwrap().sample_len_frames
                         {
                             self.playback_state = PlaybackState::Stop;
+                            self.shared_state
+                                .finished
+                                .store(self.params.playback.id(), Ordering::Relaxed);
                         } else {
                             if new_playhead_frames != 0
                                 || (self.num_active_stop_declickers > 0


### PR DESCRIPTION
This PR enables event cloning for parameter events. Cloneable events are very useful for applying patches to separate instances over time. For example, someone using Firewheel may wish to eagerly send scheduled events to the audio thread to maximize the chance of them arriving on time. Without cloning, these events would become inaccessible to the non-realtime context, meaning their effect couldn't be applied there.

Luckily, this change is very simple.

This PR also includes some changes to the `Sampler` that help to indicate playback completion. It might be better to create a method to encapsulate this behavior, since pretty much any time we set the playback state to `Stop`, the `finished` flag should be updated.