### PR TITLE
feat: implement AudioNodeProcessor for boxed processor

### DIFF
--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -442,6 +442,24 @@ pub trait AudioNodeProcessor: 'static + Send {
     }
 }
 
+impl AudioNodeProcessor for Box<dyn AudioNodeProcessor> {
+    fn new_stream(&mut self, stream_info: &StreamInfo) {
+        self.as_mut().new_stream(stream_info)
+    }
+    fn process(
+        &mut self,
+        info: &ProcInfo,
+        buffers: ProcBuffers,
+        events: &mut ProcEvents,
+        extra: &mut ProcExtra,
+    ) -> ProcessStatus {
+        self.as_mut().process(info, buffers, events, extra)
+    }
+    fn stream_stopped(&mut self, logger: &mut RealtimeLogger) {
+        self.as_mut().stream_stopped(logger)
+    }
+}
+
 pub const NUM_SCRATCH_BUFFERS: usize = 8;
 
 /// The buffers used in [`AudioNodeProcessor::process`]


### PR DESCRIPTION
In some cases, I would like to do the following:

```rust
impl AudioNode for MyNode {

    // ...

    fn construct_processor(
        &self,
        _: &Self::Configuration,
        cx: ConstructProcessorContext,
    ) -> impl AudioNodeProcessor {
        if some_condition {
            Box::new(ProcessorOne) as Box<dyn AudioNodeProcessor>
        } else {
            Box::new(ProcessorTwo) as Box<dyn AudioNodeProcessor>
        }
    }
}
```

because `impl T` does not imply `U: DerefMut<Target = T> --> U: T`, a Sized smart pointer essentially needs some implementation for the dynamic version of T.