### PR TITLE
Added simple sample and freeverb node to graph example

### DIFF
--- a/examples/visual_node_graph/Cargo.toml
+++ b/examples/visual_node_graph/Cargo.toml
@@ -15,6 +15,7 @@ eframe = { version = "0.32", default-features = false, features = [
     "x11",
     "wayland",
 ] }
+symphonium = { version = "0.6.4", features = ["mp3", "flac"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 simple-log = "2.1.0"


### PR DESCRIPTION
Added the new Reverb node to the example, along with a simple version of the sampler node. 

<img width="624" height="451" alt="image" src="https://github.com/user-attachments/assets/0267e9bc-92c2-4e28-8637-ef5c45fc54ac" />
