### PR TITLE
new playback api

### DIFF
--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -100,18 +100,18 @@ pub struct SamplerNode {
     /// [`VolumePanNode`]: crate::volume_pan::VolumePanNode
     pub volume: Volume,
 
-    /// Whether or not the current sample should be playing (true) or paused/stopped
-    /// (false).
+    /// Whether or not the current sample should start/restart playing from the current
+    /// [`SamplerNode::playhead`] (true), or be paused/stopped (false).
     pub play: Notify<bool>,
 
-    /// The position in the sample that playback will start from the next time it is
-    /// set to be played.
+    /// The position in the sample that playback will start from the next time
+    /// [`SamplerNode::play`] is set to `true`.
     ///
-    /// Set this to `None` to have the sample pick up where it last left off
-    /// (pause/resume).
+    /// Set this to `None` to have the sample pick up where it last left off the next
+    /// time it is played.
     ///
     /// If this is `Some` and the sample is already playing, then it will seek to the
-    /// new playhead.
+    /// new playhead immediately.
     pub playhead: Option<Playhead>,
 
     /// How many times a sample should be repeated.

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -902,22 +902,18 @@ impl AudioNodeProcessor for SamplerProcessor {
         if sample_changed {
             self.stop(buffers.outputs.len(), extra);
 
-            if new_playing.is_none() {
-                new_playing = Some(false);
-
-                #[cfg(feature = "scheduled_events")]
+            #[cfg(feature = "scheduled_events")]
+            if new_playing == Some(true) && playback_instant.is_none() {
                 if let Some(queued_playback_instant) = self.queued_playback_instant.take() {
                     if queued_playback_instant.to_samples(info).is_some() {
                         playback_instant = Some(queued_playback_instant);
-                    } else {
-                        // Handle an edge case where the user sent a scheduled play event at
-                        // a musical time, but there is no sample and a musical transport
-                        // is not playing.
-                        new_playing = None;
-                        self.playing = false;
-                        self.paused = false;
                     }
                 }
+            }
+
+            if new_playing.is_none() && self.playing {
+                self.playing = false;
+                self.paused = false;
             }
 
             self.loaded_sample_state = None;

--- a/crates/firewheel-pool/src/lib.rs
+++ b/crates/firewheel-pool/src/lib.rs
@@ -116,17 +116,13 @@ pub trait PoolableNode {
         event_queue: &mut ContextQueue<B>,
     );
 
-    /// Notify the node state that a sequence is playing/stopped.
-    ///
-    /// If `stopped` is `true`, then the sequence has been stopped. If `stopped` is
-    /// `false`, then a new sequence has been started.
+    /// Notify the node state that a sequence is playing.
     ///
     /// This is used to account for the delay between sending an event to the node
     /// and the node receiving the event.
     ///
     /// Return an error if the given `node_id` is invalid.
-    fn mark_stopped<B: AudioBackend>(
-        stopped: bool,
+    fn mark_playing<B: AudioBackend>(
         node_id: NodeID,
         cx: &mut FirewheelCtx<B>,
     ) -> Result<(), PoolError>;
@@ -288,7 +284,7 @@ where
 
         worker.first_node_params = params.clone();
 
-        N::mark_stopped(false, worker.first_node_id, cx).unwrap();
+        N::mark_playing(worker.first_node_id, cx).unwrap();
 
         (fx_chain)(&mut worker.fx_state, cx);
 

--- a/examples/play_sample/src/main.rs
+++ b/examples/play_sample/src/main.rs
@@ -49,14 +49,14 @@ fn main() {
     sampler_node.set_sample(sample);
     cx.queue_event_for(sampler_id, sampler_node.sync_sample_event());
 
-    sampler_node.start_or_restart(None);
-    cx.queue_event_for(sampler_id, sampler_node.sync_playback_event());
+    sampler_node.start_or_restart();
+    cx.queue_event_for(sampler_id, sampler_node.sync_play_event());
 
     // Manually set the shared `stopped` flag. This is needed to account for the delay
     // between sending a play event and the node's processor receiving that event.
     cx.node_state::<SamplerState>(sampler_id)
         .unwrap()
-        .mark_stopped(false);
+        .mark_stopped();
 
     // --- Simulated update loop ---------------------------------------------------------
 

--- a/examples/sampler_pool/src/ui.rs
+++ b/examples/sampler_pool/src/ui.rs
@@ -37,7 +37,7 @@ impl App for DemoApp {
             ui.label("Default VolumePan FX Chain");
 
             if ui.button("Play").clicked() {
-                self.audio_system.sampler_node.start_or_restart(None);
+                self.audio_system.sampler_node.start_or_restart();
 
                 // The `worker_id` can be later used to reference this piece of work being done.
                 let _worker_id = self.audio_system.sampler_pool_1.new_worker(
@@ -69,7 +69,7 @@ impl App for DemoApp {
             ui.label("Custom FX Chain");
 
             if ui.button("Play").clicked() {
-                self.audio_system.sampler_node.start_or_restart(None);
+                self.audio_system.sampler_node.start_or_restart();
 
                 // The `worker_id` can be later used to reference this piece of work being done.
                 let _worker_id = self.audio_system.sampler_pool_2.new_worker(

--- a/examples/sampler_test/src/system.rs
+++ b/examples/sampler_test/src/system.rs
@@ -5,7 +5,7 @@ use firewheel::{
     node::NodeID,
     nodes::{
         peak_meter::{PeakMeterNode, PeakMeterSmoother, PeakMeterState},
-        sampler::{PlaybackState, RepeatMode, SamplerNode},
+        sampler::{RepeatMode, SamplerNode, SamplerState},
     },
     FirewheelContext,
 };
@@ -90,7 +90,7 @@ impl AudioSystem {
     pub fn start_or_restart(&mut self, sampler_i: usize) {
         let sampler = &mut self.samplers[sampler_i];
 
-        sampler.params.start_or_restart(None);
+        sampler.params.start_or_restart();
 
         sampler
             .params
@@ -154,8 +154,18 @@ impl AudioSystem {
         }
     }
 
-    pub fn playback_state(&self, sampler_i: usize) -> &PlaybackState {
-        &self.samplers[sampler_i].params.playback
+    pub fn is_playing(&self, sampler_i: usize) -> bool {
+        self.cx
+            .node_state::<SamplerState>(self.samplers[sampler_i].node_id)
+            .unwrap()
+            .playing()
+    }
+
+    pub fn is_paused(&self, sampler_i: usize) -> bool {
+        self.cx
+            .node_state::<SamplerState>(self.samplers[sampler_i].node_id)
+            .unwrap()
+            .paused()
     }
 
     pub fn update(&mut self) {

--- a/examples/sampler_test/src/ui.rs
+++ b/examples/sampler_test/src/ui.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use eframe::App;
 use egui::{Color32, ProgressBar};
-use firewheel::nodes::sampler::{PlaybackState, RepeatMode};
+use firewheel::nodes::sampler::RepeatMode;
 
 use crate::system::{AudioSystem, SAMPLE_PATHS};
 
@@ -68,17 +68,13 @@ impl App for DemoApp {
                         self.audio_system.start_or_restart(i);
                     }
 
-                    match self.audio_system.playback_state(i) {
-                        PlaybackState::Stop => {}
-                        PlaybackState::Pause => {
-                            if ui.button("Resume").clicked() {
-                                self.audio_system.resume(i);
-                            }
+                    if self.audio_system.is_playing(i) {
+                        if ui.button("Pause").clicked() {
+                            self.audio_system.pause(i);
                         }
-                        PlaybackState::Play { .. } => {
-                            if ui.button("Pause").clicked() {
-                                self.audio_system.pause(i);
-                            }
+                    } else if self.audio_system.is_paused(i) {
+                        if ui.button("Resume").clicked() {
+                            self.audio_system.resume(i);
                         }
                     }
 

--- a/examples/spatial_basic/src/system.rs
+++ b/examples/spatial_basic/src/system.rs
@@ -42,7 +42,7 @@ impl AudioSystem {
         let mut sampler_node = SamplerNode::default();
         sampler_node.set_sample(sample);
         sampler_node.repeat_mode = RepeatMode::RepeatEndlessly;
-        sampler_node.start_or_restart(None);
+        sampler_node.start_or_restart();
 
         let sampler_node_id = cx.add_node(sampler_node.clone(), None);
 


### PR DESCRIPTION
A new and improved api for playing back samples in the sampler node.

## Breaking changes

* The `playback: Notify<PlaybackState>` parameter in `SamplerNode` has been replaced with `play: Notify<bool>`.
* A `playhead: Option<Playhead>` parameter was added to `SamplerNode`.
* The playhead argument in `start_or_restart` has been removed, and instead an extra function has been added called `play_from`.
* Extra convenience methods have been added to get the current requested playback state.
* `SamplerState::playback_state` has been replaced with `SamplerState::playing`, `SamplerState::paused`, and `SamplerState::stopped`.
* `PoolableNode::mark_stopped` has been replaced with `PoolableNode::mark_playing`.