### PR TITLE
added partialeq to config derive

### DIFF
--- a/crates/firewheel-nodes/src/noise_generator/pink.rs
+++ b/crates/firewheel-nodes/src/noise_generator/pink.rs
@@ -49,7 +49,7 @@ impl Default for PinkNoiseGenNode {
 }
 
 /// The configuration for a [`PinkNoiseGenNode`]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct PinkNoiseGenConfig {

--- a/crates/firewheel-nodes/src/noise_generator/white.rs
+++ b/crates/firewheel-nodes/src/noise_generator/white.rs
@@ -44,7 +44,7 @@ impl Default for WhiteNoiseGenNode {
 }
 
 /// The configuration for a [`WhiteNoiseGenNode`]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct WhiteNoiseGenConfig {


### PR DESCRIPTION
Sorry i missed this the first time! seedling expects configs are partialeq. I didn't bother gating this behind the bevy feature as the nodes also have partialeq, and I can see it being useful outside of the bevy context, but it does increase the resulting size.