### PR TITLE
Chris' 0.19.0-dev experiments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,8 @@ glam-29 = ["firewheel-core/glam-29"]
 glam-30 = ["firewheel-core/glam-30"]
 # Enables `glam::Vec2` and `glam::Vec3` parameter derives for glam 0.31.
 glam-31 = ["firewheel-core/glam-31"]
+# Enables `glam::Vec2` and `glam::Vec3` parameter derives for glam 0.32.
+glam-32 = ["firewheel-core/glam-32"]
 # Enables the `MIDI` event type, using the `wmidi` crate.
 midi_events = ["firewheel-core/midi_events"]
 # Enables serde derives for types
@@ -250,3 +252,20 @@ criterion = "0.7"
 [[bench]]
 name = "core"
 harness = false
+
+
+[patch."crates-io"]
+firewheel = { git = "https://github.com/ChristopherBiscardi/Firewheel", branch = "chris-0.19" }
+firewheel-ircam-hrtf = { git = "https://github.com/ChristopherBiscardi/firewheel-ircam-hrtf", branch = "chris-0.19" }
+bevy_time = { git = "https://github.com/bevyengine/bevy" }
+bevy_transform = { git = "https://github.com/bevyengine/bevy" }
+bevy = { git = "https://github.com/bevyengine/bevy" }
+bevy_app = { git = "https://github.com/bevyengine/bevy" }
+bevy_asset = { git = "https://github.com/bevyengine/bevy" }
+bevy_ecs = { git = "https://github.com/bevyengine/bevy" }
+bevy_log = { git = "https://github.com/bevyengine/bevy" }
+bevy_math = { git = "https://github.com/bevyengine/bevy" }
+bevy_platform = { git = "https://github.com/bevyengine/bevy" }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy" }
+bevy_macro_utils = { git = "https://github.com/bevyengine/bevy" }
+rtgc = { git = "https://codeberg.org/chrisbiscardi/rtgc", branch = "chris-0.19" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,11 +213,11 @@ bitflags = "2"
 thunderdome = { version = "0.6", default-features = false }
 fast-interleave = "0.1"
 firewheel-macros = { path = "crates/firewheel-macros", version = "0.10.0" }
-bevy_platform = { version = "0.18", default-features = false, features = [
+bevy_platform = { version = "0.19.0-dev", default-features = false, features = [
     "alloc",
 ] }
-bevy_ecs = { version = "0.18", default-features = false }
-bevy_reflect = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.19.0-dev", default-features = false }
+bevy_reflect = { version = "0.19.0-dev", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 egui = "0.33.3"

--- a/crates/firewheel-core/Cargo.toml
+++ b/crates/firewheel-core/Cargo.toml
@@ -47,6 +47,7 @@ std = [
     "glam-29?/std",
     "glam-30?/std",
     "glam-31?/std",
+    "glam-32?/std",
     "portable-atomic/std",
     "num-traits/std",
     "thiserror/std",
@@ -60,7 +61,8 @@ libm = [
     "num-traits/libm",
     "glam-29?/nostd-libm",
     "glam-30?/nostd-libm",
-    "glam-31?/nostd-libm"
+    "glam-31?/nostd-libm",
+    "glam-32?/nostd-libm"
 ]
 # Enables scheduling events for audio nodes.
 #
@@ -92,6 +94,8 @@ glam-29 = ["dep:glam-29"]
 glam-30 = ["dep:glam-30"]
 # Enables `glam::Vec2` and `glam::Vec3` parameter derives for glam 0.31.
 glam-31 = ["dep:glam-31"]
+# Enables `glam::Vec2` and `glam::Vec3` parameter derives for glam 0.32.
+glam-32 = ["dep:glam-32"]
 # Enables the `MIDI` event type, using the `wmidi` crate.
 midi_events = ["dep:wmidi"]
 # Enables serde derives for types
@@ -112,6 +116,7 @@ bevy_reflect = { workspace = true, optional = true }
 glam-29 = { package = "glam", version = "0.29", default-features = false, optional = true }
 glam-30 = { package = "glam", version = "0.30", default-features = false, optional = true }
 glam-31 = { package = "glam", version = "0.31", default-features = false, optional = true }
+glam-32 = { package = "glam", version = "0.32", default-features = false, optional = true }
 # TODO: Remove this once `bevy_platform` exposes the atomic float types from `portable-atomic`.
 portable-atomic = { version = "1", default-features = false, features = [
     "fallback",

--- a/crates/firewheel-core/src/diff/leaf.rs
+++ b/crates/firewheel-core/src/diff/leaf.rs
@@ -155,6 +155,11 @@ primitive_diff!(glam_31::Vec2, Vector2D);
 #[cfg(feature = "glam-31")]
 primitive_diff!(glam_31::Vec3, Vector3D);
 
+#[cfg(feature = "glam-32")]
+primitive_diff!(glam_32::Vec2, Vector2D);
+#[cfg(feature = "glam-32")]
+primitive_diff!(glam_32::Vec3, Vector3D);
+
 impl<A: ?Sized + Send + Sync + 'static> Diff for ArcGc<A> {
     fn diff<E: EventQueue>(&self, baseline: &Self, path: PathBuilder, event_queue: &mut E) {
         if !ArcGc::ptr_eq(self, baseline) {
@@ -493,3 +498,8 @@ trivial_notify!(glam_30::Vec3);
 trivial_notify!(glam_31::Vec2);
 #[cfg(feature = "glam-31")]
 trivial_notify!(glam_31::Vec3);
+
+#[cfg(feature = "glam-32")]
+trivial_notify!(glam_32::Vec2);
+#[cfg(feature = "glam-32")]
+trivial_notify!(glam_32::Vec3);

--- a/crates/firewheel-core/src/diff/leaf.rs
+++ b/crates/firewheel-core/src/diff/leaf.rs
@@ -483,3 +483,8 @@ trivial_notify!(glam_29::Vec3);
 trivial_notify!(glam_30::Vec2);
 #[cfg(feature = "glam-30")]
 trivial_notify!(glam_30::Vec3);
+
+#[cfg(feature = "glam-31")]
+trivial_notify!(glam_31::Vec2);
+#[cfg(feature = "glam-31")]
+trivial_notify!(glam_31::Vec3);

--- a/crates/firewheel-core/src/diff/leaf.rs
+++ b/crates/firewheel-core/src/diff/leaf.rs
@@ -150,6 +150,11 @@ primitive_diff!(glam_30::Vec2, Vector2D);
 #[cfg(feature = "glam-30")]
 primitive_diff!(glam_30::Vec3, Vector3D);
 
+#[cfg(feature = "glam-31")]
+primitive_diff!(glam_31::Vec2, Vector2D);
+#[cfg(feature = "glam-31")]
+primitive_diff!(glam_31::Vec3, Vector3D);
+
 impl<A: ?Sized + Send + Sync + 'static> Diff for ArcGc<A> {
     fn diff<E: EventQueue>(&self, baseline: &Self, path: PathBuilder, event_queue: &mut E) {
         if !ArcGc::ptr_eq(self, baseline) {

--- a/crates/firewheel-core/src/diff/notify.rs
+++ b/crates/firewheel-core/src/diff/notify.rs
@@ -456,10 +456,7 @@ mod reflect {
             if let bevy_reflect::ReflectRef::Struct(struct_value) =
                 bevy_reflect::PartialReflect::reflect_ref(value)
             {
-                for (i, value) in ::core::iter::Iterator::enumerate(
-                    bevy_reflect::prelude::Struct::iter_fields(struct_value),
-                ) {
-                    let (name, value) = bevy_reflect::prelude::Struct::name_at(struct_value, i).unwrap();
+                for (name, value) in struct_value {
                     if let Some(v) = bevy_reflect::prelude::Struct::field_mut(self, name) {
                         bevy_reflect::PartialReflect::try_apply(v, value)?;
                     }

--- a/crates/firewheel-core/src/diff/notify.rs
+++ b/crates/firewheel-core/src/diff/notify.rs
@@ -428,6 +428,10 @@ mod reflect {
             );
             dynamic
         }
+
+        fn index_of_name(&self, name: &str) -> Option<usize> {
+            todo!("index_of_name is a new function");
+        }
     }
 
     impl<T> bevy_reflect::PartialReflect for Notify<T>
@@ -455,7 +459,7 @@ mod reflect {
                 for (i, value) in ::core::iter::Iterator::enumerate(
                     bevy_reflect::prelude::Struct::iter_fields(struct_value),
                 ) {
-                    let name = bevy_reflect::prelude::Struct::name_at(struct_value, i).unwrap();
+                    let (name, value) = bevy_reflect::prelude::Struct::name_at(struct_value, i).unwrap();
                     if let Some(v) = bevy_reflect::prelude::Struct::field_mut(self, name) {
                         bevy_reflect::PartialReflect::try_apply(v, value)?;
                     }

--- a/crates/firewheel-core/src/diff/notify.rs
+++ b/crates/firewheel-core/src/diff/notify.rs
@@ -119,7 +119,9 @@ impl<T> core::ops::DerefMut for Notify<T> {
 
 impl<T: Copy> Copy for Notify<T> {}
 
-impl<T: RealtimeClone + Send + Sync + 'static> Diff for Notify<T> {
+impl<T: RealtimeClone + Send + Sync + 'static> Diff
+    for Notify<T>
+{
     fn diff<E: super::EventQueue>(
         &self,
         baseline: &Self,
@@ -127,15 +129,23 @@ impl<T: RealtimeClone + Send + Sync + 'static> Diff for Notify<T> {
         event_queue: &mut E,
     ) {
         if self.counter != baseline.counter {
-            event_queue.push_param(ParamData::any(self.clone()), path);
+            event_queue.push_param(
+                ParamData::any(self.clone()),
+                path,
+            );
         }
     }
 }
 
-impl<T: RealtimeClone + Send + Sync + 'static> Patch for Notify<T> {
+impl<T: RealtimeClone + Send + Sync + 'static> Patch
+    for Notify<T>
+{
     type Patch = Self;
 
-    fn patch(data: &ParamData, _: &[u32]) -> Result<Self::Patch, super::PatchError> {
+    fn patch(
+        data: &ParamData,
+        _: &[u32],
+    ) -> Result<Self::Patch, super::PatchError> {
         data.downcast_ref()
             .ok_or(super::PatchError::InvalidData)
             .cloned()
@@ -169,12 +179,20 @@ mod test {
         let mut value = baseline;
 
         let mut events = Vec::new();
-        value.diff(&baseline, PathBuilder::default(), &mut events);
+        value.diff(
+            &baseline,
+            PathBuilder::default(),
+            &mut events,
+        );
         assert_eq!(events.len(), 0);
 
         *value = 0.5f32;
 
-        value.diff(&baseline, PathBuilder::default(), &mut events);
+        value.diff(
+            &baseline,
+            PathBuilder::default(),
+            &mut events,
+        );
         assert_eq!(events.len(), 1);
     }
 }
@@ -231,7 +249,7 @@ mod reflect {
                 bevy_reflect::utility::GenericTypeInfoCell::new();
             CELL.get_or_insert::<Self, _>(|| {
                 bevy_reflect::TypeInfo::Struct(
-                    bevy_reflect::StructInfo::new::<Self>(&[
+                    bevy_reflect::structs::StructInfo::new::<Self>(&[
                         bevy_reflect::NamedField::new::<T>("value").with_custom_attributes(
                             bevy_reflect::attributes::CustomAttributes::default(),
                         ),
@@ -251,7 +269,9 @@ mod reflect {
     extern crate alloc;
     impl<T> bevy_reflect::TypePath for Notify<T>
     where
-        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
+        Notify<T>: ::core::any::Any
+            + ::core::marker::Send
+            + ::core::marker::Sync,
         T: bevy_reflect::TypePath,
     {
         fn type_path() -> &'static str {
@@ -290,7 +310,12 @@ mod reflect {
             Some("Notify")
         }
         fn crate_name() -> Option<&'static str> {
-            Some(::core::module_path!().split(':').next().unwrap())
+            Some(
+                ::core::module_path!()
+                    .split(':')
+                    .next()
+                    .unwrap(),
+            )
         }
         fn module_path() -> Option<&'static str> {
             Some(::core::module_path!())
@@ -340,7 +365,7 @@ mod reflect {
         }
     }
 
-    impl<T> bevy_reflect::Struct for Notify<T>
+    impl<T> bevy_reflect::prelude::Struct for Notify<T>
     where
         Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
         T: Clone
@@ -388,12 +413,12 @@ mod reflect {
             1usize
         }
 
-        fn iter_fields<'a>(&'a self) -> bevy_reflect::FieldIter<'a> {
-            bevy_reflect::FieldIter::new(self)
+        fn iter_fields<'a>(&'a self) -> bevy_reflect::structs::FieldIter<'a> {
+            bevy_reflect::structs::FieldIter::new(self)
         }
 
-        fn to_dynamic_struct(&self) -> bevy_reflect::DynamicStruct {
-            let mut dynamic: bevy_reflect::DynamicStruct = Default::default();
+        fn to_dynamic_struct(&self) -> bevy_reflect::structs::DynamicStruct {
+            let mut dynamic: bevy_reflect::structs::DynamicStruct = Default::default();
             dynamic.set_represented_type(bevy_reflect::PartialReflect::get_represented_type_info(
                 self,
             ));
@@ -428,10 +453,10 @@ mod reflect {
                 bevy_reflect::PartialReflect::reflect_ref(value)
             {
                 for (i, value) in ::core::iter::Iterator::enumerate(
-                    bevy_reflect::Struct::iter_fields(struct_value),
+                    bevy_reflect::prelude::Struct::iter_fields(struct_value),
                 ) {
-                    let name = bevy_reflect::Struct::name_at(struct_value, i).unwrap();
-                    if let Some(v) = bevy_reflect::Struct::field_mut(self, name) {
+                    let name = bevy_reflect::prelude::Struct::name_at(struct_value, i).unwrap();
+                    if let Some(v) = bevy_reflect::prelude::Struct::field_mut(self, name) {
                         bevy_reflect::PartialReflect::try_apply(v, value)?;
                     }
                 }
@@ -497,7 +522,7 @@ mod reflect {
         }
 
         fn reflect_partial_eq(&self, value: &dyn bevy_reflect::PartialReflect) -> Option<bool> {
-            (bevy_reflect::struct_partial_eq)(self, value)
+            (bevy_reflect::structs::struct_partial_eq)(self, value)
         }
 
         #[inline]
@@ -524,7 +549,7 @@ mod reflect {
             {
                 let mut this = <Self as ::core::default::Default>::default();
                 if let Some(field) = (|| {
-                    <T as bevy_reflect::FromReflect>::from_reflect(bevy_reflect::Struct::field(
+                    <T as bevy_reflect::FromReflect>::from_reflect(bevy_reflect::prelude::Struct::field(
                         ref_struct, "value",
                     )?)
                 })() {

--- a/crates/firewheel-core/src/diff/notify.rs
+++ b/crates/firewheel-core/src/diff/notify.rs
@@ -119,9 +119,7 @@ impl<T> core::ops::DerefMut for Notify<T> {
 
 impl<T: Copy> Copy for Notify<T> {}
 
-impl<T: RealtimeClone + Send + Sync + 'static> Diff
-    for Notify<T>
-{
+impl<T: RealtimeClone + Send + Sync + 'static> Diff for Notify<T> {
     fn diff<E: super::EventQueue>(
         &self,
         baseline: &Self,
@@ -129,23 +127,15 @@ impl<T: RealtimeClone + Send + Sync + 'static> Diff
         event_queue: &mut E,
     ) {
         if self.counter != baseline.counter {
-            event_queue.push_param(
-                ParamData::any(self.clone()),
-                path,
-            );
+            event_queue.push_param(ParamData::any(self.clone()), path);
         }
     }
 }
 
-impl<T: RealtimeClone + Send + Sync + 'static> Patch
-    for Notify<T>
-{
+impl<T: RealtimeClone + Send + Sync + 'static> Patch for Notify<T> {
     type Patch = Self;
 
-    fn patch(
-        data: &ParamData,
-        _: &[u32],
-    ) -> Result<Self::Patch, super::PatchError> {
+    fn patch(data: &ParamData, _: &[u32]) -> Result<Self::Patch, super::PatchError> {
         data.downcast_ref()
             .ok_or(super::PatchError::InvalidData)
             .cloned()
@@ -179,20 +169,12 @@ mod test {
         let mut value = baseline;
 
         let mut events = Vec::new();
-        value.diff(
-            &baseline,
-            PathBuilder::default(),
-            &mut events,
-        );
+        value.diff(&baseline, PathBuilder::default(), &mut events);
         assert_eq!(events.len(), 0);
 
         *value = 0.5f32;
 
-        value.diff(
-            &baseline,
-            PathBuilder::default(),
-            &mut events,
-        );
+        value.diff(&baseline, PathBuilder::default(), &mut events);
         assert_eq!(events.len(), 1);
     }
 }
@@ -269,9 +251,7 @@ mod reflect {
     extern crate alloc;
     impl<T> bevy_reflect::TypePath for Notify<T>
     where
-        Notify<T>: ::core::any::Any
-            + ::core::marker::Send
-            + ::core::marker::Sync,
+        Notify<T>: ::core::any::Any + ::core::marker::Send + ::core::marker::Sync,
         T: bevy_reflect::TypePath,
     {
         fn type_path() -> &'static str {
@@ -310,12 +290,7 @@ mod reflect {
             Some("Notify")
         }
         fn crate_name() -> Option<&'static str> {
-            Some(
-                ::core::module_path!()
-                    .split(':')
-                    .next()
-                    .unwrap(),
-            )
+            Some(::core::module_path!().split(':').next().unwrap())
         }
         fn module_path() -> Option<&'static str> {
             Some(::core::module_path!())
@@ -550,9 +525,9 @@ mod reflect {
             {
                 let mut this = <Self as ::core::default::Default>::default();
                 if let Some(field) = (|| {
-                    <T as bevy_reflect::FromReflect>::from_reflect(bevy_reflect::prelude::Struct::field(
-                        ref_struct, "value",
-                    )?)
+                    <T as bevy_reflect::FromReflect>::from_reflect(
+                        bevy_reflect::prelude::Struct::field(ref_struct, "value")?,
+                    )
                 })() {
                     this.value = field;
                 }

--- a/crates/firewheel-core/src/event.rs
+++ b/crates/firewheel-core/src/event.rs
@@ -323,6 +323,11 @@ param_data_from!(glam_30::Vec2, Vector2D);
 #[cfg(feature = "glam-30")]
 param_data_from!(glam_30::Vec3, Vector3D);
 
+#[cfg(feature = "glam-31")]
+param_data_from!(glam_31::Vec2, Vector2D);
+#[cfg(feature = "glam-31")]
+param_data_from!(glam_31::Vec3, Vector3D);
+
 impl From<()> for ParamData {
     fn from(_value: ()) -> Self {
         Self::None

--- a/crates/firewheel-core/src/event.rs
+++ b/crates/firewheel-core/src/event.rs
@@ -328,6 +328,11 @@ param_data_from!(glam_31::Vec2, Vector2D);
 #[cfg(feature = "glam-31")]
 param_data_from!(glam_31::Vec3, Vector3D);
 
+#[cfg(feature = "glam-32")]
+param_data_from!(glam_32::Vec2, Vector2D);
+#[cfg(feature = "glam-32")]
+param_data_from!(glam_32::Vec3, Vector3D);
+
 impl From<()> for ParamData {
     fn from(_value: ()) -> Self {
         Self::None

--- a/crates/firewheel-core/src/vector.rs
+++ b/crates/firewheel-core/src/vector.rs
@@ -166,3 +166,31 @@ impl From<Vec3> for glam_31::Vec3 {
         Self::new(value.x, value.y, value.z)
     }
 }
+
+#[cfg(feature = "glam-32")]
+impl From<glam_32::Vec2> for Vec2 {
+    fn from(value: glam_32::Vec2) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+#[cfg(feature = "glam-32")]
+impl From<glam_32::Vec3> for Vec3 {
+    fn from(value: glam_32::Vec3) -> Self {
+        Self::new(value.x, value.y, value.z)
+    }
+}
+
+#[cfg(feature = "glam-32")]
+impl From<Vec2> for glam_32::Vec2 {
+    fn from(value: Vec2) -> Self {
+        Self::new(value.x, value.y)
+    }
+}
+
+#[cfg(feature = "glam-32")]
+impl From<Vec3> for glam_32::Vec3 {
+    fn from(value: Vec3) -> Self {
+        Self::new(value.x, value.y, value.z)
+    }
+}

--- a/crates/firewheel-macros/Cargo.toml
+++ b/crates/firewheel-macros/Cargo.toml
@@ -18,5 +18,5 @@ proc-macro = true
 syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-bevy_macro_utils = "0.18"
+bevy_macro_utils = "0.19.0-dev"
 toml_edit = { version = "0.23.9", default-features = false, features = ["parse"] }


### PR DESCRIPTION
This draft pr is related to bevy_seedling updates for 0.19-dev: https://github.com/CorvusPrudens/bevy_seedling/pull/93


The main changes so far are:

- [Reflect got shuffled around](https://github.com/bevyengine/bevy/pull/22342), resulting in longer imports.
- bevy 0.19-dev is on glam 31, so some additional missing implementations were added.
- There is also a `todo!` related to `bevy_reflect::DynamicStruct::index_of` becoming `bevy_reflect::Struct::index_of_name`, which was done in [Reflect Struct QOL#22708](https://github.com/bevyengine/bevy/pull/22708)