### PR TITLE
Remove shared stdcxx requirement for Android

### DIFF
--- a/crates/firewheel-cpal/build.rs
+++ b/crates/firewheel-cpal/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
-    if target_os == "android" {
-        // This includes 'lib/<arch>/libc++_shared.so'
-        // Firewheel needs it currently on Android builds
-        println!("cargo:rustc-link-lib=dylib=c++_shared");
-    }
-}


### PR DESCRIPTION
cpal 0.16 has removed oboe and no longer needs shared stdcxx for Android so we don't need to link it. Without this PR, Android will crash at runtime if `libc++_shared.so` is missing.

Related: #38 https://github.com/RustAudio/cpal/pull/961