### PR TITLE
feat: add VolumeNode::from_linear and VolumeNode::from_amp convenience methods

### DIFF
--- a/crates/firewheel-nodes/src/volume.rs
+++ b/crates/firewheel-nodes/src/volume.rs
@@ -67,9 +67,16 @@ impl VolumeNode {
         }
     }
 
-    /// Get the volume in decibels.
-    /// amp is the raw amplitude value (not decibels).
-    /// It is used to calculate the decibel value.
+    pub fn from_decibels(decibels: f32) -> Self {
+        Self {
+            volume: Volume::Decibels(decibels),
+            smooth_seconds: DEFAULT_SMOOTH_SECONDS,
+            min_gain: DEFAULT_AMP_EPSILON,
+        }
+    }
+
+    /// Construct the volume in decibels.
+    /// amp is the raw amplitude value (not decibels) but it is used to calculate the decibel value
     pub fn from_amp(amp: f32) -> Self {
         Self {
             volume: Volume::Decibels(amp_to_db(amp)),


### PR DESCRIPTION
Not sure about from_amp, but I'm pretty sure from_linear will be popular to not write this:
```

VolumeNode {
    volume: Volume::Linear(0.0),
    ..default()
},

```