### PR TITLE
Added component attributes to pink and white noise and configs

### DIFF
--- a/crates/firewheel-nodes/src/noise_generator/pink.rs
+++ b/crates/firewheel-nodes/src/noise_generator/pink.rs
@@ -22,6 +22,7 @@ const COEFF_SUM: [i16; 5] = [22347, 27917, 29523, 29942, 30007];
 
 /// A simple node that generates white noise. (Mono output only)
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct PinkNoiseGenNode {
     /// The overall volume.
@@ -49,6 +50,7 @@ impl Default for PinkNoiseGenNode {
 
 /// The configuration for a [`PinkNoiseGenNode`]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct PinkNoiseGenConfig {
     /// The starting seed. This cannot be zero.

--- a/crates/firewheel-nodes/src/noise_generator/white.rs
+++ b/crates/firewheel-nodes/src/noise_generator/white.rs
@@ -17,6 +17,7 @@ use firewheel_core::{
 
 /// A simple node that generates white noise. (Mono output only)
 #[derive(Diff, Patch, Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct WhiteNoiseGenNode {
     /// The overall volume.
@@ -44,6 +45,7 @@ impl Default for WhiteNoiseGenNode {
 
 /// The configuration for a [`WhiteNoiseGenNode`]
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct WhiteNoiseGenConfig {
     /// The starting seed. This cannot be zero.


### PR DESCRIPTION
Note that I also noticed that the peak meter node was also missing the component derive, but I did not include it here as I was unsure the use case/if it should be included. Can easily add that in too, though.