### PR TITLE
new SampleHandle API to allow for streamed samples

### DIFF
--- a/crates/firewheel-core/src/diff/leaf.rs
+++ b/crates/firewheel-core/src/diff/leaf.rs
@@ -13,6 +13,23 @@ use crate::{
 #[cfg(feature = "musical_transport")]
 use crate::clock::{DurationMusical, InstantMusical};
 
+impl Diff for () {
+    fn diff<E: EventQueue>(&self, _baseline: &Self, _path: PathBuilder, _event_queue: &mut E) {}
+}
+
+impl Patch for () {
+    type Patch = ();
+
+    fn patch(data: &ParamData, _path: &[u32]) -> Result<Self::Patch, PatchError> {
+        match data {
+            ParamData::None => Ok(()),
+            _ => Err(PatchError::InvalidData),
+        }
+    }
+
+    fn apply(&mut self, _patch: Self::Patch) {}
+}
+
 macro_rules! primitive_diff {
     ($ty:ty, $variant:ident) => {
         impl Diff for $ty {

--- a/crates/firewheel-core/src/diff/mod.rs
+++ b/crates/firewheel-core/src/diff/mod.rs
@@ -100,7 +100,7 @@
 //! # use firewheel_core::diff::{Diff, Patch, PathBuilder};
 //! #[derive(Diff, Patch, Clone, PartialEq)]
 //! enum SoundSource {
-//!     Sample(ArcGc<dyn SampleResource>), // Will _not_ cause allocations in `Patch`.
+//!     Sample(ArcGc<dyn SampleResource + Send + Sync + 'static>), // Will _not_ cause allocations in `Patch`.
 //!     Frequency(f32),
 //! }
 //! ```

--- a/crates/firewheel-core/src/node.rs
+++ b/crates/firewheel-core/src/node.rs
@@ -52,6 +52,12 @@ impl Default for NodeID {
 #[derive(Debug)]
 pub struct NodeError(Box<dyn Error>);
 
+impl NodeError {
+    pub const fn from_boxed(error: Box<dyn Error>) -> Self {
+        Self(error)
+    }
+}
+
 impl<E> From<E> for NodeError
 where
     E: Error + 'static,

--- a/crates/firewheel-core/src/sample_resource.rs
+++ b/crates/firewheel-core/src/sample_resource.rs
@@ -49,12 +49,16 @@ pub trait SampleResource: SampleResourceInfo {
     /// If the length of `out_buffer_range` is all or partly out of bounds of
     /// the resource, then the frames which are out of bounds will be left
     /// untouched.
+    ///
+    /// Returns the number of frames that were successfully filled. This may
+    /// be less than the length of `out_buffer_range` if the range is all or
+    /// partly out of bounds of the resource
     fn fill_buffers(
         &self,
         out_buffer: &mut [&mut [f32]],
         out_buffer_range: Range<usize>,
         start_frame: u64,
-    );
+    ) -> usize;
 }
 
 /// A resource of audio samples stored as de-interleaved f32 values.
@@ -121,7 +125,7 @@ impl SampleResource for InterleavedResourceF32 {
         out_buffer: &mut [&mut [f32]],
         out_buffer_range: Range<usize>,
         start_frame: u64,
-    ) {
+    ) -> usize {
         fill_buffers_interleaved(
             out_buffer,
             out_buffer_range,
@@ -129,7 +133,7 @@ impl SampleResource for InterleavedResourceF32 {
             self.channels,
             &self.data,
             self.len_frames() as usize,
-        );
+        )
     }
 }
 
@@ -160,14 +164,14 @@ impl SampleResource for Vec<Vec<f32>> {
         out_buffer: &mut [&mut [f32]],
         out_buffer_range: Range<usize>,
         start_frame: u64,
-    ) {
+    ) -> usize {
         fill_buffers_deinterleaved_f32(
             out_buffer,
             out_buffer_range,
             start_frame,
             self,
             self[0].len(),
-        );
+        )
     }
 }
 
@@ -178,6 +182,10 @@ impl SampleResourceF32 for Vec<Vec<f32>> {
 }
 
 /// A helper method to fill buffers from a resource of interleaved samples.
+///
+/// Returns the number of frames that were successfully filled. This may
+/// be less than the length of `out_buffer_range` if the range is all or
+/// partly out of bounds of the resource
 pub fn fill_buffers_interleaved<T: RawSample + Clone>(
     out_buffer: &mut [&mut [f32]],
     out_buffer_range: Range<usize>,
@@ -185,7 +193,7 @@ pub fn fill_buffers_interleaved<T: RawSample + Clone>(
     channels: NonZeroUsize,
     resource: &[T],
     resource_len_frames: usize,
-) {
+) -> usize {
     let channels = channels.get();
 
     let Some((frames, start_frame)) = constrain_frames(
@@ -193,7 +201,7 @@ pub fn fill_buffers_interleaved<T: RawSample + Clone>(
         start_frame,
         resource_len_frames,
     ) else {
-        return;
+        return 0;
     };
 
     // Provide an optimized loop for stereo.
@@ -212,7 +220,7 @@ pub fn fill_buffers_interleaved<T: RawSample + Clone>(
             *buf1_s = src_chunk[1].to_scaled_float();
         }
 
-        return;
+        return frames;
     }
 
     let src_slice = &resource[start_frame * channels..(start_frame + frames) * channels];
@@ -227,21 +235,27 @@ pub fn fill_buffers_interleaved<T: RawSample + Clone>(
             &mut out_ch[out_buffer_range.start..out_buffer_range.start + frames],
         );
     }
+
+    frames
 }
 
 /// A helper method to fill buffers from a resource of deinterleaved samples.
+///
+/// Returns the number of frames that were successfully filled. This may
+/// be less than the length of `out_buffer_range` if the range is all or
+/// partly out of bounds of the resource
 pub fn fill_channel_deinterleaved<T: RawSample + Clone>(
     out_buffer_channel: &mut [f32],
     out_buffer_range: Range<usize>,
     start_frame: u64,
     resource_channel: &[T],
-) {
+) -> usize {
     let Some((frames, start_frame)) = constrain_frames(
         out_buffer_range.end - out_buffer_range.start,
         start_frame,
         resource_channel.len(),
     ) else {
-        return;
+        return 0;
     };
 
     let adapter = SequentialSlice::new(resource_channel, 1, frames).unwrap();
@@ -252,36 +266,50 @@ pub fn fill_channel_deinterleaved<T: RawSample + Clone>(
         start_frame,
         &mut out_buffer_channel[out_buffer_range.start..out_buffer_range.start + frames],
     );
+
+    frames
 }
 
 /// A helper method to fill buffers from a resource of deinterleaved `f32` samples.
+///
+/// Returns the number of frames that were successfully filled. This may
+/// be less than the length of `out_buffer_range` if the range is all or
+/// partly out of bounds of the resource
 pub fn fill_buffers_deinterleaved_f32<V: AsRef<[f32]>>(
     out_buffer: &mut [&mut [f32]],
     out_buffer_range: Range<usize>,
     start_frame: u64,
     resource_channels: &[V],
     resource_len_frames: usize,
-) {
+) -> usize {
     let Some((frames, start_frame)) = constrain_frames(
         out_buffer_range.end - out_buffer_range.start,
         start_frame,
         resource_len_frames,
     ) else {
-        return;
+        return 0;
     };
 
     for (out_ch, in_ch) in out_buffer.iter_mut().zip(resource_channels.iter()) {
         out_ch[out_buffer_range.start..out_buffer_range.start + frames]
             .copy_from_slice(&in_ch.as_ref()[start_frame..start_frame + frames]);
     }
+
+    frames
 }
 
-fn constrain_frames(
-    out_buffer_len: usize,
+/// A helper to constrain the requested number of frames to the available frames
+/// in the sample resource.
+///
+/// Returns `Some((available_frames, start_frame as usize))` if the range is all
+/// or partly contained in the resource, or `None` if the range is fully outside
+/// the resource (`available_frames == 0`).
+pub fn constrain_frames(
+    requested_frames: usize,
     start_frame: u64,
     resource_len_frames: usize,
 ) -> Option<(usize, usize)> {
-    let frames = (out_buffer_len as u64)
+    let frames = (requested_frames as u64)
         .min((resource_len_frames as u64).saturating_sub(start_frame)) as usize;
     if frames == 0 {
         None

--- a/crates/firewheel-core/src/sample_resource.rs
+++ b/crates/firewheel-core/src/sample_resource.rs
@@ -15,7 +15,7 @@ use bevy_platform::prelude::Vec;
 use crate::collector::ArcGc;
 
 /// Trait returning information about a resource of audio samples
-pub trait SampleResourceInfo: Send + Sync + 'static {
+pub trait SampleResourceInfo {
     /// The number of channels in this resource.
     fn num_channels(&self) -> NonZeroUsize;
 
@@ -45,6 +45,10 @@ pub trait SampleResource: SampleResourceInfo {
     /// * `start_frame` - The sample (of a single channel of audio) in the
     ///   resource at which to start copying from. Not to be confused with video
     ///   frames.
+    ///
+    /// If the length of `out_buffer_range` is all or partly out of bounds of
+    /// the resource, then the frames which are out of bounds will be left
+    /// untouched.
     fn fill_buffers(
         &self,
         out_buffer: &mut [&mut [f32]],
@@ -59,18 +63,24 @@ pub trait SampleResourceF32: SampleResourceInfo {
     fn channel(&self, i: usize) -> Option<&[f32]>;
 }
 
-impl<T: SampleResource> From<T> for ArcGc<dyn SampleResource> {
+impl<T: SampleResource + Send + Sync + 'static> From<T>
+    for ArcGc<dyn SampleResource + Send + Sync + 'static>
+{
     fn from(value: T) -> Self {
         ArcGc::new_unsized(|| {
-            bevy_platform::sync::Arc::new(value) as bevy_platform::sync::Arc<dyn SampleResource>
+            bevy_platform::sync::Arc::new(value)
+                as bevy_platform::sync::Arc<dyn SampleResource + Send + Sync + 'static>
         })
     }
 }
 
-impl<T: SampleResourceF32> From<T> for ArcGc<dyn SampleResourceF32> {
+impl<T: SampleResourceF32 + Send + Sync + 'static> From<T>
+    for ArcGc<dyn SampleResourceF32 + Send + Sync + 'static>
+{
     fn from(value: T) -> Self {
         ArcGc::new_unsized(|| {
-            bevy_platform::sync::Arc::new(value) as bevy_platform::sync::Arc<dyn SampleResourceF32>
+            bevy_platform::sync::Arc::new(value)
+                as bevy_platform::sync::Arc<dyn SampleResourceF32 + Send + Sync + 'static>
         })
     }
 }
@@ -83,9 +93,10 @@ pub struct InterleavedResourceF32 {
 }
 
 impl InterleavedResourceF32 {
-    pub fn into_dyn_resource(self) -> ArcGc<dyn SampleResource> {
+    pub fn into_dyn_resource(self) -> ArcGc<dyn SampleResource + Send + Sync + 'static> {
         ArcGc::new_unsized(|| {
-            bevy_platform::sync::Arc::new(self) as bevy_platform::sync::Arc<dyn SampleResource>
+            bevy_platform::sync::Arc::new(self)
+                as bevy_platform::sync::Arc<dyn SampleResource + Send + Sync + 'static>
         })
     }
 }

--- a/crates/firewheel-nodes/src/convolution.rs
+++ b/crates/firewheel-nodes/src/convolution.rs
@@ -71,7 +71,7 @@ pub struct ConvolutionNode {
     /// The impulse response to use.
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub impulse_response: Option<ArcGc<dyn SampleResourceF32>>,
+    pub impulse_response: Option<ArcGc<dyn SampleResourceF32 + Send + Sync + 'static>>,
 
     /// Pause the convolution processing.
     ///

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -9,19 +9,26 @@
 //   a custom `SampleResource`).
 
 use firewheel_core::clock::{DurationSamples, DurationSeconds};
+use firewheel_core::collector::{OwnedGc, OwnedGcUnsized};
 use firewheel_core::node::{NodeError, ProcBuffers, ProcExtra, ProcStreamCtx};
-#[cfg(not(feature = "std"))]
-use num_traits::Float;
 
 use bevy_platform::sync::atomic::{AtomicU64, Ordering};
+use bevy_platform::sync::Arc;
 use bevy_platform::time::Instant;
 use core::sync::atomic::AtomicU32;
 use core::{
+    error::Error,
     num::{NonZeroU32, NonZeroUsize},
     ops::Range,
 };
 use firewheel_core::diff::{EventQueue, PatchError, PathBuilder, RealtimeClone};
+use firewheel_core::sample_resource::SampleResourceInfo;
 use smallvec::SmallVec;
+
+#[cfg(not(feature = "std"))]
+use bevy_platform::prelude::Box;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
 
 use firewheel_core::{
     channel_config::{ChannelConfig, ChannelCount, NonZeroChannelCount},
@@ -98,18 +105,155 @@ pub enum PlaybackSpeedQuality {
     // TODO: more quality options
 }
 
+/// A resource for a [`SamplerNode`] that streams its data from disk or over
+/// a network.
+pub trait StreamedSample: Send + Sync + 'static {
+    /// Information about this streamed sample resource.
+    fn info(&self) -> StreamedSampleInfo;
+
+    /// Spawn a new stream, returning the resulting [`StreamedSampleProcessor`]
+    /// counterpart.
+    fn spawn_stream(&self) -> Result<OwnedGcUnsized<dyn StreamedSampleProcessor>, Box<dyn Error>>;
+}
+
+/// Information about a [`StreamedSample`] resource.
+pub struct StreamedSampleInfo {
+    /// The maximum supported playback speed, where `1.0` is playing at the
+    /// sample rate of this resource, `0.5` is playing at half the sample rate,
+    /// and `2.0` is playing at twice the sample rate.
+    ///
+    /// This is usually limited by how quickly the stream can reliably get new
+    /// samples.f this resource
+    pub max_speed: f64,
+
+    /// Whether or not this resource supports playing a sample backwards.
+    pub can_play_backwards: bool,
+}
+
+/// The realtime audio thread counterpart to spawned stream in a
+/// [`StreamedSample`].
+pub trait StreamedSampleProcessor: SampleResourceInfo + Send + Sync + 'static {
+    /// Fill the given buffers with audio data starting from the given
+    /// starting frame in the resource.
+    ///
+    /// * `out_buffer` - The buffers to fill with data. If the length of `buffers`
+    ///   is greater than the number of channels in this resource, then ignore
+    ///   the extra buffers.
+    /// * `out_buffer_range` - The range inside each buffer slice in which to
+    ///   fill with data. Do not fill any data outside of this range.
+    /// * `start_frame` - The sample (of a single channel of audio) in the
+    ///   resource at which to start copying from. Not to be confused with video
+    ///   frames.
+    /// * `speed` - The speed at which playback is occuring, where `1.0` is
+    /// playing at the sample rate of this resource, `0.5` is playing at half
+    /// the sample rate, and `2.0` is playing at twice the sample rate.
+    ///
+    /// Returns the number of frames that were successfully filled. This may
+    /// be less than the length of `out_buffer_range` if the range is all or
+    /// partly out of bounds of the resource, or if a cache miss occured.
+    /// Any frames that were not successfully filled will be left untouched.
+    fn fill_buffers(
+        &mut self,
+        out_buffer: &mut [&mut [f32]],
+        out_buffer_range: Range<usize>,
+        start_frame: u64,
+        speed: f64,
+        is_playing_backwards: bool,
+    ) -> usize;
+
+    /// Returns `true` if the given range of frames is loaded
+    /// into memory and ready to be read.
+    fn range_is_ready(&mut self, range: Range<u64>) -> bool;
+
+    /// Request to cache a new region at the given starting frame.
+    fn cache_new_starting_frame(&mut self, frame: u64, speed: f64, will_play_backwards: bool);
+}
+
+#[derive(Clone)]
+/// A source of audio samples for a [`SamplerNode`].
+pub enum SampleHandle {
+    /// A resource that has all of its data loaded into memory.
+    InMemory(ArcGc<dyn SampleResource + Send + Sync + 'static>),
+    /// A resource that streams its data from disk or over a network.
+    ///
+    /// NOT IMPLEMENTED YET! Will lead to a panic if used.
+    Streamed(Arc<dyn StreamedSample>),
+}
+
+impl SampleHandle {
+    pub fn from_sample(sample: impl SampleResource + Send + Sync + 'static) -> Self {
+        Self::InMemory(sample.into())
+    }
+
+    pub fn from_streamed(sample: impl StreamedSample) -> Self {
+        Self::Streamed(Arc::new(sample))
+    }
+
+    /// Information about the streamed sample resource.
+    ///
+    /// Returns `None` if this sample is not of type [`SampleHandle::Streamed`].
+    pub fn streamed_sample_info(&self) -> Option<StreamedSampleInfo> {
+        if let SampleHandle::Streamed(s) = self {
+            Some(s.info())
+        } else {
+            None
+        }
+    }
+
+    fn spawn_inner(&self) -> Result<SampleInner, Box<dyn Error>> {
+        Ok(match self {
+            SampleHandle::InMemory(r) => SampleInner::InMemory(ArcGc::clone(r)),
+            SampleHandle::Streamed(r) => r.spawn_stream().map(|r| SampleInner::Streamed(r))?,
+        })
+    }
+}
+
+fn spawn_sample_handle_event(
+    sample: &Option<SampleHandle>,
+) -> Result<NodeEventType, Box<dyn Error>> {
+    let data = if let Some(sample) = sample.as_ref() {
+        Some(sample.spawn_inner()?)
+    } else {
+        None
+    };
+
+    Ok(NodeEventType::Custom(OwnedGc::new(Box::new(data))))
+}
+
+impl From<ArcGc<dyn SampleResource + Send + Sync + 'static>> for SampleHandle {
+    fn from(value: ArcGc<dyn SampleResource + Send + Sync + 'static>) -> Self {
+        Self::InMemory(value)
+    }
+}
+
+impl From<Arc<dyn StreamedSample + Send + Sync + 'static>> for SampleHandle {
+    fn from(value: Arc<dyn StreamedSample + Send + Sync + 'static>) -> Self {
+        Self::Streamed(value)
+    }
+}
+
+impl PartialEq for SampleHandle {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (SampleHandle::InMemory(s), SampleHandle::InMemory(o)) => ArcGc::ptr_eq(s, o),
+            (SampleHandle::Streamed(s), SampleHandle::Streamed(o)) => Arc::ptr_eq(s, o),
+            _ => false,
+        }
+    }
+}
+
 /// A node that plays samples
 ///
 /// It supports pausing, resuming, looping, and changing the playback speed.
-#[derive(Clone, Diff, Patch, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SamplerNode {
-    /// The sample resource to use.
+    /// The source of audio samples to use.
     #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
     #[cfg_attr(feature = "serde", serde(skip))]
-    pub sample: Option<ArcGc<dyn SampleResource>>,
+    pub sample: Option<SampleHandle>,
 
     /// The volume to play the sample at.
     ///
@@ -171,6 +315,34 @@ impl Default for SamplerNode {
     }
 }
 
+impl Diff for SamplerNode {
+    fn diff<E: EventQueue>(&self, baseline: &Self, path: PathBuilder, event_queue: &mut E) {
+        if self.sample != baseline.sample {
+            match spawn_sample_handle_event(&self.sample) {
+                Ok(event) => event_queue.push(event),
+                Err(_e) => {
+                    // TODO: log error
+                }
+            }
+        }
+
+        self.volume
+            .diff(&baseline.volume, path.with(0), event_queue);
+        self.play.diff(&baseline.play, path.with(1), event_queue);
+        self.play_from
+            .diff(&baseline.play_from, path.with(2), event_queue);
+        self.repeat_mode
+            .diff(&baseline.repeat_mode, path.with(3), event_queue);
+        self.speed.diff(&baseline.speed, path.with(4), event_queue);
+        self.mono_to_stereo
+            .diff(&baseline.mono_to_stereo, path.with(5), event_queue);
+        self.crossfade_on_seek
+            .diff(&baseline.crossfade_on_seek, path.with(6), event_queue);
+        self.min_gain
+            .diff(&baseline.min_gain, path.with(7), event_queue);
+    }
+}
+
 impl core::fmt::Debug for SamplerNode {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut f = f.debug_struct("SamplerNode");
@@ -188,17 +360,13 @@ impl core::fmt::Debug for SamplerNode {
 }
 
 impl SamplerNode {
-    /// Set the parameters to a play a single sample.
-    pub fn set_sample(&mut self, sample: ArcGc<dyn SampleResource>) {
-        self.sample = Some(sample);
+    pub fn set_sample(&mut self, sample: ArcGc<dyn SampleResource + Send + Sync + 'static>) {
+        self.sample = Some(sample.into());
     }
 
-    /// Returns an event type to sync the `sample` parameter.
-    pub fn sync_sample_event(&self) -> NodeEventType {
-        NodeEventType::Param {
-            data: ParamData::any(self.sample.clone()),
-            path: ParamPath::Single(0),
-        }
+    /// Returns an event type to sync the changed `sample` parameter.
+    pub fn sync_sample_event(&self) -> Result<NodeEventType, Box<dyn Error>> {
+        spawn_sample_handle_event(&self.sample)
     }
 
     /// Returns an event type to sync the `volume` parameter.
@@ -515,7 +683,11 @@ impl Default for PlayFrom {
 impl Diff for PlayFrom {
     fn diff<E: EventQueue>(&self, baseline: &Self, path: PathBuilder, event_queue: &mut E) {
         if self != baseline {
-            event_queue.push_param(self.as_param_data(), path);
+            match self {
+                Self::Resume => event_queue.push_param(ParamData::None, path),
+                Self::Seconds(seconds) => event_queue.push_param(*seconds, path),
+                Self::Frames(frames) => event_queue.push_param(*frames, path),
+            }
         }
     }
 }
@@ -591,10 +763,26 @@ impl AudioNode for SamplerNode {
             ))
         };
 
+        let pending_sample = if let Some(sample) = &self.sample {
+            Some(sample.spawn_inner().map_err(|e| NodeError::from_boxed(e))?)
+        } else {
+            None
+        };
+
         Ok(SamplerProcessor {
             config: *config,
-            params: self.clone(),
+            params: ProcessorParams {
+                volume: self.volume,
+                play: self.play,
+                play_from: self.play_from,
+                repeat_mode: self.repeat_mode,
+                speed: self.speed,
+                mono_to_stereo: self.mono_to_stereo,
+                crossfade_on_seek: self.crossfade_on_seek,
+                min_gain: self.min_gain,
+            },
             shared_state: ArcGc::clone(&cx.custom_state::<SamplerState>().unwrap().shared_state),
+            initial_sample: Some(pending_sample),
             loaded_sample_state: None,
             declicker: Declicker::SettledAt1,
             stop_declicker_buffers,
@@ -607,18 +795,30 @@ impl AudioNode for SamplerNode {
             #[cfg(feature = "scheduled_events")]
             queued_playback_instant: None,
             min_gain: self.min_gain.max(0.0),
-            is_first_process: true,
             max_block_frames: cx.stream_info.max_block_frames.get() as usize,
             num_out_channels: config.channels.get().get() as usize,
         })
     }
 }
 
+#[derive(Patch)]
+struct ProcessorParams {
+    volume: Volume,
+    play: Notify<bool>,
+    play_from: PlayFrom,
+    repeat_mode: RepeatMode,
+    speed: f64,
+    mono_to_stereo: bool,
+    crossfade_on_seek: bool,
+    min_gain: f32,
+}
+
 struct SamplerProcessor {
     config: SamplerConfig,
-    params: SamplerNode,
+    params: ProcessorParams,
     shared_state: ArcGc<SharedState>,
 
+    initial_sample: Option<Option<SampleInner>>,
     loaded_sample_state: Option<LoadedSampleState>,
 
     declicker: Declicker,
@@ -638,7 +838,6 @@ struct SamplerProcessor {
 
     min_gain: f32,
 
-    is_first_process: bool,
     max_block_frames: usize,
     num_out_channels: usize,
 }
@@ -725,11 +924,18 @@ impl SamplerProcessor {
             };
 
         if first_copy_frames > 0 {
-            state.sample.fill_buffers(
-                buffers,
-                range_in_buffer.start..range_in_buffer.start + first_copy_frames,
-                state.playhead_frames,
-            );
+            match &mut state.sample {
+                SampleInner::InMemory(sample) => {
+                    sample.fill_buffers(
+                        buffers,
+                        range_in_buffer.start..range_in_buffer.start + first_copy_frames,
+                        state.playhead_frames,
+                    );
+                }
+                SampleInner::Streamed(_) => {
+                    todo!()
+                }
+            }
 
             state.playhead_frames += first_copy_frames as u64;
         }
@@ -743,12 +949,19 @@ impl SamplerProcessor {
                         .min(state.sample_len_frames)
                         as usize;
 
-                    state.sample.fill_buffers(
-                        buffers,
-                        range_in_buffer.start + frames_copied
-                            ..range_in_buffer.start + frames_copied + copy_frames,
-                        0,
-                    );
+                    match &mut state.sample {
+                        SampleInner::InMemory(sample) => {
+                            sample.fill_buffers(
+                                buffers,
+                                range_in_buffer.start + frames_copied
+                                    ..range_in_buffer.start + frames_copied + copy_frames,
+                                0,
+                            );
+                        }
+                        SampleInner::Streamed(_) => {
+                            todo!()
+                        }
+                    }
 
                     state.playhead_frames = copy_frames as u64;
                     state.num_times_looped_back += 1;
@@ -769,7 +982,7 @@ impl SamplerProcessor {
     }
 
     fn currently_processing_sample(&self) -> bool {
-        if self.params.sample.is_none() {
+        if self.loaded_sample_state.is_none() {
             false
         } else {
             self.playing || (self.paused && !self.declicker.has_settled())
@@ -837,14 +1050,16 @@ impl SamplerProcessor {
         }
     }
 
-    fn load_sample(&mut self, sample: ArcGc<dyn SampleResource>) {
+    fn load_sample(&mut self, sample: SampleInner) {
         let mut gain = self.params.volume.amp_clamped(self.min_gain);
         if gain > 0.99999 && gain < 1.00001 {
             gain = 1.0;
         }
 
-        let sample_len_frames = sample.len_frames();
-        let sample_num_channels = sample.num_channels();
+        let (sample_len_frames, sample_num_channels) = match &sample {
+            SampleInner::InMemory(s) => (s.len_frames(), s.num_channels()),
+            SampleInner::Streamed(s) => (s.len_frames(), s.num_channels()),
+        };
 
         let sample_mono_to_stereo = self.params.mono_to_stereo
             && self.num_out_channels > 1
@@ -864,56 +1079,69 @@ impl SamplerProcessor {
 
 impl AudioNodeProcessor for SamplerProcessor {
     fn events(&mut self, info: &ProcInfo, events: &mut ProcEvents, extra: &mut ProcExtra) {
-        let mut sample_changed = self.is_first_process;
-        let mut repeat_mode_changed = false;
-        let mut speed_changed = false;
-        let mut volume_changed = false;
-        let mut new_playing: Option<bool> = if self.is_first_process {
+        let is_first_process = self.initial_sample.is_some();
+        let mut new_playing: Option<bool> = if is_first_process {
             Some(self.playing)
         } else {
             None
         };
+        let mut new_sample = self.initial_sample.take();
+        let mut repeat_mode_changed = false;
+        let mut speed_changed = false;
+        let mut volume_changed = false;
 
         #[cfg(feature = "scheduled_events")]
         let mut playback_instant: Option<EventInstant> = None;
 
-        #[cfg(not(feature = "scheduled_events"))]
-        for patch in events.drain_patches::<SamplerNode>() {
-            match patch {
-                SamplerNodePatch::Sample(_) => sample_changed = true,
-                SamplerNodePatch::Volume(_) => volume_changed = true,
-                SamplerNodePatch::Play(play) => {
-                    new_playing = Some(*play);
-                }
-                SamplerNodePatch::RepeatMode(_) => repeat_mode_changed = true,
-                SamplerNodePatch::Speed(_) => speed_changed = true,
-                SamplerNodePatch::MinGain(min_gain) => {
-                    self.min_gain = min_gain.max(0.0);
-                }
-                _ => {}
+        #[cfg(feature = "scheduled_events")]
+        for (mut event, timestamp) in events.drain_with_timestamps() {
+            let mut s = None;
+            if event.downcast_swap::<Option<SampleInner>>(&mut s) {
+                new_sample = Some(s);
             }
 
-            self.params.apply(patch);
+            if let Some(patch) = ProcessorParams::patch_event(&event) {
+                match patch {
+                    ProcessorParamsPatch::Volume(_) => volume_changed = true,
+                    ProcessorParamsPatch::Play(play) => {
+                        playback_instant = timestamp;
+                        new_playing = Some(*play);
+                    }
+                    ProcessorParamsPatch::RepeatMode(_) => repeat_mode_changed = true,
+                    ProcessorParamsPatch::Speed(_) => speed_changed = true,
+                    ProcessorParamsPatch::MinGain(min_gain) => {
+                        self.min_gain = min_gain.max(0.0);
+                    }
+                    _ => {}
+                }
+
+                self.params.apply(patch);
+            }
         }
 
-        #[cfg(feature = "scheduled_events")]
-        for (patch, timestamp) in events.drain_patches_with_timestamps::<SamplerNode>() {
-            match patch {
-                SamplerNodePatch::Sample(_) => sample_changed = true,
-                SamplerNodePatch::Volume(_) => volume_changed = true,
-                SamplerNodePatch::Play(play) => {
-                    playback_instant = timestamp;
-                    new_playing = Some(*play);
-                }
-                SamplerNodePatch::RepeatMode(_) => repeat_mode_changed = true,
-                SamplerNodePatch::Speed(_) => speed_changed = true,
-                SamplerNodePatch::MinGain(min_gain) => {
-                    self.min_gain = min_gain.max(0.0);
-                }
-                _ => {}
+        #[cfg(not(feature = "scheduled_events"))]
+        for mut event in events.drain() {
+            let mut s = None;
+            if event.downcast_swap::<Option<SampleInner>>(&mut s) {
+                new_sample = Some(s);
             }
 
-            self.params.apply(patch);
+            if let Some(patch) = ProcessorParams::patch_event(&event) {
+                match patch {
+                    ProcessorParamsPatch::Volume(_) => volume_changed = true,
+                    ProcessorParamsPatch::Play(play) => {
+                        new_playing = Some(*play);
+                    }
+                    ProcessorParamsPatch::RepeatMode(_) => repeat_mode_changed = true,
+                    ProcessorParamsPatch::Speed(_) => speed_changed = true,
+                    ProcessorParamsPatch::MinGain(min_gain) => {
+                        self.min_gain = min_gain.max(0.0);
+                    }
+                    _ => {}
+                }
+
+                self.params.apply(patch);
+            }
         }
 
         if speed_changed {
@@ -939,7 +1167,7 @@ impl AudioNodeProcessor for SamplerProcessor {
             }
         }
 
-        if sample_changed {
+        if let Some(maybe_sample) = new_sample {
             self.stop(extra);
 
             #[cfg(feature = "scheduled_events")]
@@ -953,8 +1181,8 @@ impl AudioNodeProcessor for SamplerProcessor {
 
             self.loaded_sample_state = None;
 
-            if let Some(sample) = &self.params.sample {
-                self.load_sample(ArcGc::clone(sample));
+            if let Some(sample) = maybe_sample {
+                self.load_sample(sample);
             }
         }
 
@@ -966,7 +1194,7 @@ impl AudioNodeProcessor for SamplerProcessor {
 
                 if self.params.play_from == PlayFrom::Resume {
                     // Resume
-                    if self.playing && !self.is_first_process {
+                    if self.playing && !is_first_process {
                         // Sample is already playing, no need to do anything.
                         #[cfg(feature = "scheduled_events")]
                         {
@@ -1099,8 +1327,6 @@ impl AudioNodeProcessor for SamplerProcessor {
             } as u32,
             Ordering::Relaxed,
         );
-
-        self.is_first_process = false;
     }
 
     fn bypassed(&mut self, _bypassed: bool) {
@@ -1133,7 +1359,7 @@ impl AudioNodeProcessor for SamplerProcessor {
 
         let mut num_filled_channels = 0;
 
-        if currently_processing_sample && self.params.sample.is_some() {
+        if currently_processing_sample {
             let sample_state = self.loaded_sample_state.as_ref().unwrap();
 
             let looping = self
@@ -1235,7 +1461,6 @@ impl AudioNodeProcessor for SamplerProcessor {
 
             // The sample rate has changed, meaning that the sample resources now have
             // the incorrect sample rate and the user must reload them.
-            self.params.sample = None;
             self.loaded_sample_state = None;
             self.playing = false;
             self.paused = false;
@@ -1281,8 +1506,13 @@ impl SharedPlaybackState {
     }
 }
 
+enum SampleInner {
+    InMemory(ArcGc<dyn SampleResource + Send + Sync + 'static>),
+    Streamed(OwnedGcUnsized<dyn StreamedSampleProcessor>),
+}
+
 struct LoadedSampleState {
-    sample: ArcGc<dyn SampleResource>,
+    sample: SampleInner,
     sample_len_frames: u64,
     sample_num_channels: NonZeroUsize,
     sample_mono_to_stereo: bool,

--- a/crates/firewheel-nodes/src/sampler.rs
+++ b/crates/firewheel-nodes/src/sampler.rs
@@ -12,12 +12,10 @@ use firewheel_core::clock::{DurationSamples, DurationSeconds};
 use firewheel_core::collector::{OwnedGc, OwnedGcUnsized};
 use firewheel_core::node::{NodeError, ProcBuffers, ProcExtra, ProcStreamCtx};
 
-use bevy_platform::sync::atomic::{AtomicU64, Ordering};
-use bevy_platform::sync::Arc;
+use bevy_platform::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use bevy_platform::time::Instant;
 use core::sync::atomic::AtomicU32;
 use core::{
-    error::Error,
     num::{NonZeroU32, NonZeroUsize},
     ops::Range,
 };
@@ -105,34 +103,144 @@ pub enum PlaybackSpeedQuality {
     // TODO: more quality options
 }
 
-/// A resource for a [`SamplerNode`] that streams its data from disk or over
-/// a network.
-pub trait StreamedSample: Send + Sync + 'static {
-    /// Information about this streamed sample resource.
-    fn info(&self) -> StreamedSampleInfo;
-
-    /// Spawn a new stream, returning the resulting [`StreamedSampleProcessor`]
-    /// counterpart.
-    fn spawn_stream(&self) -> Result<OwnedGcUnsized<dyn StreamedSampleProcessor>, Box<dyn Error>>;
-}
-
-/// Information about a [`StreamedSample`] resource.
-pub struct StreamedSampleInfo {
-    /// The maximum supported playback speed, where `1.0` is playing at the
-    /// sample rate of this resource, `0.5` is playing at half the sample rate,
-    /// and `2.0` is playing at twice the sample rate.
+/// A source of audio samples for a [`SamplerNode`].
+pub enum SamplerNodeResource {
+    /// A resource of audio samples where the entire contents of the sample are
+    /// already loaded into memory.
     ///
-    /// This is usually limited by how quickly the stream can reliably get new
-    /// samples.f this resource
-    pub max_speed: f64,
+    /// Prefer this for resources which are less than 20 or so seconds long
+    /// (i.e. sound effects).
+    InMemory(ArcGc<dyn SampleResource + Send + Sync + 'static>),
 
-    /// Whether or not this resource supports playing a sample backwards.
-    pub can_play_backwards: bool,
+    /// NOT IMPLEMENTED YET! Will lead to a panic if used.
+    ///
+    /// A resource of audio samples that are streamed from disk or over a network.
+    ///
+    /// Prefer this for resources which are greather than 20 or so seconds long
+    /// (i.e. music tracks and ambience).
+    ///
+    /// This uses considerably less memory, but requires a more complicated setup.
+    /// It also has the potential to run into cache misses if the playhead is moved
+    /// to a region that hasn't been loaded yet, or if the stream fails to send
+    /// enough samples in time.
+    Streamed(OwnedGcUnsized<dyn StreamedSample>),
 }
 
-/// The realtime audio thread counterpart to spawned stream in a
-/// [`StreamedSample`].
-pub trait StreamedSampleProcessor: SampleResourceInfo + Send + Sync + 'static {
+impl SamplerNodeResource {
+    pub fn from_sample<T: SampleResource + Send + Sync + 'static>(sample: T) -> Self {
+        Self::InMemory(sample.into())
+    }
+
+    pub fn from_streamed<T: StreamedSample>(sample: T) -> Self {
+        Self::Streamed(OwnedGcUnsized::new_unsized(Box::new(sample)))
+    }
+
+    /// The number of channels in this resource.
+    pub fn num_channels(&self) -> NonZeroUsize {
+        match self {
+            Self::InMemory(s) => s.num_channels(),
+            Self::Streamed(s) => s.num_channels(),
+        }
+    }
+
+    /// The length of this resource in samples (of a single channel of audio).
+    ///
+    /// Not to be confused with video frames.
+    pub fn len_frames(&self) -> u64 {
+        match self {
+            Self::InMemory(s) => s.len_frames(),
+            Self::Streamed(s) => s.len_frames(),
+        }
+    }
+
+    /// The sample rate of this resource.
+    ///
+    /// Returns `None` if the sample rate is unknown.
+    pub fn sample_rate(&self) -> Option<NonZeroU32> {
+        match self {
+            Self::InMemory(s) => s.sample_rate(),
+            Self::Streamed(s) => s.sample_rate(),
+        }
+    }
+
+    /// Fill the given buffers with audio data starting from the given
+    /// starting frame in the resource.
+    ///
+    /// * `out_buffer` - The buffers to fill with data. If the length of `buffers`
+    ///   is greater than the number of channels in this resource, then ignore
+    ///   the extra buffers.
+    /// * `out_buffer_range` - The range inside each buffer slice in which to
+    ///   fill with data. Do not fill any data outside of this range.
+    /// * `start_frame` - The sample (of a single channel of audio) in the
+    ///   resource at which to start copying from. Not to be confused with video
+    ///   frames.
+    /// * `speed` - The speed at which playback is occuring, where `1.0` is
+    /// playing at the sample rate of this resource, `0.5` is playing at half
+    /// the sample rate, and `2.0` is playing at twice the sample rate.
+    ///
+    /// Returns the number of frames that were successfully filled. This may
+    /// be less than the length of `out_buffer_range` if the range is all or
+    /// partly out of bounds of the resource, or if a cache miss occured.
+    /// Any frames that were not successfully filled will be left untouched.
+    pub fn fill_buffers(
+        &mut self,
+        out_buffer: &mut [&mut [f32]],
+        out_buffer_range: Range<usize>,
+        start_frame: u64,
+        speed: f64,
+        is_playing_backwards: bool,
+    ) -> usize {
+        match self {
+            SamplerNodeResource::InMemory(s) => {
+                s.fill_buffers(out_buffer, out_buffer_range.clone(), start_frame)
+            }
+            SamplerNodeResource::Streamed(s) => s.fill_buffers(
+                out_buffer,
+                out_buffer_range,
+                start_frame,
+                speed,
+                is_playing_backwards,
+            ),
+        }
+    }
+
+    /// Returns `true` if the given range of frames is loaded
+    /// into memory and ready to be read.
+    pub fn range_is_ready(&mut self, range: Range<u64>) -> bool {
+        if let SamplerNodeResource::Streamed(s) = self {
+            s.range_is_ready(range)
+        } else {
+            true
+        }
+    }
+
+    /// Request to cache a new region at the given starting frame.
+    pub fn cache_new_starting_frame(&mut self, frame: u64, speed: f64, will_play_backwards: bool) {
+        if let SamplerNodeResource::Streamed(s) = self {
+            s.cache_new_starting_frame(frame, speed, will_play_backwards);
+        }
+    }
+}
+
+impl From<ArcGc<dyn SampleResource + Send + Sync + 'static>> for SamplerNodeResource {
+    fn from(value: ArcGc<dyn SampleResource + Send + Sync + 'static>) -> Self {
+        Self::InMemory(value)
+    }
+}
+
+impl From<OwnedGcUnsized<dyn StreamedSample>> for SamplerNodeResource {
+    fn from(value: OwnedGcUnsized<dyn StreamedSample>) -> Self {
+        Self::Streamed(value)
+    }
+}
+
+/// A resource of audio samples that are streamed from disk or over a network.
+///
+/// This uses considerably less memory, but requires a more complicated setup. It
+/// also has the potential to run into cache misses if the playhead is moved to a
+/// region that hasn't been loaded yet, or if the stream fails to send enough samples
+/// in time.
+pub trait StreamedSample: SampleResourceInfo + Send + Sync + 'static {
     /// Fill the given buffers with audio data starting from the given
     /// starting frame in the resource.
     ///
@@ -169,92 +277,14 @@ pub trait StreamedSampleProcessor: SampleResourceInfo + Send + Sync + 'static {
     fn cache_new_starting_frame(&mut self, frame: u64, speed: f64, will_play_backwards: bool);
 }
 
-#[derive(Clone)]
-/// A source of audio samples for a [`SamplerNode`].
-pub enum SampleHandle {
-    /// A resource that has all of its data loaded into memory.
-    InMemory(ArcGc<dyn SampleResource + Send + Sync + 'static>),
-    /// A resource that streams its data from disk or over a network.
-    ///
-    /// NOT IMPLEMENTED YET! Will lead to a panic if used.
-    Streamed(Arc<dyn StreamedSample>),
-}
-
-impl SampleHandle {
-    pub fn from_sample(sample: impl SampleResource + Send + Sync + 'static) -> Self {
-        Self::InMemory(sample.into())
-    }
-
-    pub fn from_streamed(sample: impl StreamedSample) -> Self {
-        Self::Streamed(Arc::new(sample))
-    }
-
-    /// Information about the streamed sample resource.
-    ///
-    /// Returns `None` if this sample is not of type [`SampleHandle::Streamed`].
-    pub fn streamed_sample_info(&self) -> Option<StreamedSampleInfo> {
-        if let SampleHandle::Streamed(s) = self {
-            Some(s.info())
-        } else {
-            None
-        }
-    }
-
-    fn spawn_inner(&self) -> Result<SampleInner, Box<dyn Error>> {
-        Ok(match self {
-            SampleHandle::InMemory(r) => SampleInner::InMemory(ArcGc::clone(r)),
-            SampleHandle::Streamed(r) => r.spawn_stream().map(|r| SampleInner::Streamed(r))?,
-        })
-    }
-}
-
-fn spawn_sample_handle_event(
-    sample: &Option<SampleHandle>,
-) -> Result<NodeEventType, Box<dyn Error>> {
-    let data = if let Some(sample) = sample.as_ref() {
-        Some(sample.spawn_inner()?)
-    } else {
-        None
-    };
-
-    Ok(NodeEventType::Custom(OwnedGc::new(Box::new(data))))
-}
-
-impl From<ArcGc<dyn SampleResource + Send + Sync + 'static>> for SampleHandle {
-    fn from(value: ArcGc<dyn SampleResource + Send + Sync + 'static>) -> Self {
-        Self::InMemory(value)
-    }
-}
-
-impl From<Arc<dyn StreamedSample + Send + Sync + 'static>> for SampleHandle {
-    fn from(value: Arc<dyn StreamedSample + Send + Sync + 'static>) -> Self {
-        Self::Streamed(value)
-    }
-}
-
-impl PartialEq for SampleHandle {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (SampleHandle::InMemory(s), SampleHandle::InMemory(o)) => ArcGc::ptr_eq(s, o),
-            (SampleHandle::Streamed(s), SampleHandle::Streamed(o)) => Arc::ptr_eq(s, o),
-            _ => false,
-        }
-    }
-}
-
 /// A node that plays samples
 ///
 /// It supports pausing, resuming, looping, and changing the playback speed.
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, Diff, Patch, PartialEq)]
 #[cfg_attr(feature = "bevy", derive(bevy_ecs::prelude::Component))]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SamplerNode {
-    /// The source of audio samples to use.
-    #[cfg_attr(feature = "bevy_reflect", reflect(ignore))]
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub sample: Option<SampleHandle>,
-
     /// The volume to play the sample at.
     ///
     /// Note, this gain parameter is *NOT* smoothed! If you need the gain to be
@@ -302,7 +332,6 @@ pub struct SamplerNode {
 impl Default for SamplerNode {
     fn default() -> Self {
         Self {
-            sample: None,
             volume: Volume::default(),
             play: Default::default(),
             play_from: PlayFrom::default(),
@@ -315,73 +344,59 @@ impl Default for SamplerNode {
     }
 }
 
-impl Diff for SamplerNode {
-    fn diff<E: EventQueue>(&self, baseline: &Self, path: PathBuilder, event_queue: &mut E) {
-        if self.sample != baseline.sample {
-            match spawn_sample_handle_event(&self.sample) {
-                Ok(event) => event_queue.push(event),
-                Err(_e) => {
-                    // TODO: log error
-                }
-            }
-        }
-
-        self.volume
-            .diff(&baseline.volume, path.with(0), event_queue);
-        self.play.diff(&baseline.play, path.with(1), event_queue);
-        self.play_from
-            .diff(&baseline.play_from, path.with(2), event_queue);
-        self.repeat_mode
-            .diff(&baseline.repeat_mode, path.with(3), event_queue);
-        self.speed.diff(&baseline.speed, path.with(4), event_queue);
-        self.mono_to_stereo
-            .diff(&baseline.mono_to_stereo, path.with(5), event_queue);
-        self.crossfade_on_seek
-            .diff(&baseline.crossfade_on_seek, path.with(6), event_queue);
-        self.min_gain
-            .diff(&baseline.min_gain, path.with(7), event_queue);
-    }
-}
-
-impl core::fmt::Debug for SamplerNode {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut f = f.debug_struct("SamplerNode");
-        f.field("has_sample", &self.sample.is_some());
-        f.field("volume", &self.volume);
-        f.field("play", &self.play);
-        f.field("play_from", &self.play_from);
-        f.field("repeat_mode", &self.repeat_mode);
-        f.field("speed", &self.speed);
-        f.field("mono_to_stereo", &self.mono_to_stereo);
-        f.field("crossfade_on_seek", &self.crossfade_on_seek);
-        f.field("min_gain", &self.min_gain);
-        f.finish()
-    }
-}
-
 impl SamplerNode {
-    pub fn set_sample(&mut self, sample: ArcGc<dyn SampleResource + Send + Sync + 'static>) {
-        self.sample = Some(sample.into());
+    /// Returns an event to clear the sample resource from a sampler node.
+    pub fn clear_sample_event() -> NodeEventType {
+        NodeEventType::Custom(OwnedGc::new(Box::<Option<SamplerNodeResource>>::new(None)))
     }
 
-    /// Returns an event type to sync the changed `sample` parameter.
-    pub fn sync_sample_event(&self) -> Result<NodeEventType, Box<dyn Error>> {
-        spawn_sample_handle_event(&self.sample)
+    /// Returns an event to set the sample resource for a sampler node from the
+    /// given sample resource.
+    pub fn set_sample_event<T: SampleResource + Send + Sync + 'static>(sample: T) -> NodeEventType {
+        Self::set_resource_event(SamplerNodeResource::from_sample(sample))
+    }
+
+    /// Returns an event to set the sample resource for a sampler node from the
+    /// given streamed sample resource.
+    pub fn set_streamed_sample_event<T: StreamedSample>(sample: T) -> NodeEventType {
+        Self::set_resource_event(SamplerNodeResource::from_streamed(sample))
+    }
+
+    /// Returns an event to set the sample resource for a sampler node from the
+    /// given type-erased sample resource.
+    pub fn set_dyn_sample_event(
+        sample: ArcGc<dyn SampleResource + Send + Sync + 'static>,
+    ) -> NodeEventType {
+        Self::set_resource_event(sample.into())
+    }
+
+    /// Returns an event to set the sample resource for a sampler node from the
+    /// given type-erased streamed sample resource.
+    pub fn set_dyn_streamed_sample_event(
+        sample: OwnedGcUnsized<dyn StreamedSample>,
+    ) -> NodeEventType {
+        Self::set_resource_event(sample.into())
+    }
+
+    /// Returns an event to set the sample resource for a sampler node.
+    pub fn set_resource_event(sample: SamplerNodeResource) -> NodeEventType {
+        NodeEventType::Custom(OwnedGc::new(Box::new(Some(sample))))
     }
 
     /// Returns an event type to sync the `volume` parameter.
     pub fn sync_volume_event(&self) -> NodeEventType {
         NodeEventType::Param {
             data: ParamData::Volume(self.volume),
-            path: ParamPath::Single(1),
+            path: ParamPath::Single(0),
         }
     }
 
     /// Returns an event type to sync the `play` parameter.
     pub fn sync_play_event(&self) -> NodeEventType {
         NodeEventType::Param {
+            // TODO: This is not how `Patch` for `Notify<bool>` is implemented.
             data: ParamData::Bool(*self.play),
-            path: ParamPath::Single(2),
+            path: ParamPath::Single(1),
         }
     }
 
@@ -389,7 +404,7 @@ impl SamplerNode {
     pub fn sync_play_from_event(&self) -> NodeEventType {
         NodeEventType::Param {
             data: self.play_from.as_param_data(),
-            path: ParamPath::Single(3),
+            path: ParamPath::Single(2),
         }
     }
 
@@ -397,7 +412,7 @@ impl SamplerNode {
     pub fn sync_repeat_mode_event(&self) -> NodeEventType {
         NodeEventType::Param {
             data: ParamData::any(self.repeat_mode),
-            path: ParamPath::Single(4),
+            path: ParamPath::Single(3),
         }
     }
 
@@ -405,7 +420,31 @@ impl SamplerNode {
     pub fn sync_speed_event(&self) -> NodeEventType {
         NodeEventType::Param {
             data: ParamData::F64(self.speed),
+            path: ParamPath::Single(4),
+        }
+    }
+
+    /// Returns an event type to sync the `mono_to_stereo` parameter.
+    pub fn sync_mono_to_stereo_event(&self) -> NodeEventType {
+        NodeEventType::Param {
+            data: ParamData::Bool(self.mono_to_stereo),
             path: ParamPath::Single(5),
+        }
+    }
+
+    /// Returns an event type to sync the `crossfade_on_seek` parameter.
+    pub fn sync_crossfade_on_seek_event(&self) -> NodeEventType {
+        NodeEventType::Param {
+            data: ParamData::Bool(self.crossfade_on_seek),
+            path: ParamPath::Single(6),
+        }
+    }
+
+    /// Returns an event type to sync the `min_gain` parameter.
+    pub fn sync_min_gain_event(&self) -> NodeEventType {
+        NodeEventType::Param {
+            data: ParamData::F32(self.min_gain),
+            path: ParamPath::Single(7),
         }
     }
 
@@ -541,6 +580,13 @@ impl SamplerState {
         )
     }
 
+    /// Returns `true` if the processor currently has a sample resource.
+    pub fn has_sample_resource(&self) -> bool {
+        self.shared_state
+            .has_sample_resource
+            .load(Ordering::Relaxed)
+    }
+
     /// Returns `true` if the sample is currently playing.
     pub fn playing(&self) -> bool {
         SharedPlaybackState::from_u32(self.shared_state.playback_state.load(Ordering::Relaxed))
@@ -597,36 +643,35 @@ impl SamplerState {
     /// A score of how suitable this node is to start new work (Play a new sample). The
     /// higher the score, the better the candidate.
     pub fn worker_score(&self, params: &SamplerNode) -> u64 {
-        if params.sample.is_some() {
-            let playback_state = SharedPlaybackState::from_u32(
-                self.shared_state.playback_state.load(Ordering::Relaxed),
-            );
+        if !self.has_sample_resource() {
+            return u64::MAX;
+        }
 
-            if *params.play {
-                let playhead_frames = self.playhead_frames();
+        let playback_state =
+            SharedPlaybackState::from_u32(self.shared_state.playback_state.load(Ordering::Relaxed));
 
-                if playback_state == SharedPlaybackState::Stopped {
-                    if playhead_frames.0 > 0 {
-                        // Sequence has likely finished playing.
-                        u64::MAX - 4
-                    } else {
-                        // Sequence has likely not started playing yet.
-                        u64::MAX - 5
-                    }
+        if *params.play {
+            let playhead_frames = self.playhead_frames();
+
+            if playback_state == SharedPlaybackState::Stopped {
+                if playhead_frames.0 > 0 {
+                    // Sequence has likely finished playing.
+                    u64::MAX - 4
                 } else {
-                    // The older the sample is, the better it is as a candidate to steal
-                    // work from.
-                    playhead_frames.0 as u64
+                    // Sequence has likely not started playing yet.
+                    u64::MAX - 5
                 }
             } else {
-                match playback_state {
-                    SharedPlaybackState::Stopped => u64::MAX - 1,
-                    SharedPlaybackState::Paused => u64::MAX - 2,
-                    SharedPlaybackState::Playing => u64::MAX - 3,
-                }
+                // The older the sample is, the better it is as a candidate to steal
+                // work from.
+                playhead_frames.0 as u64
             }
         } else {
-            u64::MAX
+            match playback_state {
+                SharedPlaybackState::Stopped => u64::MAX - 1,
+                SharedPlaybackState::Paused => u64::MAX - 2,
+                SharedPlaybackState::Playing => u64::MAX - 3,
+            }
         }
     }
 }
@@ -763,26 +808,10 @@ impl AudioNode for SamplerNode {
             ))
         };
 
-        let pending_sample = if let Some(sample) = &self.sample {
-            Some(sample.spawn_inner().map_err(|e| NodeError::from_boxed(e))?)
-        } else {
-            None
-        };
-
         Ok(SamplerProcessor {
             config: *config,
-            params: ProcessorParams {
-                volume: self.volume,
-                play: self.play,
-                play_from: self.play_from,
-                repeat_mode: self.repeat_mode,
-                speed: self.speed,
-                mono_to_stereo: self.mono_to_stereo,
-                crossfade_on_seek: self.crossfade_on_seek,
-                min_gain: self.min_gain,
-            },
+            params: *self,
             shared_state: ArcGc::clone(&cx.custom_state::<SamplerState>().unwrap().shared_state),
-            initial_sample: Some(pending_sample),
             loaded_sample_state: None,
             declicker: Declicker::SettledAt1,
             stop_declicker_buffers,
@@ -797,28 +826,16 @@ impl AudioNode for SamplerNode {
             min_gain: self.min_gain.max(0.0),
             max_block_frames: cx.stream_info.max_block_frames.get() as usize,
             num_out_channels: config.channels.get().get() as usize,
+            is_first_process: true,
         })
     }
 }
 
-#[derive(Patch)]
-struct ProcessorParams {
-    volume: Volume,
-    play: Notify<bool>,
-    play_from: PlayFrom,
-    repeat_mode: RepeatMode,
-    speed: f64,
-    mono_to_stereo: bool,
-    crossfade_on_seek: bool,
-    min_gain: f32,
-}
-
 struct SamplerProcessor {
     config: SamplerConfig,
-    params: ProcessorParams,
+    params: SamplerNode,
     shared_state: ArcGc<SharedState>,
 
-    initial_sample: Option<Option<SampleInner>>,
     loaded_sample_state: Option<LoadedSampleState>,
 
     declicker: Declicker,
@@ -840,6 +857,7 @@ struct SamplerProcessor {
 
     max_block_frames: usize,
     num_out_channels: usize,
+    is_first_process: bool,
 }
 
 impl SamplerProcessor {
@@ -925,14 +943,14 @@ impl SamplerProcessor {
 
         if first_copy_frames > 0 {
             match &mut state.sample {
-                SampleInner::InMemory(sample) => {
+                SamplerNodeResource::InMemory(sample) => {
                     sample.fill_buffers(
                         buffers,
                         range_in_buffer.start..range_in_buffer.start + first_copy_frames,
                         state.playhead_frames,
                     );
                 }
-                SampleInner::Streamed(_) => {
+                SamplerNodeResource::Streamed(_) => {
                     todo!()
                 }
             }
@@ -950,7 +968,7 @@ impl SamplerProcessor {
                         as usize;
 
                     match &mut state.sample {
-                        SampleInner::InMemory(sample) => {
+                        SamplerNodeResource::InMemory(sample) => {
                             sample.fill_buffers(
                                 buffers,
                                 range_in_buffer.start + frames_copied
@@ -958,7 +976,7 @@ impl SamplerProcessor {
                                 0,
                             );
                         }
-                        SampleInner::Streamed(_) => {
+                        SamplerNodeResource::Streamed(_) => {
                             todo!()
                         }
                     }
@@ -1050,15 +1068,15 @@ impl SamplerProcessor {
         }
     }
 
-    fn load_sample(&mut self, sample: SampleInner) {
+    fn load_sample(&mut self, sample: SamplerNodeResource) {
         let mut gain = self.params.volume.amp_clamped(self.min_gain);
         if gain > 0.99999 && gain < 1.00001 {
             gain = 1.0;
         }
 
         let (sample_len_frames, sample_num_channels) = match &sample {
-            SampleInner::InMemory(s) => (s.len_frames(), s.num_channels()),
-            SampleInner::Streamed(s) => (s.len_frames(), s.num_channels()),
+            SamplerNodeResource::InMemory(s) => (s.len_frames(), s.num_channels()),
+            SamplerNodeResource::Streamed(s) => (s.len_frames(), s.num_channels()),
         };
 
         let sample_mono_to_stereo = self.params.mono_to_stereo
@@ -1079,13 +1097,15 @@ impl SamplerProcessor {
 
 impl AudioNodeProcessor for SamplerProcessor {
     fn events(&mut self, info: &ProcInfo, events: &mut ProcEvents, extra: &mut ProcExtra) {
-        let is_first_process = self.initial_sample.is_some();
+        let is_first_process = self.is_first_process;
+        self.is_first_process = false;
+
         let mut new_playing: Option<bool> = if is_first_process {
             Some(self.playing)
         } else {
             None
         };
-        let mut new_sample = self.initial_sample.take();
+        let mut new_sample = None;
         let mut repeat_mode_changed = false;
         let mut speed_changed = false;
         let mut volume_changed = false;
@@ -1096,20 +1116,20 @@ impl AudioNodeProcessor for SamplerProcessor {
         #[cfg(feature = "scheduled_events")]
         for (mut event, timestamp) in events.drain_with_timestamps() {
             let mut s = None;
-            if event.downcast_swap::<Option<SampleInner>>(&mut s) {
+            if event.downcast_swap::<Option<SamplerNodeResource>>(&mut s) {
                 new_sample = Some(s);
             }
 
-            if let Some(patch) = ProcessorParams::patch_event(&event) {
+            if let Some(patch) = SamplerNode::patch_event(&event) {
                 match patch {
-                    ProcessorParamsPatch::Volume(_) => volume_changed = true,
-                    ProcessorParamsPatch::Play(play) => {
+                    SamplerNodePatch::Volume(_) => volume_changed = true,
+                    SamplerNodePatch::Play(play) => {
                         playback_instant = timestamp;
                         new_playing = Some(*play);
                     }
-                    ProcessorParamsPatch::RepeatMode(_) => repeat_mode_changed = true,
-                    ProcessorParamsPatch::Speed(_) => speed_changed = true,
-                    ProcessorParamsPatch::MinGain(min_gain) => {
+                    SamplerNodePatch::RepeatMode(_) => repeat_mode_changed = true,
+                    SamplerNodePatch::Speed(_) => speed_changed = true,
+                    SamplerNodePatch::MinGain(min_gain) => {
                         self.min_gain = min_gain.max(0.0);
                     }
                     _ => {}
@@ -1122,19 +1142,19 @@ impl AudioNodeProcessor for SamplerProcessor {
         #[cfg(not(feature = "scheduled_events"))]
         for mut event in events.drain() {
             let mut s = None;
-            if event.downcast_swap::<Option<SampleInner>>(&mut s) {
+            if event.downcast_swap::<Option<SamplerNodeResource>>(&mut s) {
                 new_sample = Some(s);
             }
 
-            if let Some(patch) = ProcessorParams::patch_event(&event) {
+            if let Some(patch) = SamplerNode::patch_event(&event) {
                 match patch {
-                    ProcessorParamsPatch::Volume(_) => volume_changed = true,
-                    ProcessorParamsPatch::Play(play) => {
+                    SamplerNodePatch::Volume(_) => volume_changed = true,
+                    SamplerNodePatch::Play(play) => {
                         new_playing = Some(*play);
                     }
-                    ProcessorParamsPatch::RepeatMode(_) => repeat_mode_changed = true,
-                    ProcessorParamsPatch::Speed(_) => speed_changed = true,
-                    ProcessorParamsPatch::MinGain(min_gain) => {
+                    SamplerNodePatch::RepeatMode(_) => repeat_mode_changed = true,
+                    SamplerNodePatch::Speed(_) => speed_changed = true,
+                    SamplerNodePatch::MinGain(min_gain) => {
                         self.min_gain = min_gain.max(0.0);
                     }
                     _ => {}
@@ -1168,6 +1188,10 @@ impl AudioNodeProcessor for SamplerProcessor {
         }
 
         if let Some(maybe_sample) = new_sample {
+            self.shared_state
+                .has_sample_resource
+                .store(maybe_sample.is_some(), Ordering::Relaxed);
+
             self.stop(extra);
 
             #[cfg(feature = "scheduled_events")]
@@ -1474,6 +1498,7 @@ impl AudioNodeProcessor for SamplerProcessor {
 
 struct SharedState {
     sample_playhead_frames: AtomicU64,
+    has_sample_resource: AtomicBool,
     playback_state: AtomicU32,
     finished: AtomicU64,
 }
@@ -1482,6 +1507,7 @@ impl Default for SharedState {
     fn default() -> Self {
         Self {
             sample_playhead_frames: AtomicU64::new(0),
+            has_sample_resource: AtomicBool::new(false),
             playback_state: AtomicU32::new(SharedPlaybackState::Stopped as u32),
             finished: AtomicU64::new(0),
         }
@@ -1506,13 +1532,8 @@ impl SharedPlaybackState {
     }
 }
 
-enum SampleInner {
-    InMemory(ArcGc<dyn SampleResource + Send + Sync + 'static>),
-    Streamed(OwnedGcUnsized<dyn StreamedSampleProcessor>),
-}
-
 struct LoadedSampleState {
-    sample: SampleInner,
+    sample: SamplerNodeResource,
     sample_len_frames: u64,
     sample_num_channels: NonZeroUsize,
     sample_mono_to_stereo: bool,

--- a/crates/firewheel-pool/src/lib.rs
+++ b/crates/firewheel-pool/src/lib.rs
@@ -204,9 +204,9 @@ where
         self.workers.len()
     }
 
-    /// Queue a new work to play a sequence.
+    /// Queue new work to play a sequence.
     ///
-    /// * `params` - The parameters of the sequence to play.
+    /// * `params` - The parameters of the first node.
     /// * `time` - The instant these new parameters should take effect. If this
     /// is `None`, then the parameters will take effect as soon as the node receives
     /// the event.
@@ -215,6 +215,8 @@ where
     /// one. If this is `false`, then an error will be returned if no more workers
     /// are left.
     /// * `cx` - The Firewheel context.
+    /// * `first_node` - A closure to send additional events to the first node, such
+    /// as setting the sample resource.
     /// * `fx_chain` - A closure to add additional nodes to this worker instance.
     ///
     /// This will return an error if `params.playback == PlaybackState::Stop`.
@@ -224,6 +226,7 @@ where
         #[cfg(feature = "scheduled_events")] time: Option<EventInstant>,
         steal: bool,
         cx: &mut FirewheelContext,
+        first_node: impl FnOnce(&mut ContextQueue),
         fx_chain: impl FnOnce(&mut FxChainState<FX>, &mut FirewheelContext),
     ) -> Result<NewWorkerResult, NewWorkerError> {
         if N::params_stopped(params) {
@@ -279,6 +282,8 @@ where
 
         N::diff(&worker.first_node_params, params, &mut event_queue);
 
+        (first_node)(&mut event_queue);
+
         worker.first_node_params = params.clone();
 
         N::mark_playing(worker.first_node_id, cx).unwrap();
@@ -288,6 +293,7 @@ where
         Ok(NewWorkerResult {
             worker_id,
             old_worker_id,
+            first_node_id: worker.first_node_id,
             was_playing_sequence,
         })
     }
@@ -618,6 +624,9 @@ pub struct NewWorkerResult {
 
     /// The ID that was previously assigned to this worker.
     pub old_worker_id: Option<WorkerID>,
+
+    /// The ID of the first node in this worker.
+    pub first_node_id: NodeID,
 
     /// If this is `true`, then this worker was already playing a sequence, and that
     /// sequence has been stopped.

--- a/crates/firewheel-symphonium/src/lib.rs
+++ b/crates/firewheel-symphonium/src/lib.rs
@@ -53,17 +53,26 @@ impl SampleResource for SymphoniumAudio {
         out_buffer: &mut [&mut [f32]],
         out_buffer_range: Range<usize>,
         start_frame: u64,
-    ) {
-        if start_frame > self.0.frames() as u64 {
-            return;
-        }
-        let start_frame = start_frame as usize;
+    ) -> usize {
+        let Some((frames, start_frame)) = firewheel_core::sample_resource::constrain_frames(
+            out_buffer_range.end - out_buffer_range.start,
+            start_frame,
+            self.0.frames(),
+        ) else {
+            return 0;
+        };
 
         for (ch_i, out_ch) in out_buffer.iter_mut().enumerate().take(self.0.channels()) {
             self.0
-                .fill_channel(ch_i, start_frame, &mut out_ch[out_buffer_range.clone()])
+                .fill_channel(
+                    ch_i,
+                    start_frame,
+                    &mut out_ch[out_buffer_range.start..out_buffer_range.start + frames],
+                )
                 .unwrap();
         }
+
+        frames
     }
 }
 
@@ -132,14 +141,14 @@ impl SampleResource for SymphoniumAudioF32 {
         out_buffer: &mut [&mut [f32]],
         out_buffer_range: Range<usize>,
         start_frame: u64,
-    ) {
+    ) -> usize {
         firewheel_core::sample_resource::fill_buffers_deinterleaved_f32(
             out_buffer,
             out_buffer_range,
             start_frame,
             &self.0.data,
             self.0.frames(),
-        );
+        )
     }
 }
 

--- a/crates/firewheel-symphonium/src/lib.rs
+++ b/crates/firewheel-symphonium/src/lib.rs
@@ -18,7 +18,7 @@ impl SymphoniumAudio {
         self.0.frames() as f64 / self.0.sample_rate().get() as f64
     }
 
-    pub fn into_dyn_resource(self) -> ArcGc<dyn SampleResource> {
+    pub fn into_dyn_resource(self) -> ArcGc<dyn SampleResource + Send + Sync + 'static> {
         self.into()
     }
 
@@ -83,7 +83,7 @@ impl SymphoniumAudioF32 {
         self.0.frames() as f64 / sample_rate.get() as f64
     }
 
-    pub fn into_dyn_resource(self) -> ArcGc<dyn SampleResourceF32> {
+    pub fn into_dyn_resource(self) -> ArcGc<dyn SampleResourceF32 + Send + Sync + 'static> {
         self.into()
     }
 
@@ -157,7 +157,9 @@ impl From<symphonium::DecodedAudioF32> for SymphoniumAudioF32 {
 
 /// A helper method to convert a [`symphonium::DecodedAudio`] resource into
 /// a type erased [`SampleResource`].
-pub fn dyn_symphonium_resource(data: symphonium::DecodedAudio) -> ArcGc<dyn SampleResource> {
+pub fn dyn_symphonium_resource(
+    data: symphonium::DecodedAudio,
+) -> ArcGc<dyn SampleResource + Send + Sync + 'static> {
     SymphoniumAudio(data).into_dyn_resource()
 }
 
@@ -165,6 +167,6 @@ pub fn dyn_symphonium_resource(data: symphonium::DecodedAudio) -> ArcGc<dyn Samp
 /// a type erased [`SampleResource`].
 pub fn dyn_symphonium_resource_f32(
     data: symphonium::DecodedAudioF32,
-) -> ArcGc<dyn SampleResourceF32> {
+) -> ArcGc<dyn SampleResourceF32 + Send + Sync + 'static> {
     SymphoniumAudioF32(data).into_dyn_resource()
 }

--- a/examples/play_sample/src/main.rs
+++ b/examples/play_sample/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
     );
 
     sampler_node.set_sample(sample);
-    cx.queue_event_for(sampler_id, sampler_node.sync_sample_event());
+    cx.queue_event_for(sampler_id, sampler_node.sync_sample_event().unwrap());
 
     sampler_node.start_or_restart();
     cx.queue_event_for(sampler_id, sampler_node.sync_play_event());

--- a/examples/play_sample/src/main.rs
+++ b/examples/play_sample/src/main.rs
@@ -76,7 +76,7 @@ fn main() {
     // --- Simulated update loop ---------------------------------------------------------
 
     loop {
-        if cx.node_state::<SamplerState>(sampler_id).unwrap().stopped() && false {
+        if cx.node_state::<SamplerState>(sampler_id).unwrap().stopped() {
             // Sample has finished playing.
             break;
         }

--- a/examples/play_sample/src/main.rs
+++ b/examples/play_sample/src/main.rs
@@ -62,22 +62,21 @@ fn main() {
         .unwrap(),
     );
 
-    sampler_node.set_sample(sample);
-    cx.queue_event_for(sampler_id, sampler_node.sync_sample_event().unwrap());
+    cx.queue_event_for(sampler_id, SamplerNode::set_dyn_sample_event(sample));
 
     sampler_node.start_or_restart();
     cx.queue_event_for(sampler_id, sampler_node.sync_play_event());
 
-    // Manually set the shared `stopped` flag. This is needed to account for the delay
+    // Manually set the shared playback flag. This is needed to account for the delay
     // between sending a play event and the node's processor receiving that event.
     cx.node_state::<SamplerState>(sampler_id)
         .unwrap()
-        .mark_stopped();
+        .mark_playing();
 
     // --- Simulated update loop ---------------------------------------------------------
 
     loop {
-        if cx.node_state::<SamplerState>(sampler_id).unwrap().stopped() {
+        if cx.node_state::<SamplerState>(sampler_id).unwrap().stopped() && false {
             // Sample has finished playing.
             break;
         }

--- a/examples/sampler_pool/src/system.rs
+++ b/examples/sampler_pool/src/system.rs
@@ -1,5 +1,6 @@
 use firewheel::{
     channel_config::NonZeroChannelCount,
+    collector::ArcGc,
     cpal::CpalStream,
     diff::Memo,
     nodes::{
@@ -8,6 +9,7 @@ use firewheel::{
         StereoToMonoNode,
     },
     pool::{AudioNodePool, FxChain, SamplerPool, SamplerPoolVolumePan},
+    sample_resource::SampleResource,
     FirewheelContext,
 };
 
@@ -27,6 +29,7 @@ pub struct AudioSystem {
     pub sampler_pool_1: SamplerPoolVolumePan,
     pub sampler_pool_2: AudioNodePool<SamplerPool, MyCustomChain>,
     pub sampler_node: SamplerNode,
+    pub sample: ArcGc<dyn SampleResource + Send + Sync + 'static>,
 }
 
 impl AudioSystem {
@@ -74,8 +77,7 @@ impl AudioSystem {
             .unwrap(),
         );
 
-        let mut sampler_node = SamplerNode::default();
-        sampler_node.set_sample(sample);
+        let sampler_node = SamplerNode::default();
 
         // Note, you can get the playhead and other state of a worker like this:
         // let playhead = sampler_pool_1
@@ -89,6 +91,7 @@ impl AudioSystem {
             sampler_pool_1,
             sampler_pool_2,
             sampler_node,
+            sample,
         }
     }
 

--- a/examples/sampler_pool/src/ui.rs
+++ b/examples/sampler_pool/src/ui.rs
@@ -1,5 +1,9 @@
 use eframe::App;
-use firewheel::{nodes::volume_pan::VolumePanNode, Volume};
+use firewheel::{
+    diff::EventQueue,
+    nodes::{sampler::SamplerNode, volume_pan::VolumePanNode},
+    Volume,
+};
 
 use crate::system::AudioSystem;
 
@@ -45,6 +49,12 @@ impl App for DemoApp {
                     None, // Apply the changes immediately
                     true, // Steal worker if pool is full
                     &mut self.audio_system.cx,
+                    |event_queue| {
+                        // Additional events to send to the first node in the worker.
+                        event_queue.push(SamplerNode::set_dyn_sample_event(
+                            self.audio_system.sample.clone(),
+                        ));
+                    },
                     |fx_chain_state, cx| {
                         // While we don't change these parameters in this example, in a typical app
                         // you would want to reset the parameters to the desired state when playing
@@ -77,6 +87,12 @@ impl App for DemoApp {
                     None, // Apply the changes immediately
                     true, // Steal worker if pool is full
                     &mut self.audio_system.cx,
+                    |event_queue| {
+                        // Additional events to send to the first node in the worker.
+                        event_queue.push(SamplerNode::set_dyn_sample_event(
+                            self.audio_system.sample.clone(),
+                        ));
+                    },
                     |fx_chain_state, cx| {
                         // While we don't change these parameters in this example, in a typical app
                         // you would want to reset the parameters to the desired state when playing

--- a/examples/sampler_test/src/system.rs
+++ b/examples/sampler_test/src/system.rs
@@ -73,12 +73,13 @@ impl AudioSystem {
                     .unwrap(),
                 );
 
-                let mut params = SamplerNode::default();
-                params.set_sample(sample);
+                let params = SamplerNode::default();
 
                 let node_id = cx
                     .add_node(params.clone(), None)
                     .expect("Sampler node should construct without error");
+
+                cx.queue_event_for(node_id, SamplerNode::set_dyn_sample_event(sample));
 
                 cx.connect(node_id, peak_meter_id, &[(0, 0), (1, 1)], false)
                     .unwrap();

--- a/examples/spatial_basic/src/system.rs
+++ b/examples/spatial_basic/src/system.rs
@@ -46,13 +46,14 @@ impl AudioSystem {
         let graph_out_node_id = cx.graph_out_node_id();
 
         let mut sampler_node = SamplerNode::default();
-        sampler_node.set_sample(sample);
         sampler_node.repeat_mode = RepeatMode::RepeatEndlessly;
         sampler_node.start_or_restart();
 
         let sampler_node_id = cx
             .add_node(sampler_node.clone(), None)
             .expect("Sampler node should construct without error");
+
+        cx.queue_event_for(sampler_node_id, SamplerNode::set_dyn_sample_event(sample));
 
         let spatial_basic_node = SpatialBasicNode::default();
         let spatial_basic_node_id = cx

--- a/examples/visual_node_graph/src/system.rs
+++ b/examples/visual_node_graph/src/system.rs
@@ -13,13 +13,13 @@ use firewheel::{
         freeverb::FreeverbNode,
         mix::{MixNode, MixNodeConfig},
         noise_generator::{pink::PinkNoiseGenNode, white::WhiteNoiseGenNode},
-        sampler::{SampleHandle, SamplerNode},
+        sampler::SamplerNode,
         svf::SvfNode,
         volume::{VolumeNode, VolumeNodeConfig},
         volume_pan::VolumePanNode,
         StereoToMonoNode,
     },
-    sample_resource::SampleResourceF32,
+    sample_resource::{SampleResource, SampleResourceF32},
     ContextQueue, FirewheelContext, SymphoniumAudioF32,
 };
 use symphonium::cache::SymphoniumCache;
@@ -57,7 +57,7 @@ pub enum NodeType {
 pub struct AudioSystem {
     pub cx: FirewheelContext,
     pub stream: CpalStream,
-    pub(crate) samples: Vec<SampleHandle>,
+    pub(crate) samples: Vec<ArcGc<dyn SampleResource + Send + Sync + 'static>>,
     pub(crate) ir_samples: Vec<(
         &'static str,
         ArcGc<dyn SampleResourceF32 + Send + Sync + 'static>,

--- a/examples/visual_node_graph/src/system.rs
+++ b/examples/visual_node_graph/src/system.rs
@@ -13,13 +13,13 @@ use firewheel::{
         freeverb::FreeverbNode,
         mix::{MixNode, MixNodeConfig},
         noise_generator::{pink::PinkNoiseGenNode, white::WhiteNoiseGenNode},
-        sampler::SamplerNode,
+        sampler::{SampleHandle, SamplerNode},
         svf::SvfNode,
         volume::{VolumeNode, VolumeNodeConfig},
         volume_pan::VolumePanNode,
         StereoToMonoNode,
     },
-    sample_resource::{SampleResource, SampleResourceF32},
+    sample_resource::SampleResourceF32,
     ContextQueue, FirewheelContext, SymphoniumAudioF32,
 };
 use symphonium::cache::SymphoniumCache;
@@ -57,8 +57,11 @@ pub enum NodeType {
 pub struct AudioSystem {
     pub cx: FirewheelContext,
     pub stream: CpalStream,
-    pub(crate) samples: Vec<ArcGc<dyn SampleResource>>,
-    pub(crate) ir_samples: Vec<(&'static str, ArcGc<dyn SampleResourceF32>)>,
+    pub(crate) samples: Vec<SampleHandle>,
+    pub(crate) ir_samples: Vec<(
+        &'static str,
+        ArcGc<dyn SampleResourceF32 + Send + Sync + 'static>,
+    )>,
 }
 
 const IR_SAMPLE_PATHS: [&'static str; 2] = [
@@ -100,6 +103,7 @@ impl AudioSystem {
                     )
                     .unwrap(),
                 )
+                .into()
             })
             .collect();
 

--- a/examples/visual_node_graph/src/ui.rs
+++ b/examples/visual_node_graph/src/ui.rs
@@ -647,21 +647,26 @@ impl<'a> SnarlViewer<GuiAudioNode> for DemoViewer<'a> {
                         })
                         .wrap_mode(egui::TextWrapMode::Truncate)
                         .show_ui(ui, |ui| {
+                            let mut tmp_selection = selection;
+
                             if ui
-                                .selectable_value(&mut params.sample, None, "None")
+                                .selectable_value(&mut tmp_selection, None, "None")
                                 .clicked()
                             {
                                 ui.memory_mut(|mem| {
                                     mem.data.insert_temp::<Option<usize>>(mem_id, None);
                                 });
-                                params.sample = None;
+
+                                self.audio_system
+                                    .cx
+                                    .queue_event_for(node.id, SamplerNode::clear_sample_event());
                             }
 
                             for sample_index in 0..SAMPLE_PATHS.len() {
                                 if ui
                                     .selectable_value(
-                                        &mut params.sample,
-                                        Some(self.audio_system.samples[sample_index].clone()),
+                                        &mut tmp_selection,
+                                        Some(sample_index),
                                         SAMPLE_PATHS[sample_index].rsplit("/").next().unwrap(),
                                     )
                                     .clicked()
@@ -672,8 +677,13 @@ impl<'a> SnarlViewer<GuiAudioNode> for DemoViewer<'a> {
                                             Some(sample_index),
                                         );
                                     });
-                                    params.sample =
-                                        Some(self.audio_system.samples[sample_index].clone());
+
+                                    self.audio_system.cx.queue_event_for(
+                                        node.id,
+                                        SamplerNode::set_dyn_sample_event(
+                                            self.audio_system.samples[sample_index].clone(),
+                                        ),
+                                    );
                                 }
                             }
                         });

--- a/examples/visual_node_graph/src/ui.rs
+++ b/examples/visual_node_graph/src/ui.rs
@@ -647,6 +647,16 @@ impl<'a> SnarlViewer<GuiAudioNode> for DemoViewer<'a> {
                         })
                         .wrap_mode(egui::TextWrapMode::Truncate)
                         .show_ui(ui, |ui| {
+                            if ui
+                                .selectable_value(&mut params.sample, None, "None")
+                                .clicked()
+                            {
+                                ui.memory_mut(|mem| {
+                                    mem.data.insert_temp::<Option<usize>>(mem_id, None);
+                                });
+                                params.sample = None;
+                            }
+
                             for sample_index in 0..SAMPLE_PATHS.len() {
                                 if ui
                                     .selectable_value(
@@ -662,9 +672,8 @@ impl<'a> SnarlViewer<GuiAudioNode> for DemoViewer<'a> {
                                             Some(sample_index),
                                         );
                                     });
-                                    params.set_sample(
-                                        self.audio_system.samples[sample_index].clone(),
-                                    );
+                                    params.sample =
+                                        Some(self.audio_system.samples[sample_index].clone());
                                 }
                             }
                         });

--- a/examples/visualizer/src/system.rs
+++ b/examples/visualizer/src/system.rs
@@ -49,11 +49,11 @@ impl AudioSystem {
             .unwrap(),
         );
 
-        let mut sampler_params = SamplerNode::default();
-        sampler_params.set_sample(sample);
+        let sampler_params = SamplerNode::default();
         let sampler_node_id = cx
             .add_node(sampler_params.clone(), None)
             .expect("Sampler node should construct without error");
+        cx.queue_event_for(sampler_node_id, SamplerNode::set_dyn_sample_event(sample));
 
         let triple_buffer_params = TripleBufferNode {
             window_size: WindowSize::Samples(window_size),


### PR DESCRIPTION
This adds a new `SampleHandle` API for the sampler node which adds support for `!Sync` sample resources that are streamed from disk/over a network.

The one thing I'm not so sure about is that `StreamedSample::spawn_stream()` doesn't take any arguments (because the `Diff` trait method which this method is called in doesn't take any arguments), meaning that users will have to do fancy things like message channels or statics to spawn any threads or futures for the stream. We could maybe consider adding an extra argument to the `Diff` trait to handle creating new threads/futures, though I'm not sure what that should look like.

Note the streaming logic has not been implemented in the sampler node processor yet. This is just to get the groundwork done to make the integration process much smoother when we do decide to add streamed sample resources.

---

I also ended up having to do some manual diffing/patching to get this to work. The macros didn't like that a field was trying to send a non-cloneable, non-sync value through the event queue.

In the process of trying to do the diffing/patching, I found a use to have a `()` parameter as a sort of "spacer" for the parameter indices. I ended up not using it, but I left the `Diff` and `Patch` implementations for `()` in the PR anyway.