### PR TITLE
fix(cpal): support non-f32 ASIO native sample formats (I16/I24/I32)

### DIFF
--- a/crates/firewheel-cpal/src/lib.rs
+++ b/crates/firewheel-cpal/src/lib.rs
@@ -512,25 +512,88 @@ impl CpalStream {
             Arc::clone(&is_running),
         );
 
+        let out_sample_format = default_config.sample_format();
+
         info!(
-            "Starting output audio stream with device \"{:?}\" with configuration {:?}",
-            &out_device_id, &out_stream_config
+            "Starting output audio stream with device \"{:?}\" with configuration {:?} (native sample format: {:?})",
+            &out_device_id, &out_stream_config, out_sample_format,
         );
 
-        let out_stream_handle = out_device.build_output_stream(
-            &out_stream_config,
-            move |output: &mut [f32], info: &cpal::OutputCallbackInfo| {
-                data_callback.callback(output, info);
-            },
-            move |err| {
-                if let Err(e) = err_to_cx_tx.send(err) {
-                    // Make sure the error gets logged even if the handle has been dropped.
-                    #[cfg(any(feature = "log", feature = "tracing"))]
-                    error!("Audio stream error occurred: {}", e.0);
-                }
-            },
-            Some(BUILD_STREAM_TIMEOUT),
-        )?;
+        // The cpal ASIO backend requires the callback buffer type to match the
+        // driver's native format (unlike WASAPI, which converts internally).
+        // For non-f32 formats, render into an f32 scratch buffer and convert
+        // on the way out. The f32 path stays a direct passthrough.
+        let scratch_cap = max_block_frames * num_out_channels;
+        let out_stream_handle = match out_sample_format {
+            cpal::SampleFormat::F32 => out_device.build_output_stream(
+                &out_stream_config,
+                move |output: &mut [f32], info: &cpal::OutputCallbackInfo| {
+                    data_callback.callback(output, info);
+                },
+                err_callback(err_to_cx_tx.clone()),
+                Some(BUILD_STREAM_TIMEOUT),
+            )?,
+            cpal::SampleFormat::I16 => {
+                let mut scratch = vec![0f32; scratch_cap];
+                out_device.build_output_stream(
+                    &out_stream_config,
+                    move |output: &mut [i16], info: &cpal::OutputCallbackInfo| {
+                        if scratch.len() < output.len() {
+                            scratch.resize(output.len(), 0.0);
+                        }
+                        let buf = &mut scratch[..output.len()];
+                        data_callback.callback(buf, info);
+                        for (o, &f) in output.iter_mut().zip(buf.iter()) {
+                            *o = <i16 as cpal::FromSample<f32>>::from_sample_(f);
+                        }
+                    },
+                    err_callback(err_to_cx_tx.clone()),
+                    Some(BUILD_STREAM_TIMEOUT),
+                )?
+            }
+            cpal::SampleFormat::I24 => {
+                let mut scratch = vec![0f32; scratch_cap];
+                out_device.build_output_stream(
+                    &out_stream_config,
+                    move |output: &mut [cpal::I24], info: &cpal::OutputCallbackInfo| {
+                        if scratch.len() < output.len() {
+                            scratch.resize(output.len(), 0.0);
+                        }
+                        let buf = &mut scratch[..output.len()];
+                        data_callback.callback(buf, info);
+                        for (o, &f) in output.iter_mut().zip(buf.iter()) {
+                            *o = <cpal::I24 as cpal::FromSample<f32>>::from_sample_(f);
+                        }
+                    },
+                    err_callback(err_to_cx_tx.clone()),
+                    Some(BUILD_STREAM_TIMEOUT),
+                )?
+            }
+            cpal::SampleFormat::I32 => {
+                let mut scratch = vec![0f32; scratch_cap];
+                out_device.build_output_stream(
+                    &out_stream_config,
+                    move |output: &mut [i32], info: &cpal::OutputCallbackInfo| {
+                        if scratch.len() < output.len() {
+                            scratch.resize(output.len(), 0.0);
+                        }
+                        let buf = &mut scratch[..output.len()];
+                        data_callback.callback(buf, info);
+                        for (o, &f) in output.iter_mut().zip(buf.iter()) {
+                            *o = <i32 as cpal::FromSample<f32>>::from_sample_(f);
+                        }
+                    },
+                    err_callback(err_to_cx_tx.clone()),
+                    Some(BUILD_STREAM_TIMEOUT),
+                )?
+            }
+            fmt => {
+                error!("Unsupported cpal output sample format: {:?}", fmt);
+                return Err(StartStreamError::BuildStreamError(
+                    cpal::BuildStreamError::StreamConfigNotSupported,
+                ));
+            }
+        };
 
         out_stream_handle.play()?;
 
@@ -592,6 +655,18 @@ impl Drop for CpalStream {
         // Make sure any remaining errors/warnings get logged.
         #[cfg(any(feature = "log", feature = "tracing"))]
         self.log_status();
+    }
+}
+
+fn err_callback(
+    err_to_cx_tx: mpsc::Sender<cpal::StreamError>,
+) -> impl FnMut(cpal::StreamError) + Send + 'static {
+    move |err| {
+        if let Err(e) = err_to_cx_tx.send(err) {
+            // Make sure the error gets logged even if the handle has been dropped.
+            #[cfg(any(feature = "log", feature = "tracing"))]
+            error!("Audio stream error occurred: {}", e.0);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`CpalStream::new` builds the output stream with a hardcoded `&mut [f32]` callback. This works on WASAPI because cpal opens it in shared mode with `AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY` ([cpal `host/wasapi/device.rs`](https://github.com/RustAudio/cpal/blob/master/src/host/wasapi/device.rs)), so Windows converts between the client format and the device's native mix format.

The cpal ASIO backend has no such conversion — it just compares the requested `SampleFormat` against `output_data_type()` and bails:

```rust
// cpal/src/host/asio/stream.rs
if sample_format != expected_sample_format {
    return Err(BuildStreamError::StreamConfigNotSupported);
}
```

Most pro-audio ASIO drivers expose Int16 / Int24 / Int32, not f32. RME MADIface USB (tested here) delivers `ASIOSTInt32LSB` → `SampleFormat::I32`, so firewheel's f32-only path always fails:

```
panic: failed to start audio stream: BuildStreamError(StreamConfigNotSupported)
```

## Fix

Dispatch on `default_output_config().sample_format()` and build the stream with a callback matching the driver's native type. For non-f32 formats, render into an f32 scratch buffer (allocated once at stream start) and convert on the way out via `cpal::FromSample`. The f32 path is unchanged.

Handled: `F32` (unchanged), `I16`, `I24`, `I32`. Other formats still return `StreamConfigNotSupported`.

Error-forwarding closure extracted into a small `err_callback` helper so each arm constructs it the same way.

## Scope: output only

The input path (`start_input_stream`) has the identical bug — hardcoded `&[f32]` callback, same ASIO strict check. A follow-up PR will fix it symmetrically once I've verified it end-to-end on a failing device.

## Testing

Windows 10, tested with `examples/beep_test` (440 Hz tone, 4 s):
- RME MADIface USB (ASIO, native I32) — previously panicked with `StreamConfigNotSupported`, now streams cleanly.

## Notes

Conversion uses `cpal::FromSample` — one multiply + cast per sample, trivial versus any real DSP graph.